### PR TITLE
fix: Disable tests and examples by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # build options
-option(SEN_BUILD_EXAMPLES "Build examples" ON)
-option(SEN_BUILD_TESTS "Build tests" ON)
+option(SEN_BUILD_EXAMPLES "Build examples" OFF)
+option(SEN_BUILD_TESTS "Build tests" OFF)
 option(SEN_BUILD_DOCS "Build documentation" ON)
 option(SEN_DISABLE_CLANG_TIDY "Disable clang-tidy" ON)
 option(SEN_DISABLE_EXTRA_COMPONENTS "Disable non-critical components" OFF)

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -190,4 +190,4 @@ To build, use `conan build . --profile=sen_gcc`. Alternatively, use
 `cmake -S . -B build -G Ninja --preset sen_gcc && cmake --build build` (you can replace 'sen_gcc'
 with the preset of your choice).
 
-**Note:** If you want to build Sen with tests/examples supply the following environment variables when calling conan: `ENABLE_EXAMPLES=false ENABLE_TESTS=false`
+**Note:** If you want to build Sen with tests/examples supply the following environment variables when calling conan: `ENABLE_EXAMPLES=true ENABLE_TESTS=true`

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -189,3 +189,5 @@ Use Conan to fetch the third-party dependencies `conan install . --profile=sen_g
 To build, use `conan build . --profile=sen_gcc`. Alternatively, use
 `cmake -S . -B build -G Ninja --preset sen_gcc && cmake --build build` (you can replace 'sen_gcc'
 with the preset of your choice).
+
+**Note:** If you want to build Sen with tests/examples supply the following environment variables when calling conan: `ENABLE_EXAMPLES=false ENABLE_TESTS=false`


### PR DESCRIPTION
To reduce the amount of dependencies that are needed by the user, we disable example and test building by default.