### PR TITLE
fix(core,kernel): subscription-path + buildQuery correctness fixes

### DIFF
--- a/libs/core/include/sen/core/obj/detail/native_object_proxy.h
+++ b/libs/core/include/sen/core/obj/detail/native_object_proxy.h
@@ -70,29 +70,31 @@ protected:  // called by the generated code
   void senImplRemoveUntypedConnection(ConnId id, MemberHash memberHash) override;
 
 private:
-  struct EventCallbackData
+  // Held by shared_ptr: senImplEventEmitted queues work items that capture this and may
+  // run after senImplRemoveUntypedConnection erases the slot.
+  struct PropertyCallbackData
   {
     uint32_t id;
     std::shared_ptr<EventCallback<VarList>> callback;
   };
 
-  using EventCallbackList = std::vector<EventCallbackData>;
+  using PropertyCallbackList = std::vector<PropertyCallbackData>;
 
-  struct EventData
+  struct PropertyData
   {
-    EventCallbackList list;
+    PropertyCallbackList list;
     TransportMode transportMode;
   };
 
-  using EventCallbackMap = std::unordered_map<MemberHash, EventData>;
+  using PropertyCallbackMap = std::unordered_map<MemberHash, PropertyData>;
 
 private:
   NativeObject* owner_;
   std::shared_ptr<Object> guard_;
   std::string localName_;
   TimeStamp lastCommitTime_;
-  std::unique_ptr<EventCallbackMap> eventCallbacks_;
-  std::recursive_mutex eventCallbacksMutex_;
+  std::unique_ptr<PropertyCallbackMap> propertyCallbacks_;
+  std::recursive_mutex propertyCallbacksMutex_;
 };
 
 }  // namespace impl

