### PR TITLE
refactor: generated unbounded sequence class template

### DIFF
--- a/components/influx/src/component.cpp
+++ b/components/influx/src/component.cpp
@@ -79,7 +79,7 @@ public:
     }
 
     // create the recorder
-    auto recorder = std::make_unique<Recorder>(std::move(database), config.selections, api);
+    auto recorder = std::make_unique<Recorder>(std::move(database), config.selections.asVector(), api);
 
     getLogger()->info("sending information to InfluxDB");
     return api.execLoop(config.samplingPeriod, nullptr, false);

--- a/components/py/src/component.cpp
+++ b/components/py/src/component.cpp
@@ -79,7 +79,7 @@ struct PyComponent: public kernel::Component
 
     if (!config_.imports.empty())
     {
-      packageManager_->import(config_.imports);
+      packageManager_->import(config_.imports.asVector());
     }
 
     return done();

--- a/libs/core/include/sen/core/obj/detail/gen.h
+++ b/libs/core/include/sen/core/obj/detail/gen.h
@@ -39,6 +39,7 @@
 
 // std
 #include <optional>
+#include <type_traits>
 
 #define SEN_IMPL_GEN_NATIVE_MEMBERS                                                                                    \
 protected:                                                                                                             \
@@ -118,11 +119,54 @@ private:
 
 /// Used by the code generator NOLINTNEXTLINE
 #define SEN_IMPL_GEN_UNBOUNDED_SEQUENCE(classname, elementtype)                                                        \
-  struct classname final: public std::vector<elementtype>                                                              \
+  class classname final: private std::vector<elementtype>                                                              \
   {                                                                                                                    \
     using Parent = std::vector<elementtype>;                                                                           \
+                                                                                                                       \
+  public:                                                                                                              \
+    using Parent::value_type;                                                                                          \
+                                                                                                                       \
     using Parent::Parent;                                                                                              \
     using Parent::operator=;                                                                                           \
+    using Parent::assign;                                                                                              \
+                                                                                                                       \
+    using Parent::at;                                                                                                  \
+    using Parent::operator[];                                                                                          \
+    using Parent::front;                                                                                               \
+    using Parent::back;                                                                                                \
+    using Parent::data;                                                                                                \
+                                                                                                                       \
+    using Parent::begin;                                                                                               \
+    using Parent::cbegin;                                                                                              \
+    using Parent::rbegin;                                                                                              \
+    using Parent::crbegin;                                                                                             \
+    using Parent::end;                                                                                                 \
+    using Parent::cend;                                                                                                \
+    using Parent::rend;                                                                                                \
+    using Parent::crend;                                                                                               \
+                                                                                                                       \
+    using Parent::empty;                                                                                               \
+    using Parent::size;                                                                                                \
+    using Parent::max_size;                                                                                            \
+    using Parent::reserve;                                                                                             \
+    using Parent::capacity;                                                                                            \
+    using Parent::shrink_to_fit;                                                                                       \
+                                                                                                                       \
+    using Parent::clear;                                                                                               \
+    using Parent::insert;                                                                                              \
+    using Parent::emplace;                                                                                             \
+    using Parent::erase;                                                                                               \
+    using Parent::push_back;                                                                                           \
+    using Parent::emplace_back;                                                                                        \
+    using Parent::pop_back;                                                                                            \
+    using Parent::resize;                                                                                              \
+    using Parent::swap;                                                                                                \
+                                                                                                                       \
+    constexpr const Parent& asVector() const& noexcept { return *this; }                                               \
+    Parent asVector() && noexcept(std::is_nothrow_move_constructible_v<Parent>) { return std::move(*this); }           \
+                                                                                                                       \
+    friend bool operator==(const classname& lhs, const classname& rhs) { return lhs.asVector() == rhs.asVector(); }    \
+    friend bool operator!=(const classname& lhs, const classname& rhs) { return !(lhs == rhs); }                       \
   };
 
 /// Used by the code generator NOLINTNEXTLINE
@@ -174,7 +218,8 @@ private:
       std::move(std::begin(elems), std::end(elems), std::begin(*this));                                                \
     }                                                                                                                  \
                                                                                                                        \
