### PR TITLE
build: ensures generated coverage data is process specific

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ if(SEN_COVERAGE_ENABLE)
     )
     target_link_options(sen_coverage_flags INTERFACE --coverage)
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    file(TO_NATIVE_PATH "${CMAKE_BINARY_DIR}/coverage_data/coverage-%m.profraw" SEN_COVERAGE_DATA_DIR)
+    file(TO_NATIVE_PATH "${CMAKE_BINARY_DIR}/coverage_data/coverage-%p-%m.profraw" SEN_COVERAGE_DATA_DIR)
     target_compile_options(
       sen_coverage_flags
       INTERFACE -g


### PR DESCRIPTION
To ensure that we correctly generated coverage data when executing tests in parallel, we need to inject the PID of the generating process into the file name. This way, there are not conflicitng generations and the merging step can always correctly merge the data together.