### PR TITLE
feat: cleans conan cache before creating a backup

### DIFF
--- a/.github/workflows/conan.yaml
+++ b/.github/workflows/conan.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Setup conan profile
         shell: bash
         run: |
-          rm ~/.conan2/profiles/default
+          rm -f ~/.conan2/profiles/default
           conan profile detect --force -vquiet
           cp .conan/profiles/sen_$COMPILER ~/.conan2/profiles/default
           echo tools.system.package_manager:mode=install >> ~/.conan2/profiles/default
@@ -115,3 +115,9 @@ jobs:
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           conan create . --user airbus --channel dev --lockfile-out=package.lock \
               --build=missing -s:a build_type=${{ matrix.build_type }}
+
+      - name: Remove unwanted parts from conan cache before backup
+        shell: bash
+        run: |
+          conan remove sen --confirm
+          conan cache clean "*" -s -b -d


### PR DESCRIPTION
Backups should only include the build packages not the: sources, downloaded artifacts, or build artifacts.