-    constexpr const Parent& asArray() const noexcept { return *this; }                                                 \
+    constexpr const Parent& asArray() const& noexcept { return *this; }                                                \
+    Parent asArray() && noexcept(std::is_nothrow_move_constructible_v<element>) { return std::move(*this); }           \
                                                                                                                        \
     friend bool operator==(const classname& lhs, const classname& rhs) { return lhs.asArray() == rhs.asArray(); }      \
     friend bool operator!=(const classname& lhs, const classname& rhs) { return !(lhs == rhs); }                       \
@@ -209,7 +254,8 @@ private:
     using Parent::swap;                                                                                                \
     using Parent::emplace;                                                                                             \
                                                                                                                        \
-    constexpr const Parent& asOptional() const noexcept { return *this; }                                              \
+    constexpr const Parent& asOptional() const& noexcept { return *this; }                                             \
+    Parent asOptional() && noexcept(std::is_nothrow_move_constructible_v<Parent>) { return std::move(*this); }         \
                                                                                                                        \
     friend constexpr bool operator==(const classname& lhs, const classname& rhs)                                       \
     {                                                                                                                  \

--- a/libs/db/src/input.cpp
+++ b/libs/db/src/input.cpp
@@ -721,7 +721,7 @@ private:
     const auto type = kernelTypes_.get(entry.type);
 
     SEN_ASSERT(type.has_value() && "The type for the annotation should be known by the kernel.");
-    return {entry.time, db::Annotation(std::move(type).value(), std::move(entry.value))};
+    return {entry.time, db::Annotation(std::move(type).value(), std::move(entry.value).asVector())};
   }
 
   [[nodiscard]] DataCursor::Entry provideRuntimeDataFront(const DataCursorState& state)
@@ -793,7 +793,7 @@ private:
                              elem.session,
                              elem.bus,
                              findClassAndAssociateObjectId(elem.type, elem.objectId),
-                             std::move(elem.properties)});
+                             std::move(elem.properties).asVector()});
       }
 
       return {data.time, db::Keyframe(std::move(snapshots))};
@@ -827,7 +827,7 @@ private:
                       }
                     }
 
-                    return {data.time, PropertyChange(data.objectId, property, std::move(data.value))};
+                    return {data.time, PropertyChange(data.objectId, property, std::move(data.value).asVector())};
                   },
                   [this](v1::Event& data) -> DataCursor::Entry
                   {
@@ -856,14 +856,14 @@ private:
                       }
                     }
 
-                    return {data.time, db::Event(data.objectId, event, std::move(data.args))};
+                    return {data.time, db::Event(data.objectId, event, std::move(data.args).asVector())};
                   },
                   processKeyframe,
                   [&processKeyframe](v1::CompressedKeyframe& data) -> DataCursor::Entry
                   {
                     // uncompress the buffer
                     std::vector<uint8_t> memBuffer;
-                    uncompressBuffer(data.buffer, memBuffer, data.decompressedSize);
+                    uncompressBuffer(data.buffer.asVector(), memBuffer, data.decompressedSize);
 
                     // read the keyframe
                     v1::Keyframe keyframe;
@@ -882,7 +882,7 @@ private:
                                                   data.object.session,
                                                   data.object.bus,
                                                   findClassAndAssociateObjectId(data.object.type, data.object.objectId),
-                                                  std::move(data.object.properties)))};
+                                                  std::move(data.object.properties).asVector()))};
                   },
                   [](v1::Deletion& data) -> DataCursor::Entry { return {data.time, db::Deletion(data.objectId)}; }},
       dataEntry);

--- a/libs/db/src/output.cpp
+++ b/libs/db/src/output.cpp
@@ -256,7 +256,7 @@ public:
 
       v1::CompressedKeyframe compressedKey;
       compressedKey.decompressedSize = static_cast<uint32_t>(memBuf.size());
