### PR TITLE
refactor: generated optional class template

### DIFF
--- a/apps/cli_gen/src/cpp/templates/optional_decl.j2
+++ b/apps/cli_gen/src/cpp/templates/optional_decl.j2
@@ -3,7 +3,7 @@ namespace {{ namespace }}
 {
 
 {{ blockComment(description, 0) }}
-SEN_IMPL_GEN_OPTIONAL({{ name }}, {{ qualElementType }}, {% if publicSymbols %}true{% else %}false{% endif %})
+SEN_IMPL_GEN_OPTIONAL({{ name }}, {{ qualElementType }})
 
 {% if publicSymbols %}SEN_EXPORT {% endif %}std::ostream& operator<<(std::ostream& out, const {{ name }}& val);
 

--- a/apps/cli_gen/src/cpp/templates/optional_impl.j2
+++ b/apps/cli_gen/src/cpp/templates/optional_impl.j2
@@ -15,16 +15,6 @@ std::ostream& operator<<(std::ostream& out, const {{ name }}& val)
   return out << "<empty>";
 }
 
-bool operator==(const {{ qualType }}& lhs, const {{ qualType }}& rhs)
-{
-  return static_cast<bool>(lhs) == static_cast<bool>(rhs) && (!lhs || *lhs == *rhs);
-}
-
-bool operator!=(const {{ qualType }}& lhs, const {{ qualType }}& rhs)
-{
-  return static_cast<bool>(lhs) != static_cast<bool>(rhs) || (static_cast<bool>(lhs) && *lhs != *rhs);
-}
-
 } // namespace {{ namespace }}
 
 ::sen::ConstTypeHandle<::sen::OptionalType> sen::MetaTypeTrait<{{ qualType }}>::meta()

--- a/components/rest/src/object_members_manager.cpp
+++ b/components/rest/src/object_members_manager.cpp
@@ -78,7 +78,7 @@ bool ObjectMembersManager::subscribeProperty(const sen::kernel::KernelApi& kerne
      {
        std::ignore = args;
 
-       if (maxUpdateTime.has_value() && (info.creationTime - lastUpdate) <= maxUpdateTime)
+       if (maxUpdateTime.has_value() && (info.creationTime - lastUpdate) <= maxUpdateTime.asOptional())
        {
          // Dropping update
          return;

--- a/libs/core/include/sen/core/obj/detail/gen.h
+++ b/libs/core/include/sen/core/obj/detail/gen.h
@@ -162,19 +162,36 @@ private:
   SEN_MAYBE_EXPORT(doExport) bool operator!=(const classname& lhs, const classname& rhs);
 
 /// Used by the code generator NOLINTNEXTLINE
-#define SEN_IMPL_GEN_OPTIONAL(classname, elementtype, doExport)                                                        \
-  struct classname final: public std::optional<elementtype>                                                            \
+#define SEN_IMPL_GEN_OPTIONAL(classname, elementtype)                                                                  \
+  class classname final: private std::optional<elementtype>                                                            \
   {                                                                                                                    \
     using Parent = std::optional<elementtype>;                                                                         \
+                                                                                                                       \
+  public:                                                                                                              \
+    using Parent::value_type;                                                                                          \
+                                                                                                                       \
     using Parent::Parent;                                                                                              \
     using Parent::operator=;                                                                                           \
+                                                                                                                       \
     using Parent::operator->;                                                                                          \
     using Parent::operator*;                                                                                           \
     using Parent::operator bool;                                                                                       \
-  };                                                                                                                   \
+    using Parent::has_value;                                                                                           \
+    using Parent::value;                                                                                               \
+    using Parent::value_or;                                                                                            \
                                                                                                                        \
-  SEN_MAYBE_EXPORT(doExport) bool operator==(const classname& lhs, const classname& rhs);                              \
-  SEN_MAYBE_EXPORT(doExport) bool operator!=(const classname& lhs, const classname& rhs);
+    using Parent::reset;                                                                                               \
+    using Parent::swap;                                                                                                \
+    using Parent::emplace;                                                                                             \
+                                                                                                                       \
+    constexpr const Parent& asOptional() const noexcept { return *this; }                                              \
+                                                                                                                       \
+    friend constexpr bool operator==(const classname& lhs, const classname& rhs)                                       \
+    {                                                                                                                  \
+      return lhs.asOptional() == rhs.asOptional();                                                                     \
+    }                                                                                                                  \
+    friend constexpr bool operator!=(const classname& lhs, const classname& rhs) { return !(lhs == rhs); }             \
+  };
 
 /// Used by the code generator NOLINTNEXTLINE
 #define SEN_IMPL_GEN_OPTIONAL_TRAITS(classname, doExport)                                                              \

--- a/libs/core/test/obj/gen_test.cpp
+++ b/libs/core/test/obj/gen_test.cpp
@@ -50,22 +50,7 @@ sen::impl::RemoteObjectInfo createTestProxyInfo()
 SEN_IMPL_GEN_UNBOUNDED_SEQUENCE(TestUnboundedSeq, int)
 SEN_IMPL_GEN_BOUNDED_SEQUENCE(TestBoundedSeq, int, 5)
 SEN_IMPL_GEN_FIXED_SEQUENCE(TestFixedSeq, int, 3)
-SEN_IMPL_GEN_OPTIONAL(TestOptionalInt, int, false)
-
-bool operator==(const TestOptionalInt& lhs, const TestOptionalInt& rhs)
-{
-  if (lhs.has_value() != rhs.has_value())
-  {
-    return false;
-  }
-  if (!lhs.has_value())
-  {
-    return true;
-  }
-  return *lhs == *rhs;
-}
-
-bool operator!=(const TestOptionalInt& lhs, const TestOptionalInt& rhs) { return !(lhs == rhs); }
+SEN_IMPL_GEN_OPTIONAL(TestOptionalInt, int)
 
 }  // namespace
 

--- a/libs/kernel/src/type_specs_utils.cpp
+++ b/libs/kernel/src/type_specs_utils.cpp
@@ -457,8 +457,8 @@ ConstTypeHandle<CustomType> makeNonNative(const CustomTypeSpec& typeData,
                             typeData.description,
                             getNumericType(spec.elementType),
                             UnitRegistry::get().searchUnitByName(spec.unit.name),
-                            spec.minValue,
-                            spec.maxValue);
+                            spec.minValue.asOptional(),
+                            spec.maxValue.asOptional());
 
   return QuantityType::make(quantitySpec);
 }
@@ -524,7 +524,7 @@ ConstTypeHandle<CustomType> makeNonNative(const CustomTypeSpec& typeData,
                             typeData.qualifiedName,
                             typeData.description,
                             findType(spec.elementType, nativeTypes, nonNativeTypes),
-                            spec.maxSize,
+                            spec.maxSize.asOptional(),
                             spec.fixedSize);
 
   return SequenceType::make(sequenceSpec);


### PR DESCRIPTION
Ensures we do not allow users to slice or inherit from generated optionals, while providing the expected optional API.