### PR TITLE
build: fixes test_package execution

### DIFF
--- a/.github/workflows/conan.yaml
+++ b/.github/workflows/conan.yaml
@@ -114,6 +114,7 @@ jobs:
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           conan create . --user airbus --channel dev --lockfile-out=package.lock \
+              --test-folder .conan/test_packages/package \
               --build=missing -s:a build_type=${{ matrix.build_type }}
 
       - name: Remove unwanted parts from conan cache before backup

--- a/conanfile.py
+++ b/conanfile.py
@@ -149,8 +149,7 @@ class SenConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "none")
         self.cpp_info.builddirs = [join("cmake", "sen")]
-        for component in ["core", "kernel", "db", "util"]:
-            self.cpp_info.components[component].set_property("cmake_target_name", f"sen::{component}")
+        self.cpp_info.set_property("cmake_target_name", "sen::core sen::kernel sen::db sen::util")
 
         # runenv library paths
         self.runenv_info.prepend_path("PATH", join(self.package_folder, "bin"))


### PR DESCRIPTION
Due to the non standard test_package folder location in Sen, we need to expliclty specify where the test_package can be found.