-      writeToCompressedBuffer(memBuf, compressedKey.buffer);
+      writeToCompressedBuffer(memBuf.asVector(), compressedKey.buffer);
 
       if (createIndex)
       {

--- a/libs/db/src/util.cpp
+++ b/libs/db/src/util.cpp
@@ -74,7 +74,7 @@ std::shared_ptr<spdlog::logger> getLogger()
   return logger;
 }
 
-void writeToCompressedBuffer(const std::vector<uint8_t>& memBuf, std::vector<uint8_t>& lz4Buf)
+void writeToCompressedBuffer(const std::vector<uint8_t>& memBuf, kernel::Buffer& lz4Buf)
 {
   // allocate space for the compressed data
   lz4Buf.resize(LZ4_compressBound(static_cast<int>(memBuf.size())));

--- a/libs/db/src/util.h
+++ b/libs/db/src/util.h
@@ -35,7 +35,7 @@ inline void write(T&& data, FILE* file);
 template <typename T>
 [[nodiscard]] inline std::shared_ptr<ResizableHeapBlock> writeSizeAndDataToBuffer(const T& data);
 
-void writeToCompressedBuffer(const std::vector<uint8_t>& memBuf, std::vector<uint8_t>& lz4Buf);
+void writeToCompressedBuffer(const std::vector<uint8_t>& memBuf, kernel::Buffer& lz4Buf);
 
 void uncompressBuffer(const std::vector<uint8_t>& lz4Buf, std::vector<uint8_t>& memBuf, std::size_t decompressedSize);
 

--- a/libs/kernel/src/bus/remote_participant.cpp
+++ b/libs/kernel/src/bus/remote_participant.cpp
@@ -362,11 +362,11 @@ void UpdatesBufferStorage::applyStateAndStopMonitoring(sen::impl::RemoteObject& 
   if (const auto itr = data_.find(proxy.getId()); itr != data_.end())
   {
     // initialize with addition
-    proxy.initializeState(itr->second.staticState.state, itr->second.staticState.time);
+    proxy.initializeState(itr->second.staticState.state.asVector(), itr->second.staticState.time);
 
     // initialize with the requested state
     const auto& dynamicStateTime = itr->second.dynamicState.timestamp;
-    proxy.initializeState(itr->second.dynamicState.state, dynamicStateTime);
+    proxy.initializeState(itr->second.dynamicState.state.asVector(), dynamicStateTime);
 
     // apply updates newer than the requested state
     for (const auto& update: itr->second.updates)
@@ -918,7 +918,7 @@ void RemoteParticipant::rcvMethodCall(TransportMode mode, InputStream& in)
             }
           };
 
-          InputStream argsIn(*argsBuffer);
+          InputStream argsIn(argsBuffer->asVector());
 
           // ensure that the stream call can modify the local object
           localObject->senImplStreamCall(methodId, argsIn, std::move(callForwarder));
@@ -954,11 +954,11 @@ void RemoteParticipant::rcvMethodResponse(InputStream& in)
       if (retValSize != 0U)
       {
         auto retValBuffer = makeConstSpan(in.advance(retValSize), retValSize);
-        responseData.returnValBuffer = std::make_shared<Buffer>(retValBuffer.begin(), retValBuffer.end());
+        responseData.returnValBuffer = std::make_shared<std::vector<uint8_t>>(retValBuffer.begin(), retValBuffer.end());
       }
       else
       {
-        responseData.returnValBuffer = std::make_shared<Buffer>();
+        responseData.returnValBuffer = std::make_shared<std::vector<uint8_t>>();
       }
     }
     break;

--- a/libs/kernel/src/type_specs_utils.cpp
+++ b/libs/kernel/src/type_specs_utils.cpp
@@ -641,7 +641,7 @@ ConstTypeHandle<CustomType> makeNonNative(const CustomTypeSpec& typeData,
           getPropertyCategory(spec.category),
           getTransportMode(spec.transportMode),
           spec.checkedSet,
-          spec.tags};
+          spec.tags.asVector()};
 }
 
 [[nodiscard]] ::sen::EventSpec makeEventSpec(const EventSpec& spec,


### PR DESCRIPTION
Ensures we do not allow users to slice or inherit from generated unbounded sequences, while providing the expected sequence API.