--- a/libs/core/src/obj/native_object_proxy.cpp
+++ b/libs/core/src/obj/native_object_proxy.cpp
@@ -70,11 +70,11 @@ void NativeObjectProxy::invokeUntyped(const Method* method, const VarList& args,
 
 ConnectionGuard NativeObjectProxy::onPropertyChangedUntyped(const Property* prop, EventCallback<VarList>&& callback)
 {
-  std::scoped_lock<std::recursive_mutex> lock(eventCallbacksMutex_);
+  std::scoped_lock<std::recursive_mutex> lock(propertyCallbacksMutex_);
 
-  if (!eventCallbacks_)
+  if (!propertyCallbacks_)
   {
-    eventCallbacks_ = std::make_unique<EventCallbackMap>();
+    propertyCallbacks_ = std::make_unique<PropertyCallbackMap>();
   }
 
   if (auto callbackLock = callback.lock(); callbackLock.isValid())
@@ -82,7 +82,7 @@ ConnectionGuard NativeObjectProxy::onPropertyChangedUntyped(const Property* prop
     const auto connId = senImplMakeConnectionId();
     const auto memberHash = prop->getId();
 
-    auto [itr, done] = eventCallbacks_->try_emplace(memberHash, EventData {{}, prop->getTransportMode()});
+    auto [itr, done] = propertyCallbacks_->try_emplace(memberHash, PropertyData {{}, prop->getTransportMode()});
     itr->second.list.push_back({connId.get(), std::make_shared<EventCallback<VarList>>(std::move(callback))});
 
     return senImplMakeConnectionGuard(connId, memberHash, false);
@@ -103,29 +103,29 @@ Var NativeObjectProxy::getPropertyUntyped(const Property* prop) const { return s
 
 void NativeObjectProxy::senImplEventEmitted(MemberHash id, std::function<VarList()>&& argsGetter, const EventInfo& info)
 {
-  std::scoped_lock<std::recursive_mutex> lock(eventCallbacksMutex_);
+  std::scoped_lock<std::recursive_mutex> lock(propertyCallbacksMutex_);
 
-  if (!eventCallbacks_)
+  if (!propertyCallbacks_)
   {
     return;
   }
 
-  auto itr = eventCallbacks_->find(id);
-  if (itr != eventCallbacks_->end())
+  auto itr = propertyCallbacks_->find(id);
+  if (itr != propertyCallbacks_->end())
   {
-    const auto& eventData = itr->second;
+    const auto& propertyData = itr->second;
 
-    if (!eventData.list.empty())
+    if (!propertyData.list.empty())
     {
       const auto args = argsGetter();
-      for (const auto& elem: eventData.list)
+      for (const auto& elem: propertyData.list)
       {
         if (auto callbackLock = elem.callback->lock(); callbackLock.isValid())
         {
           // Capture the shared_ptr by value: the entry may be erased before the workQueue
           // drains, and Callback::invoke is a no-op on an invalidated CallbackData.
           callbackLock.pushAnswer([args, info, callback = elem.callback]() { callback->invoke(info, args); },
-                                  impl::cannotBeDropped(eventData.transportMode));
+                                  impl::cannotBeDropped(propertyData.transportMode));
         }
       }
     }
@@ -136,12 +136,12 @@ void NativeObjectProxy::removeTypedConnectionOnOwner(ConnId connId) { owner_->se
 
 void NativeObjectProxy::senImplRemoveUntypedConnection(ConnId id, MemberHash memberHash)
 {
-  std::scoped_lock<std::recursive_mutex> lock(eventCallbacksMutex_);
+  std::scoped_lock<std::recursive_mutex> lock(propertyCallbacksMutex_);
 
-  if (eventCallbacks_)
+  if (propertyCallbacks_)
   {
-    auto itr = eventCallbacks_->find(memberHash.get());
-    if (itr != eventCallbacks_->end())
+    auto itr = propertyCallbacks_->find(memberHash.get());
+    if (itr != propertyCallbacks_->end())
     {
       auto& callbackList = itr->second.list;
 
@@ -158,13 +158,13 @@ void NativeObjectProxy::senImplRemoveUntypedConnection(ConnId id, MemberHash mem
       // delete the entry for this member if empty
       if (callbackList.empty())
       {
-        eventCallbacks_->erase(itr);
+        propertyCallbacks_->erase(itr);
       }
 
       // delete the callbacks container if empty
-      if (eventCallbacks_->empty())
+      if (propertyCallbacks_->empty())
       {
-        eventCallbacks_ = {};
+        propertyCallbacks_ = {};
       }
     }
   }

--- a/libs/core/src/obj/object_filter.cpp
+++ b/libs/core/src/obj/object_filter.cpp
@@ -122,6 +122,14 @@ public:
     }
   }
 
+  /// Track and evaluate the snapshot. Must be atomic: splitting them leaves
+  /// notifyAddedOnExistingObjects with an empty currentAdditions_.
+  void seedFromExistingObjects(const std::unordered_map<ObjectId, std::shared_ptr<Object>>& objects)
+  {
+    startTracking(objects);
+    evaluateTrackedObjects();
+  }
+
   void evaluateTrackedObjects()
   {
     // clear it because we will recompute this here
@@ -440,8 +448,7 @@ std::shared_ptr<ObjectProvider> ObjectFilter::getOrCreateNamedProvider(const std
   providers_.push_back(ptr);
 
   ptr->setName(name);
-  ptr->startTracking(lastPresentObjects_);
-  ptr->evaluateTrackedObjects();
+  ptr->seedFromExistingObjects(lastPresentObjects_);
 
   return ptr;
 }
@@ -502,13 +509,13 @@ void ObjectFilter::addSubscriber(std::shared_ptr<Interest> interest,
   ownedProviders_.push_back(std::make_shared<impl::FilteredProvider>(this, interest));
   providers_.push_back(ownedProviders_.back());
   const auto provider = providers_.back().lock();
-  provider->addListener(listener, notifyAboutExisting);
 
+  // Seed before the listener registers; notifyAddedOnExistingObjects bails on empty.
   if (notifyAboutExisting)
   {
-    provider->startTracking(lastPresentObjects_);
-    provider->evaluateTrackedObjects();
+    provider->seedFromExistingObjects(lastPresentObjects_);
   }
+  provider->addListener(listener, notifyAboutExisting);
 }
 
 void ObjectFilter::removeSubscriber(std::shared_ptr<Interest> interest,

--- a/libs/core/test/obj/native_object_proxy_test.cpp
+++ b/libs/core/test/obj/native_object_proxy_test.cpp
@@ -319,3 +319,30 @@ TEST(NativeObjectProxy, RemoveTypedConnectionFallback)
 
   EXPECT_TRUE(ownerTriggered);
 }
+
+/// @test
+/// Removing a property-change connection while a work item is still queued must not crash
+/// and must not deliver the callback on drain.
+TEST(NativeObjectProxy, RemoveDuringEmitNoCrashAndCallbackInvalidated)
+{
+  const ProxyTestFixture fixture;
+  const auto* metaClass = example_class::ExampleClassInterface::meta().type();
+  const auto* propertyInfo = metaClass->searchPropertyByName("prop1");
+
+  bool callbackTriggered = false;
+  {
+    auto guard = fixture.proxy->onPropertyChangedUntyped(
+      propertyInfo,
+      EventCallback<VarList>(fixture.getQueue(), [&](const auto&, const auto&) { callbackTriggered = true; }));
+
+    fixture.owner->setNextProp1("first_emit");
+    fixture.owner->commit(TimeStamp {100});
+    fixture.proxy->drainInputs();
+  }  // guard destructs -> remove runs while the work item is still queued
+
+  while (fixture.getQueue()->executeAll())
+  {
+  }
+
+  EXPECT_FALSE(callbackTriggered);
+}

--- a/libs/core/test/obj/object_filter_test.cpp
+++ b/libs/core/test/obj/object_filter_test.cpp
@@ -650,3 +650,47 @@ TEST(ObjectFilter, Subscriber_RemoveWithInterestHandlesExpiredProvider)
 
   EXPECT_EQ(listener.providerToDrop, nullptr);
 }
+
+/// @test
+/// addSubscriber(..., notifyAboutExisting=true) seeds a newly-created provider's listener
+/// with the filter's current match set.
+TEST(ObjectFilter, Subscriber_NotifyAboutExistingTrueSeedsNewProvider)
+{
+  TestObjectFilter filter(getTestOwnerId());
+  const auto interest = createEmptyInterest();
+
+  auto obj = std::make_shared<TestOwner>("TestObj1");
+  TestObjectFilter::ObjectSet set;
+  set.newObjects[obj->getId()] = obj;
+  set.currentObjects[obj->getId()] = obj;
+  filter.evaluate(set);
+
+  MockListener listener;
+  filter.addSubscriber(interest, &listener, true);
+
+  ASSERT_EQ(listener.added.size(), 1U);
+  EXPECT_EQ(listener.added[0], obj->getId());
+
+  filter.removeSubscriber(interest, &listener, false);
+}
+
+/// @test
+/// addSubscriber(..., notifyAboutExisting=false) does not broadcast existing matches.
+TEST(ObjectFilter, Subscriber_NotifyAboutExistingFalseStaysSilent)
+{
+  TestObjectFilter filter(getTestOwnerId());
+  const auto interest = createEmptyInterest();
+
+  auto obj = std::make_shared<TestOwner>("TestObj1");
+  TestObjectFilter::ObjectSet set;
+  set.newObjects[obj->getId()] = obj;
+  set.currentObjects[obj->getId()] = obj;
+  filter.evaluate(set);
+
+  MockListener listener;
+  filter.addSubscriber(interest, &listener, false);
+
+  EXPECT_TRUE(listener.added.empty());
+
+  filter.removeSubscriber(interest, &listener, false);
+}

--- a/libs/kernel/include/sen/kernel/component_api.h
+++ b/libs/kernel/include/sen/kernel/component_api.h
@@ -142,22 +142,27 @@ public:
   /// The work queue of this runner
   [[nodiscard]] ::sen::impl::WorkQueue* getWorkQueue() const noexcept;
 
+  /// Subscribe to every object of type T on `bus`. The returned Subscription owns the
+  /// kernel-side wiring; destruct it to stop.
+  ///
+  /// Callback lifetime (this overload, the next, and selectFrom): onAdded / onRemoved
+  /// fire on the kernel's run() thread between subscribe and the Subscription's
+  /// destruction. References they capture must outlive the Subscription. Capture state
+  /// by shared_ptr or via a component member.
   template <typename T, typename Bus>
   [[nodiscard]] std::shared_ptr<Subscription<T>> selectAllFrom(const Bus& bus);
 
-  /// Overload of selectAllFrom that installs addition and removal callbacks before subscribing,
-  /// so they fire for objects already present at subscription time.
-  /// Pass nullptr for either callback to skip it.
+  /// As above, plus addition/removal callbacks installed before subscribing so they fire
+  /// for objects already present. Pass nullptr to skip either.
   template <typename T, typename Bus>
   [[nodiscard]] std::shared_ptr<Subscription<T>> selectAllFrom(
     const Bus& bus,
     typename sen::ObjectList<T>::Callback onAdded,
     typename sen::ObjectList<T>::Callback onRemoved = nullptr);
 
-  /// Creates a subscription for objects matching the given Sen query string.
-  /// Unlike selectAllFrom, this lets you supply an arbitrary query with WHERE conditions.
-  /// Example: selectFrom<Shape>(bus, "SELECT Shape FROM local.bus WHERE color IN (\"red\")").
-  /// It installs addition and removal callbacks before subscribing. Pass nullptr for either callback to skip it.
+  /// Subscription against an arbitrary Sen query (with WHERE conditions).
+  /// Example: `selectFrom<Shape>(bus, R"(SELECT Shape FROM local.bus WHERE color IN ("red"))")`.
+  /// Installs the callbacks before subscribing. Pass nullptr to skip either.
   template <typename T, typename Bus>
   [[nodiscard]] std::shared_ptr<Subscription<T>> selectFrom(const Bus& bus,
                                                             const std::string& query,
@@ -403,14 +408,15 @@ inline std::shared_ptr<Subscription<T>> KernelApi::selectFrom(const Bus& bus,
 template <typename T>
 inline std::string KernelApi::buildQuery(const BusAddress& address) const
 {
-  const ClassType* meta = nullptr;
-  if constexpr (!std::is_same_v<T, Object>)
-  {
-    meta = &T::meta();
-  }
-
   std::string query = "SELECT ";
-  query.append(meta ? meta->getQualifiedName() : "*");
+  if constexpr (std::is_same_v<T, Object>)
+  {
+    query.append("*");
+  }
+  else
+  {
+    query.append(T::meta()->asClassType()->getQualifiedName());
+  }
   query.append(" FROM ");
   query.append(address.sessionName);
   query.append(".");
@@ -422,14 +428,15 @@ inline std::string KernelApi::buildQuery(const BusAddress& address) const
 template <typename T>
 inline std::string KernelApi::buildQuery(std::string_view bus) const
 {
-  const ClassType* meta = nullptr;
-  if constexpr (!std::is_same_v<T, Object>)
-  {
-    meta = T::meta()->asClassType();
-  }
-
   std::string query = "SELECT ";
-  query.append(meta ? meta->getQualifiedName() : "*");
+  if constexpr (std::is_same_v<T, Object>)
+  {
+    query.append("*");
+  }
+  else
+  {
+    query.append(T::meta()->asClassType()->getQualifiedName());
+  }
   query.append(" FROM ");
   query.append(bus);
 

--- a/libs/kernel/src/pipeline_component.cpp
+++ b/libs/kernel/src/pipeline_component.cpp
@@ -259,6 +259,23 @@ void PipelineComponent::validateConfig(const CustomTypeRegistry& reg) const
 
   for (const auto& obj: config_.objects)
   {
+    // Both names set (bus-published) or both empty (not bus-published). A half-empty
+    // address would otherwise be silently dropped at connection time.
+    const bool hasSession = !obj.bus.sessionName.empty();
+    const bool hasBus = !obj.bus.busName.empty();
+    if (hasSession != hasBus)
+    {
+      std::string err;
+      err.append("object '");
+      err.append(obj.name);
+      err.append("' has an incomplete bus address (sessionName='");
+      err.append(obj.bus.sessionName);
+      err.append("', busName='");
+      err.append(obj.bus.busName);
+      err.append("'); both must be set, or both omitted");
+      throw std::runtime_error(err);
+    }
+
     auto basicType = reg.get(obj.className);
     if (!basicType)
     {

--- a/libs/kernel/test/unit/test_kernel/test_kernel_test.cpp
+++ b/libs/kernel/test/unit/test_kernel/test_kernel_test.cpp
@@ -201,3 +201,21 @@ TEST(TestKernel, repeatedNames)
   sen::kernel::TestKernel kernel(&component);
   kernel.step();
 }
+
+/// @test
+/// A pipeline object with one side of `bus` empty (trailing or leading dot) is rejected
+/// at config-validation time.
+TEST(TestKernel, busAddressMustBeFullySpecified)
+{
+  const auto* yaml = R"yaml(
+build:
+  - name: comp
+    group: 1
+    freqHz: 100
+    objects:
+      - name: obj
+        class: test.MyClass
+        bus: "session."
+)yaml";
+  EXPECT_THROW(sen::kernel::TestKernel::fromYamlString(yaml), std::runtime_error);
+}


### PR DESCRIPTION
Three crashes/dangling-pointer bugs in the kernel subscription + query path, plus tightening fixes found while auditing the path. This is the foundation of the stack: every downstream branch is sensitive to kernel subscription correctness, and the fixes here are root-cause — nothing downstream needs a workaround.

**Stack — part 1/6 (base: `main`).** Review and merge bottom-up.

---
**The stack**
1. #64 — kernel subscription-path fixes
2. #65 — mode-driven build selection + libs/gen
3. #66 — jsonrpc component
4. #67 — @sen/client TypeScript library
5. #68 — db Python bindings
6. #69 — Web Explorer + getting-started docs

Each PR is based on its predecessor's branch and shows only its own changes. Review in any order; merge strictly bottom-up. Note: this repository is squash-merge only, so after each merge the remaining branches must be rebased onto the updated `main` and force-pushed before the next PR's diff reads correctly again.
