### PR TITLE
feat(jsonrpc-ts-client): @sen/client TypeScript library

### DIFF
--- a/components/jsonrpc/clients/typescript/.gitignore
+++ b/components/jsonrpc/clients/typescript/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.vite/
+coverage/
+src/generated/

--- a/components/jsonrpc/clients/typescript/CMakeLists.txt
+++ b/components/jsonrpc/clients/typescript/CMakeLists.txt
@@ -1,0 +1,131 @@
+# === CMakeLists.txt ===================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+
+# Lets people keep jsonrpc C++ but skip the node toolchain.
+option(SEN_BUILD_JSONRPC_TS_CLIENT "Build the @sen/client TypeScript package" ON)
+if(NOT SEN_BUILD_JSONRPC_TS_CLIENT)
+  return()
+endif()
+
+# Generate the TypeScript value-type modules consumed by the @sen/client npm package from the
+# project's STL files (one .ts per STL plus an index.ts barrel, into src/generated/). The output
+# is gitignored; this target produces it as part of the regular build, so the npm-side
+# `tsc`/`vite`/`vitest` invocations see fresh types whenever an STL changes.
+set(_ts_client_out_dir ${CMAKE_CURRENT_SOURCE_DIR}/src/generated)
+set(_ts_client_stls ${PROJECT_SOURCE_DIR}/components/jsonrpc/stl/jsonrpc.stl)
+
+# Hardcoded now until we have the full typescript generation pipeline.
+set(_ts_client_outputs
+    ${_ts_client_out_dir}/index.ts
+    ${_ts_client_out_dir}/jsonrpc.ts
+    ${_ts_client_out_dir}/type_specs.ts
+    ${_ts_client_out_dir}/basic_types.ts
+    ${_ts_client_out_dir}/log.ts
+)
+
+# The kernel STL include path is supplied explicitly; jsonrpc.stl `import`s into sen.kernel.*.
+add_custom_command(
+  OUTPUT ${_ts_client_outputs}
+  COMMAND_EXPAND_LISTS VERBATIM
+  COMMAND sen::cli_gen ts stl ${_ts_client_stls} -i ${PROJECT_SOURCE_DIR}/libs/kernel -d ${_ts_client_out_dir}
+  DEPENDS ${_ts_client_stls} sen::cli_gen
+  COMMENT "Generating @sen/client TypeScript types -> ${_ts_client_out_dir}"
+)
+
+add_custom_target(jsonrpc_ts_client_codegen ALL DEPENDS ${_ts_client_outputs})
+add_dependencies(jsonrpc_ts_client_codegen sen::cli_gen)
+set_target_properties(jsonrpc_ts_client_codegen PROPERTIES FOLDER "components/jsonrpc")
+
+# Everything below needs the node toolchain; codegen above stays available without it.
+find_program(NPM_EXEC npm)
+if(NOT NPM_EXEC)
+  message(STATUS "jsonrpc TS client: npm not found; skipping package install/build/tests")
+  return()
+endif()
+
+set(_ts_client_node_modules_sentinel ${CMAKE_CURRENT_SOURCE_DIR}/node_modules/.package-lock.json)
+
+# `npm` is a node script whose shebang needs node on PATH. The Conan toolchain places node in
+# its own bin dir; we surface that on PATH at build-command level via `cmake -E env --modify
+# PATH=path_list_prepend:...`, which is platform-aware (handles `:` vs `;` separator and
+# quoting). Requires CMake >= 3.25; Sen pins 3.28.1 via Conan tool_requires.
+get_filename_component(_node_bin_dir ${NPM_EXEC} DIRECTORY)
+
+# `npm ci` (not `npm install`) so the lockfile is the source of truth: faster, deterministic,
+# and refuses to silently rewrite package-lock.json when a `^`-range admits a newer subdep.
+add_custom_command(
+  OUTPUT ${_ts_client_node_modules_sentinel}
+  COMMAND ${CMAKE_COMMAND} -E env --modify "PATH=path_list_prepend:${_node_bin_dir}" ${NPM_EXEC} ci
+          --no-audit --no-fund --silent
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/package.json ${CMAKE_CURRENT_SOURCE_DIR}/package-lock.json
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMENT "npm ci for @sen/client"
+  VERBATIM
+)
+add_custom_target(jsonrpc_ts_client_npm_install DEPENDS ${_ts_client_node_modules_sentinel})
+
+# Production bundle (dist/). The package's `exports` map resolves `@sen/client` into dist/,
+# so anything that bundles against the package (web_explorer's frontend) must depend on
+# this target — a fresh checkout cannot rely on a manually-built dist/ lying around.
+file(
+  GLOB_RECURSE
+  _ts_client_sources
+  CONFIGURE_DEPENDS
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/*.ts
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/*.tsx
+)
+set(_ts_client_dist_output ${CMAKE_CURRENT_SOURCE_DIR}/dist/index.js)
+add_custom_command(
+  OUTPUT ${_ts_client_dist_output}
+  COMMAND ${CMAKE_COMMAND} -E env --modify "PATH=path_list_prepend:${_node_bin_dir}" ${NPM_EXEC} run build
+          --silent
+  DEPENDS ${_ts_client_node_modules_sentinel} ${_ts_client_outputs} ${_ts_client_sources}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMENT "Building @sen/client bundle -> dist/"
+  VERBATIM
+)
+add_custom_target(jsonrpc_ts_client_dist DEPENDS ${_ts_client_dist_output})
+add_dependencies(jsonrpc_ts_client_dist jsonrpc_ts_client_codegen jsonrpc_ts_client_npm_install)
+set_target_properties(jsonrpc_ts_client_dist PROPERTIES FOLDER "components/jsonrpc")
+
+# Tests (opt-in). Gated on SEN_BUILD_TESTS because REQ_DEPS includes the `inheritance` test
+# fixture target, which only exists when tests are enabled.
+if(SEN_BUILD_TESTS)
+  # globalSetup reads SEN_BINARY and SEN_CONFIG from the environment (set below) to spawn the
+  # Sen subprocess; both are absolute so the test is cwd-independent.
+  add_sen_integration_test(
+    jsonrpc_ts_client_integration
+    COMMAND
+    ${NPM_EXEC}
+    run
+    test:integration
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    REQ_DEPS jsonrpc jsonrpc_ts_client_codegen jsonrpc_ts_client_npm_install inheritance
+  )
+  set_tests_properties(jsonrpc_ts_client_integration PROPERTIES RUN_SERIAL TRUE)
+  append_test_env_modification(
+    jsonrpc_ts_client_integration
+    "SEN_BINARY=set:$<TARGET_FILE:sen::cli_sen>"
+    "SEN_CONFIG=set:${CMAKE_CURRENT_SOURCE_DIR}/test/integration/configs/inheritance.yaml"
+    "PATH=path_list_prepend:${_node_bin_dir}"
+  )
+
+  # Full-strictness `tsc --noEmit` over prod + test configs. vite builds do not typecheck
+  # (esbuild strips types), so without this gate a type error ships silently.
+  add_sen_integration_test(
+    jsonrpc_ts_client_typecheck
+    COMMAND
+    ${NPM_EXEC}
+    run
+    typecheck
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    REQ_DEPS jsonrpc_ts_client_codegen jsonrpc_ts_client_npm_install
+  )
+  append_test_env_modification(jsonrpc_ts_client_typecheck "PATH=path_list_prepend:${_node_bin_dir}")
+else()
+  message(STATUS "jsonrpc TS client: tests disabled, skipping test registration")
+endif()

--- a/components/jsonrpc/clients/typescript/README.md
+++ b/components/jsonrpc/clients/typescript/README.md
@@ -1,0 +1,368 @@
+# @sen/client
+
+A TypeScript client for [Sen](https://github.com/airbus/sen) over JSON-RPC 2.0 / WebSocket.
+Connect to a running Sen process, query its objects, subscribe to property changes and events,
+and invoke methods. Works in browsers and in Node.js (>=22).
+
+```bash
+npm install @sen/client
+```
+
+## Hello, animals
+
+In one terminal, start a Sen process exposing the bundled `animals` package:
+
+```bash
+sen run components/jsonrpc/clients/typescript/examples/browser/animals.yaml
+```
+
+That spins up two objects on the bus `my.tutorial`: `rufus` (a Cat) and `elon` (a Dog), both
+extending the base class `Animal`. The JSON-RPC server listens on `ws://127.0.0.1:8080`.
+
+In a second terminal, connect to it:
+
+```ts
+import { connect } from "@sen/client";
+
+const client = await connect({ url: "ws://127.0.0.1:8080" });
+
+// Declare an interest: a live query against the Sen object graph.
+const interest = await client.declareInterest({
+  name: "cats",
+  query: "SELECT animals.Cat FROM my.tutorial",
+});
+
+// React to every Cat the interest matches now or in the future. The handler fires
+// immediately for every object already present and again for each later arrival.
+interest.onObjectAdded(async (cat) => {
+  console.log(`got ${cat.className} named ${cat.name}`);
+
+  // Subscribe to the cat's position. The handler fires once with the current value
+  // and again every time it changes.
+  cat.onPropertyChanged("position", (pos) => {
+    console.log("position:", pos);
+  });
+
+  // Call a method. Arguments are passed by name.
+  await cat.invoke("jumpToLocation", { x: 42, y: 17 });
+});
+
+// Stay open for a few seconds so subscribed updates have time to arrive, then clean up.
+// In a real app you'd keep the client open for as long as you need it (e.g. until SIGINT).
+await new Promise((r) => setTimeout(r, 3_000));
+
+await interest.release();
+client.close();
+```
+
+You should see the initial position print, then the post-jump position, before the script
+exits. The `onObjectAdded` callback handles the initial match set and live churn uniformly,
+which is the whole point of the API shape.
+
+## Concepts
+
+The library has three layered handles:
+
+- **`Client`**: the connection. One per Sen process. Owns the WebSocket, hands out interests.
+- **`InterestHandle`**: a live query. Keeps a local cache of matching objects in sync with the
+  server. Notifies you when objects come and go.
+- **`ObjectHandle`**: one object in an interest's match set. The unit of work for property
+  reads/writes, event subscriptions, and method calls.
+
+You only ever construct a `Client`. Interests and objects come from it.
+
+### Queries
+
+`declareInterest` takes a Sen query string. The simplest form is `SELECT <Class> FROM <bus>`,
+but the query language supports joins, filters, and inheritance traversal. See the Sen
+[interest documentation](https://airbus.github.io/sen/latest/) for the full grammar.
+
+Register `onObjectAdded` to drive work; it fires for every currently-matched object on
+registration and again for every later arrival.
+
+```ts
+interest.onObjectAdded((obj) => console.log("added:", obj.className, obj.name));
+interest.onObjectRemoved((name) => console.log("removed:", name));
+```
+
+`interest.objects()` returns a synchronous snapshot of currently-matched objects (combine
+with `onObjectAdded` to avoid missing late arrivals). `for await (const obj of interest)`
+is a thin wrapper over `onObjectAdded`.
+
+`await interest.release()` drops the server-side state and clears local handlers; idempotent.
+
+#### Pre-subscribing
+
+By default an interest only tracks object membership; you pay a round-trip on the first
+`obj.get(prop)`. Pass a `subscribe` block to ask the server to pre-subscribe property values
+(and optionally events) as part of the same call, so matched objects arrive with their values
+already cached:
+
+```ts
+const fleet = await client.declareInterest({
+  name: "fleet",
+  query: "SELECT aircraft.Aircraft FROM ops",
+  subscribe: {
+    properties: ["altitude", "speed"],   // or "*" for every property
+    events: ["landed", "takenOff"],      // or "*", or omit
+    maxRateHz: 10,                       // optional throttle on property pushes
+  },
+});
+```
+
+After pre-subscribing, the first `obj.get("altitude")` returns from the local cache without a
+wire trip, and any `obj.onPropertyChanged("altitude", ...)` registered later sees the value the
+moment a push arrives.
+
+### Properties
+
+Read once:
+
+```ts
+const pos = await rufus.get("position");
+```
+
+`get` returns a value from the local cache if there is one (kept fresh by active subscriptions);
+pass `{ fresh: true }` to force a server round-trip.
+
+Write (only on properties marked `[writable]` in the STL):
+
+```ts
+await rufus.set("name", "Rufus the Magnificent");
+```
+
+Writes to non-writable properties throw `JsonRpcError`.
+
+Subscribe to changes:
+
+```ts
+const cancel = rufus.onPropertyChanged("position", (pos) => {
+  console.log("position:", pos);
+});
+
+// later:
+cancel();
+```
+
+Multiple consumers can subscribe to the same property. The library issues one wire
+subscription and fans out; when the last consumer cancels, it unsubscribes on the wire.
+
+To watch every property in one bundle:
+
+```ts
+rufus.onAnyChange((changes) => {
+  for (const [name, value] of changes) console.log(name, "=", value);
+});
+```
+
+### Events
+
+Events are like properties but fire-and-forget; the handler receives the positional args:
+
+```ts
+rufus.onEventTriggered("madeSound", (args) => {
+  const [content] = args;
+  console.log("the cat said:", content);
+});
+```
+
+### Methods
+
+`invoke` takes a method name and an object of named arguments:
+
+```ts
+await rufus.invoke("jumpToLocation", { x: 42, y: 17 });
+const reply = await someTeacher.invoke("ask", { question: "what time is it?" });
+```
+
+Arguments are validated locally against the method's declared signature before the call goes
+on the wire, so a typo in an argument name throws immediately. The return value, if any, is
+the method's declared return type; void methods return `null`.
+
+### Runtime values
+
+Properties, event args, and method results come back as `Var` values. Most are plain
+JavaScript: strings, numbers, booleans, arrays, plain objects. Two types are runtime classes:
+
+- **`Quantity`**: a number with units (`{value, unit, minValue?, maxValue?}`).
+- **`Variant`**: a tagged union (`{type, value}`).
+
+Use the narrowing helpers (`isPrimitive`, `isStruct`, `isSequence`, `isQuantity`, `isVariant`)
+to walk an unknown value:
+
+```ts
+import { isQuantity, isVariant } from "@sen/client";
+
+const distance = await rufus.get("travelDistance");
+if (isQuantity(distance)) {
+  console.log(`${distance.value} ${distance.unit.abbreviation}`);
+}
+```
+
+**64-bit integers (`i64` / `u64`)** arrive as `bigint`, not `number`. The server emits them
+as JSON decimal strings to preserve precision past `Number.MAX_SAFE_INTEGER` (2^53 - 1), and
+the client decodes that string into a `bigint`. Values fed into APIs that need a `number`
+(uPlot x-axes, `Date(ms)`, etc.) must be narrowed explicitly with `numberFromExact`, which
+throws `RangeError` instead of silently losing the high bits:
+
+```ts
+import { numberFromExact } from "@sen/client";
+
+const byteCount = await disk.get("byteCount");   // bigint
+if (typeof byteCount === "bigint") {
+  // safe for values up to 2^53 - 1; throws past that
+  const asNumber = numberFromExact(byteCount, "byteCount");
+}
+```
+
+`TimeStamp` arrives as the wire string (RFC-3339 UTC with nanosecond precision); pass it
+through `parseSenTimestamp` for a `Date` (millisecond precision) plus a `nanoseconds`
+remainder.
+
+## Errors
+
+Three classes, all extending `SenClientError` (which extends `Error`):
+
+- **`JsonRpcError`**: the server returned a JSON-RPC error. Carries `code`, `message`, `data?`.
+  Common case: writing a non-writable property, calling a method that does not exist on the
+  server.
+- **`TransportError`**: a connection-level problem (disconnect mid-call, malformed frame).
+- **`TimeoutError`**: the call did not get a response in time. Carries `timeoutMs`.
+
+Per-call timeout defaults come from `ClientOptions.defaultTimeoutMs`; override with
+`{ timeoutMs }` on individual calls. Pass an `AbortSignal` via `{ signal }` for composable
+cancellation.
+
+## Reconnection
+
+By default the transport reconnects on its own with exponential backoff, and after each
+successful reconnect the client re-declares every interest automatically
+(`reconnect.autoReestablish`, default `true`); subscriptions resume with them. While
+reconnecting, in-flight calls fail with `TransportError`. The lifecycle hooks are for UI
+state and custom work — don't call `reestablishAll()` from them yourself, recovery is
+already wired:
+
+```ts
+client.onDisconnect(() => console.warn("connection lost"));
+client.onReconnect(() => console.log("back online"));
+```
+
+For custom recovery (for example, apps where fresh state after an outage is the correct
+behaviour), opt out with `reconnect: { autoReestablish: false }` and drive
+`reestablishAll()` — or your own re-declares — from `onReconnect`. `reestablishAll()` is
+single-flight: overlapping calls coalesce instead of racing each other's `createInterest`.
+
+For UIs that want a single hook for every transition (connecting / open / reconnecting /
+closed), use `onConnectionStateChange`:
+
+```ts
+client.onConnectionStateChange((state) => {
+  statusBadge.textContent = state;
+});
+```
+
+`reestablishAll()` re-declares every interest in parallel. Subscriptions on those interests
+resume automatically once the interests are active again.
+
+To disable auto-reconnect entirely (useful for short-lived scripts):
+
+```ts
+const client = await connect({
+  url: "ws://127.0.0.1:8080",
+  reconnect: { enabled: false },
+});
+```
+
+## Batch reads
+
+For panels that need every property of one or many objects in one shot (a dashboard refresh,
+say), the wire offers a batch read that walks the inheritance chain server-side and returns
+each object's full property map in a single round-trip:
+
+```ts
+const states = await interest.getObjectsBatchState({
+  // both filters are optional; omit to fetch every matched object / every property
+  objectNames: ["rufus", "elon"],
+  propertyNames: ["position", "name"],
+});
+
+for (const state of states) {
+  console.log(state.name, state.className, state.properties);
+  // per-property failures (e.g. variant with no current value) land in state.errors
+}
+```
+
+Each returned `ObjectBatchState` carries `properties` (successful reads, with the property's
+`TypeSpec` attached for narrowing) and `errors` (per-property failure messages). Object names
+that did not match the interest's current set are silently skipped -- check the returned
+`name` field against your input list to detect them.
+
+## React bindings
+
+The package ships React hooks under the `@sen/client/react` entry point. They sit on top of
+the same `Client` / `InterestHandle` / `ObjectHandle` lifecycle described above; you still
+hold a `Client` instance for the lifetime of the React tree.
+
+Pass the `Client` down via props or React context (your app code), then hand it to the
+hooks:
+
+```tsx
+import type { Client, ObjectHandle } from "@sen/client";
+import { useInterest, useObjects, useProperty, useInvoke } from "@sen/client/react";
+
+function CatList({ client }: { client: Client }) {
+  // Declares the interest on mount, releases on unmount.
+  const { handle: cats } = useInterest(client, {
+    name: "cats",
+    query: "SELECT animals.Cat FROM my.tutorial",
+  });
+  // Live snapshot of the interest's match set; re-renders on add / remove.
+  const objects = useObjects(cats);
+  return (
+    <ul>
+      {objects.map((cat) => <CatRow key={cat.name} cat={cat} />)}
+    </ul>
+  );
+}
+
+function CatRow({ cat }: { cat: ObjectHandle }) {
+  // Live-subscribes to the property; re-renders on each push.
+  const position = useProperty(cat, "position") as { x: number; y: number } | undefined;
+  const { invoke, status } = useInvoke(cat);
+  return (
+    <li>
+      {cat.name} at {position?.x},{position?.y}{" "}
+      <button
+        onClick={() => invoke("jumpToLocation", { x: 42, y: 17 })}
+        disabled={status === "pending"}
+      >
+        jump
+      </button>
+    </li>
+  );
+}
+```
+
+`Client` lives outside the React tree -- create it once with `await connect({ url })`,
+then pass it down (props or context). The hooks accept `Client | null` /
+`InterestHandle | null` so a pre-connect render is safe.
+
+Hook surface:
+
+| Hook | Purpose |
+|---|---|
+| `useConnectionState(client)` | Current connection state for status badges. |
+| `useTopology(client)` | Discover sessions / buses. |
+| `useTypeSpec(client, name)` | Fetch a class / struct / variant `TypeSpec` (cached per connection). |
+| `useInterest(client, { name, query, subscribe? })` | Declares the interest on mount, releases on unmount. Returns `{ handle, error }`. |
+| `useObjects(interest)` | Live snapshot of an interest's match-set. Returns `ObjectHandle[]`. |
+| `useObject(interest, name)` | Single object by name from a given interest. |
+| `useProperty(obj, name)` | Live-subscribed value of one property on one object. |
+| `useSetProperty(obj)` | Returns `{ setProperty, status, error }` for writing a property with explicit pending / success / error states. |
+| `useInvoke(obj)` | Returns `{ invoke, reset, status, result, error }` for invoking a method by name (passed at call time). |
+| `useEvents(obj, name, opts?)` | Bounded ring of recent deliveries (default 200) for one named event on one object. |
+
+For grids and tables that need cell-level updates without re-rendering the whole list,
+`@sen/client/react` also exposes a small store primitive (`makeStore`, `makeBufferStore`,
+`useCell`, `useView`) for fine-grained subscriptions. See the dedicated
+[`react/store/README.md`](src/react/store/README.md).

--- a/components/jsonrpc/clients/typescript/architecture.md
+++ b/components/jsonrpc/clients/typescript/architecture.md
@@ -1,0 +1,111 @@
+# @sen/client -- Architecture
+
+One-page mental model for contributors. For end-user docs see [`README.md`](README.md);
+for the mkdocs landing page see [`docs/components/jsonrpc_ts_client.md`](../../../../docs/components/jsonrpc_ts_client.md).
+
+## Purpose
+
+A TypeScript library that lets a browser or Node.js program talk to a Sen process over the
+jsonrpc component's wire (JSON-RPC 2.0 + WebSocket). Wraps the raw wire surface in three
+layered handles -- `Client`, `InterestHandle`, `ObjectHandle` -- and exposes matching React
+hooks for UI consumers.
+
+## Layers
+
+```
++---------------------------------------+
+| React hooks  (use_object, use_property, ...) |
+| Store primitives (make_store, use_cell, ...) |
++---------------------------------------+
+| Handles                                |
+|   Client / InterestHandle / ObjectHandle |
++---------------------------------------+
+| Internal services                       |
+|   protocol_client    -- typed RPC calls |
+|   subscription_registry -- fan-out     |
+|   type_cache         -- per-conn TypeSpec |
+|   var_codec          -- encode / parse Var |
+|   transport          -- WebSocket + reconnect |
++---------------------------------------+
+| Generated wire types                    |
+|   src/generated/*.ts (from cli_gen ts)  |
++---------------------------------------+
+```
+
+## Modules
+
+| Path | Class / surface | Responsibility |
+|---|---|---|
+| `src/connect.ts` | `connect()` | Entry point. Opens the WebSocket, runs the initial handshake, returns a ready `Client`. |
+| `src/client.ts` | `Client` | The connection. One per Sen process. Owns the WebSocket lifecycle, hands out `InterestHandle`s, surfaces connection-state events. |
+| `src/handles.ts` | `InterestHandle`, `ObjectHandle` | High-level facades over interests + per-object state. Hide the wire and the registry from consumers. |
+| `src/errors.ts` | `SenClientError` hierarchy | `JsonRpcError`, `TransportError`, `TimeoutError`. |
+| `src/values.ts` | `Var`, `Quantity`, `Variant`, `VarList`, `VarMap` | Runtime value types matching the wire shape. |
+| `src/narrowing.ts` | `isPrimitive`, `isStruct`, `isSequence`, `isQuantity`, `isVariant` | Type-guard helpers for walking unknown `Var`s. |
+| `src/internal/transport.ts` | WebSocket adapter | Auto-reconnect with backoff. Single inbound message handler; multiplexes responses + notifications. |
+| `src/internal/protocol_client.ts` | Typed RPC calls | One method per wire RPC; encodes/decodes payloads against the generated types. |
+| `src/internal/subscription_registry.ts` | Refcounted subscription fan-out | One wire subscription per `(interest, object, member)`; multiple consumers share it. |
+| `src/internal/type_cache.ts` | Per-connection `TypeSpec` cache | Avoids refetching class shapes; invalidated when the connection drops. |
+| `src/internal/var_codec.ts` | `parseVar` + `encodeVar` | Wire <-> runtime conversion (Quantity / Variant tagging, etc). |
+| `src/internal/subscribe_codec.ts` | Subscription request encoding | Builds the wire shape from a high-level `subscribe` block. |
+| `src/internal/notification_validators.ts` | Shape-only validators | Cheap checks before `parseVar` runs on deep payloads. |
+| `src/internal/cancel.ts` | `CancelFn` plumbing | Unified cancel semantics across handlers and AbortSignal. |
+| `src/internal/report_error.ts` | Error reporting hook | Configurable `ReportError` callback for transport-level surprises. |
+| `src/internal/class_spec_lookup.ts` | Class spec helpers | Walks the inheritance chain when resolving a property's declared type. |
+| `src/react/*` | React hooks | `useObject`, `useObjects`, `useProperty`, `useEvents`, `useInvoke`, etc. All sit on top of the handles. |
+| `src/react/store/*` | Store primitives | `makeStore`, `makeBufferStore`, `useCell`, `useView` -- fine-grained subscription primitives for grids / tables. |
+| `src/generated/*` | Wire types | Emitted at build time by `cli_gen ts` from `components/jsonrpc/stl/jsonrpc.stl`. Never edit by hand. |
+
+## Key invariants
+
+- **One Client per Sen process.** A `Client` owns one WebSocket. Sharing it across multiple
+  components is safe and expected.
+- **Handles are owned facades, not values.** `InterestHandle` and `ObjectHandle` carry
+  per-consumer state (callbacks, refcounts). Don't equality-compare them across boundaries
+  -- look them up via `client.interest(name)` or `interest.object(name)`.
+- **One wire subscription per `(interest, object, member)`.** `subscription_registry`
+  refcounts consumers. 50 React components subscribing to the same property cause one wire
+  subscription; the registry fans the notification out locally.
+- **Transport auto-reconnects; interests re-declare automatically by default.**
+  `reconnect.autoReestablish` (default on) runs `reestablishAll()` after each successful
+  reconnect; apps that want fresh-state recovery opt out and drive their own. `reestablishAll`
+  is single-flight -- overlapping triggers coalesce, because two interleaved runs would race
+  each other's `createInterest` into "interest already exists" and strand cleared handles.
+- **Wire types are generated, not hand-written.** `cli_gen ts` runs at build time. A new
+  wire field flows automatically into TypeScript; a stale hand-written type cannot drift.
+- **`exactOptionalPropertyTypes`** is on (`tsconfig.json`). Code that wants "absent" must
+  omit the key, not set it to `undefined`. `protocol_client` carefully builds payloads to
+  match.
+
+## Extension points
+
+- **New wire method**: add to `components/jsonrpc/stl/jsonrpc.stl` on the C++ side; the next
+  build regenerates `src/generated/`. Add a typed wrapper in `protocol_client.ts` and a
+  high-level facade in `handles.ts` (or `Client`) as needed.
+- **New React hook**: implement it under `src/react/`, re-export from `src/react/index.ts`.
+  Hooks should sit on top of the handles, not the internal layer.
+- **Replace the WebSocket**: `transport.ts` types its WebSocket dependency structurally; an
+  alternative transport (e.g. an in-process pair for tests) can implement the same shape.
+  `test/test_helpers/mock_websocket.ts` does exactly this.
+- **Per-connection observers**: add a callback registry on `Client`. The existing
+  `onDisconnect` / `onReconnect` / `onConnectionStateChange` follow the same pattern.
+
+## Tests
+
+- `test/*.test.ts` -- unit tests against the handles + internal layer (mocked transport).
+- `test/store/*.test.ts` -- store primitives.
+- `test/integration/*.test.ts` -- spawned-Sen integration: a real Sen process, a real
+  WebSocket. Slower but catches wire-shape regressions the unit tests miss.
+- `test/test_helpers/mock_websocket.ts` -- the in-process WebSocket double used everywhere.
+
+## Build
+
+- `src/generated/` is produced by the CMake target `jsonrpc_ts_client_codegen`. Run a
+  CMake build of the Sen tree at least once before any `npm` command; the directory is
+  gitignored and `npm test` / `npm run typecheck` will fail with unresolved imports of
+  `./generated/index.js` until it is populated.
+- `npm run build` -- esbuild bundles `src/index.ts` -> `dist/index.js` (ESM, source maps).
+- `npm run typecheck` -- `tsc --noEmit` against the production tsconfig + the test tsconfig.
+- `npm test` -- vitest, unit only.
+- `npm run test:integration` -- vitest, integration. Needs `SEN_BINARY` + `SEN_CONFIG` env
+  vars pointing at a built Sen + a yaml config exposing the test fixtures.

--- a/components/jsonrpc/clients/typescript/examples/browser/README.md
+++ b/components/jsonrpc/clients/typescript/examples/browser/README.md
@@ -1,0 +1,34 @@
+# Browser smoke
+
+Static HTML page that loads the built `@sen/client` bundle in a real browser, connects to a
+Sen subprocess over WebSocket, and runs the top-level [README](../../README.md)'s hello-world
+against the actual `dist/` artifact.
+
+## Run
+
+```bash
+# 1. Build the bundle.
+cd /workspace/components/jsonrpc/clients/typescript
+npm run build
+
+# 2. Start Sen on the bundled animals config (port 8080).
+/workspace/build/gcc/Release/build/gcc/Release/bin/sen \
+  run /workspace/components/jsonrpc/clients/typescript/examples/browser/animals.yaml &
+
+# 3. Serve the package (port 8000) so the page can import dist/index.js.
+python3 -m http.server 8000
+```
+
+Open `http://localhost:8000/examples/browser/`. You should see:
+
+```
+connecting to ws://127.0.0.1:8080...
+connected.
+got animals.Cat named rufus
+position: x=0 m, y=0 m
+position: x=42 m, y=17 m
+done.
+```
+
+An `<script type="importmap">` aliases `@sen/client` to the bundle path so the page can
+`import { connect } from "@sen/client"` as a real consumer would.

--- a/components/jsonrpc/clients/typescript/examples/browser/animals.yaml
+++ b/components/jsonrpc/clients/typescript/examples/browser/animals.yaml
@@ -1,0 +1,24 @@
+# $schema: ../../../../../examples/config/base/schema.json
+
+# Sen config used by the @sen/client hello-world and browser smoke. Spawns the rufus cat
+# and elon dog from the `animals` example package on the `my.tutorial` bus, and exposes
+# the kernel over jsonrpc on ws://127.0.0.1:8080 (the URL all client docs connect to).
+# `animals` ships with examples enabled (Conan: with_examples=True).
+
+load:
+  - name: jsonrpc
+    address: "127.0.0.1"
+    port: 8080
+
+build:
+  - name: tutorial
+    freqHz: 30
+    imports: [animals]
+    group: 3
+    objects:
+      - class: animals.CatImpl
+        name: rufus
+        bus: my.tutorial
+      - class: animals.DogImpl
+        name: elon
+        bus: my.tutorial

--- a/components/jsonrpc/clients/typescript/examples/browser/index.html
+++ b/components/jsonrpc/clients/typescript/examples/browser/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>@sen/client browser smoke</title>
+  <style>
+    body { font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; max-width: 720px; margin: 2em auto; padding: 0 1em; }
+    h1 { font-size: 16px; }
+    pre { background: #f4f4f4; padding: 1em; border-radius: 4px; overflow: auto; }
+    .err { color: #b00020; }
+  </style>
+</head>
+<body>
+  <h1>@sen/client browser smoke</h1>
+  <p>
+    The same hello-world from the README, loaded in a browser via the built
+    <code>dist/index.js</code>. Run a Sen with the co-located
+    <code>animals.yaml</code> on <code>ws://127.0.0.1:8080</code> before opening this page.
+    See <a href="./README.md">README</a> for the full setup.
+  </p>
+  <pre id="log"></pre>
+
+  <script type="importmap">
+    {
+      "imports": {
+        "@sen/client": "../../dist/index.js"
+      }
+    }
+  </script>
+  <script type="module">
+    import { connect } from "@sen/client";
+
+    const logEl = document.getElementById("log");
+    const log = (msg, cls) => {
+      const line = document.createElement("span");
+      if (cls) line.className = cls;
+      line.textContent = msg + "\n";
+      logEl.appendChild(line);
+    };
+
+    try {
+      log("connecting to ws://127.0.0.1:8080...");
+      const client = await connect({ url: "ws://127.0.0.1:8080" });
+      log("connected.");
+
+      const interest = await client.declareInterest({
+        name: "cats",
+        query: "SELECT animals.Cat FROM my.tutorial",
+      });
+
+      interest.onObjectAdded(async (cat) => {
+        log(`got ${cat.className} named ${cat.name}`);
+        cat.onPropertyChanged("position", (pos) => {
+          log(`position: x=${pos.x.value} ${pos.x.unit.abbreviation}, y=${pos.y.value} ${pos.y.unit.abbreviation}`);
+        });
+        await cat.invoke("jumpToLocation", { x: 42, y: 17 });
+      });
+
+      // Hold for a few seconds so subscribed updates arrive, then clean up.
+      await new Promise((r) => setTimeout(r, 3_000));
+      await interest.release();
+      client.close();
+      log("done.");
+    } catch (err) {
+      log("ERROR: " + (err?.message ?? String(err)), "err");
+    }
+  </script>
+</body>
+</html>

--- a/components/jsonrpc/clients/typescript/package-lock.json
+++ b/components/jsonrpc/clients/typescript/package-lock.json
@@ -1,0 +1,3561 @@
+{
+  "name": "@sen/client",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@sen/client",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "@types/react": "^19.0.0",
+        "react": "^19.0.0",
+        "typescript": "^5.7.0",
+        "vite": "^6.0.0",
+        "vite-plugin-dts": "^4.3.0",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/api-extractor": {
+      "version": "7.58.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.7.tgz",
+      "integrity": "sha512-yK6OycD46gIzLRpj6ueVUWPk1ACSpkN1LBo05gY1qPTylbWyUCanXfH7+VgkI5LJrJoRSQR5F04XuCffCXLOBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/api-extractor-model": "7.33.8",
+        "@microsoft/tsdoc": "~0.16.0",
+        "@microsoft/tsdoc-config": "~0.18.1",
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/rig-package": "0.7.3",
+        "@rushstack/terminal": "0.24.0",
+        "@rushstack/ts-command-line": "5.3.9",
+        "diff": "~8.0.2",
+        "minimatch": "10.2.3",
+        "resolve": "~1.22.1",
+        "semver": "~7.7.4",
+        "source-map": "~0.6.1",
+        "typescript": "5.9.3"
+      },
+      "bin": {
+        "api-extractor": "bin/api-extractor"
+      }
+    },
+    "node_modules/@microsoft/api-extractor-model": {
+      "version": "7.33.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.8.tgz",
+      "integrity": "sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "~0.16.0",
+        "@microsoft/tsdoc-config": "~0.18.1",
+        "@rushstack/node-core-library": "5.23.1"
+      }
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+      "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "ajv": "~8.18.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.2"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rushstack/node-core-library": {
+      "version": "5.23.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.1.tgz",
+      "integrity": "sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "~8.18.0",
+        "ajv-draft-04": "~1.0.0",
+        "ajv-formats": "~3.0.1",
+        "fs-extra": "~11.3.0",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.7.4"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/problem-matcher": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz",
+      "integrity": "sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/rig-package": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.3.tgz",
+      "integrity": "sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1"
+      }
+    },
+    "node_modules/@rushstack/terminal": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.0.tgz",
+      "integrity": "sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/problem-matcher": "0.2.1",
+        "supports-color": "~8.1.1"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/ts-command-line": {
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.9.tgz",
+      "integrity": "sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rushstack/terminal": "0.24.0",
+        "@types/argparse": "1.0.38",
+        "argparse": "~1.0.9",
+        "string-argv": "~0.3.1"
+      }
+    },
+    "node_modules/@types/argparse": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.35.tgz",
+      "integrity": "sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.35",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.35.tgz",
+      "integrity": "sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.35",
+        "@vue/shared": "3.5.35"
+      }
+    },
+    "node_modules/@vue/compiler-vue2": {
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
+      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.0.tgz",
+      "integrity": "sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "~2.4.11",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/compiler-vue2": "^2.7.16",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^0.4.9",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/language-core/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.35.tgz",
+      "integrity": "sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/alien-signals": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.4.14.tgz",
+      "integrity": "sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-dts": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz",
+      "integrity": "sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/api-extractor": "^7.50.1",
+        "@rollup/pluginutils": "^5.1.4",
+        "@volar/typescript": "^2.4.11",
+        "@vue/language-core": "2.2.0",
+        "compare-versions": "^6.1.1",
+        "debug": "^4.4.0",
+        "kolorist": "^1.8.0",
+        "local-pkg": "^1.0.0",
+        "magic-string": "^0.30.17"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/components/jsonrpc/clients/typescript/package.json
+++ b/components/jsonrpc/clients/typescript/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@sen/client",
+  "version": "0.0.0",
+  "description": "TypeScript client for the Sen JSON-RPC over WebSocket gateway.",
+  "license": "Apache-2.0",
+  "author": "Airbus",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/airbus/sen.git",
+    "directory": "components/jsonrpc/clients/typescript"
+  },
+  "homepage": "https://airbus.github.io/sen/latest/",
+  "type": "module",
+  "private": true,
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./react": {
+      "types": "./dist/react/index.d.ts",
+      "import": "./dist/react/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "prepack": "vite build",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "react": { "optional": true }
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "@types/react": "^19.0.0",
+    "react": "^19.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.3.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/components/jsonrpc/clients/typescript/src/client.ts
+++ b/components/jsonrpc/clients/typescript/src/client.ts
@@ -1,0 +1,403 @@
+// === client.ts =======================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import type { ReportError } from "./connect.js";
+import type { CustomTypeSpec, SessionInfo } from "./generated/index.js";
+import { InterestHandle, type InterestDeclaration, type PreSubscription } from "./handles.js";
+import type { JsonRpcClient } from "./internal/protocol_client.js";
+import { normalizeError } from "./internal/report_error.js";
+import { toWireSubscribeBlock } from "./internal/subscribe_codec.js";
+import type { Transport } from "./internal/transport.js";
+import type { TypeCache } from "./internal/type_cache.js";
+import type { CancelFn } from "./values.js";
+
+export type { SessionInfo };
+
+/** Connection lifecycle states reported by {@link Client.connectionState} and {@link Client.onConnectionStateChange}. */
+export type ConnectionState = "connecting" | "open" | "reconnecting" | "closed";
+
+/** Client returned by `connect()`. Declare interests through it; per-object ops live on `ObjectHandle`. */
+export class Client {
+  private readonly cancelInterestUpdateListener: CancelFn;
+  private readonly cancelPropertyChangedListener: CancelFn;
+  private readonly cancelEventTriggeredListener: CancelFn;
+  private readonly cancelTopologyChangedListener: CancelFn;
+  private readonly interestHandles = new Map<string, InterestHandle>();
+  private readonly declareChains = new Map<string, Promise<void>>();
+  private readonly topologyHandlers = new Set<(sessions: SessionInfo[]) => void>();
+  private topologySubscribed = false;
+  private lastTopology: SessionInfo[] = [];
+  private hasTopology = false;
+  private reestablishRun: Promise<void> | null = null;
+  private reestablishQueued = false;
+  /** Bumped on every reconnect; lets reestablishAll tell "queued during a pass on this same
+   *  connection" (already satisfied) from "queued because the connection changed mid-pass". */
+  private connectionEpoch = 0;
+
+  /** @internal */
+  constructor(
+    private readonly transport: Transport,
+    private readonly protocol: JsonRpcClient,
+    private readonly typeCache: TypeCache,
+    private readonly reportError: ReportError,
+  ) {
+    this.cancelInterestUpdateListener = this.protocol.onInterestUpdate((params) => {
+      if (params.types.length > 0) this.typeCache.setMany(params.types);
+      if (params.typeSchemas.length > 0) this.typeCache.setSchemasFromBlob(params.typeSchemas);
+      this.interestHandles.get(params.interestName)?.applyUpdate(params);
+    });
+    this.cancelPropertyChangedListener = this.protocol.onPropertyChanged((params) => {
+      this.interestHandles.get(params.interestName)?.dispatchPropertyChanged(params);
+    });
+    this.cancelEventTriggeredListener = this.protocol.onEventTriggered((params) => {
+      this.interestHandles.get(params.interestName)?.dispatchEventTriggered(params);
+    });
+    this.cancelTopologyChangedListener = this.protocol.onTopologyChanged((params) => {
+      this.lastTopology = params.sessions;
+      this.hasTopology = true;
+      for (const handler of this.topologyHandlers) handler(params.sessions);
+    });
+    this.transport.onReconnect(() => {
+      this.connectionEpoch += 1;
+    });
+  }
+
+  /**
+   * Declare an interest: a live query against the Sen object graph. The returned
+   * {@link InterestHandle} starts out empty; matched objects arrive shortly after, either in
+   * an immediate server-side push or in a subsequent `interestUpdate` notification (the wire
+   * does not guarantee an order between the `createInterest` response and the initial push).
+   * Register {@link InterestHandle.onObjectAdded} to handle them either way; it replays for
+   * current matches and streams later arrivals. `name` must be unique for this connection.
+   *
+   * @example
+   * ```ts
+   * const interest = await client.declareInterest({
+   *   name: "cats",
+   *   query: "SELECT animals.Cat FROM my.tutorial",
+   *   subscribe: { properties: "*" },  // optional pre-subscription
+   * });
+   * interest.onObjectAdded((cat) => console.log(cat.name));
+   * // ... later
+   * await interest.release();
+   * ```
+   */
+  async declareInterest(params: {
+    name: string;
+    query: string;
+    subscribe?: PreSubscription;
+    /** Opt into JSON-Schema shipping: every interestUpdate for this interest's lifetime carries
+     *  schema fragments for previously-unseen types in `params.typeSchemas`. Per-connection
+     *  dedup applies. */
+    withSchemas?: boolean;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  }): Promise<InterestHandle> {
+    const previous = this.declareChains.get(params.name);
+    // Wait for any prior declare/release cycle for this name to fully settle before issuing
+    // the next wire createInterest. `previous` is undefined for the first declare of a name,
+    // or after the prior cycle has been cleared from the map.
+    const chain: Promise<InterestHandle> = (async () => {
+      if (previous !== undefined) {
+        try {
+          await previous;
+        } catch {
+          // A prior cycle's failure doesn't block subsequent declares; the handle that
+          // failed is already torn down and the name is free for a fresh try.
+        }
+      }
+      return this.declareInterestImpl(params);
+    })();
+    // Track the FULL lifecycle (declare → use → release) so the next declare for the same
+    // name waits on it. A rejected declare unblocks immediately (no handle to release).
+    const cycle: Promise<void> = chain.then(
+      (h) => h.settled,
+      () => undefined,
+    );
+    this.declareChains.set(params.name, cycle);
+    void cycle.then(() => {
+      // Clear the map entry once the cycle settles, so names that come and go don't pile up.
+      // Guard against clobbering a newer chain that was installed during this cycle.
+      if (this.declareChains.get(params.name) === cycle) {
+        this.declareChains.delete(params.name);
+      }
+    });
+    return chain;
+  }
+
+  private async declareInterestImpl(params: {
+    name: string;
+    query: string;
+    subscribe?: PreSubscription;
+    withSchemas?: boolean;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  }): Promise<InterestHandle> {
+    const wireSubscribe = toWireSubscribeBlock(params.subscribe);
+    const declaration: InterestDeclaration = { query: params.query };
+    if (wireSubscribe !== null) declaration.subscribe = wireSubscribe;
+    if (params.withSchemas === true) declaration.withSchemas = true;
+    const handle = new InterestHandle(
+      params.name,
+      declaration,
+      this.protocol,
+      this.typeCache,
+      (interestName) => this.interestHandles.delete(interestName),
+      this.reportError,
+    );
+    // Register before the wire call: the server may push the initial match-set immediately.
+    this.interestHandles.set(params.name, handle);
+    try {
+      const call: Parameters<JsonRpcClient["createInterest"]>[0] = {
+        interestName: params.name,
+        query: params.query,
+      };
+      if (wireSubscribe !== null) call.subscribe = wireSubscribe;
+      if (params.withSchemas === true) call.withSchemas = true;
+      if (params.timeoutMs !== undefined) call.timeoutMs = params.timeoutMs;
+      if (params.signal !== undefined) call.signal = params.signal;
+      await this.protocol.createInterest(call);
+      handle.markActive();
+      handle.noteReestablished(this.connectionEpoch);
+    } catch (err) {
+      handle.markRejected(normalizeError(err));
+      throw err;
+    }
+    return handle;
+  }
+
+  /** Current wire state. */
+  get connectionState(): ConnectionState {
+    return this.transport.connectionState;
+  }
+
+  /**
+   * Read a `CustomTypeSpec` from the local cache, or `undefined` if not yet known. Types
+   * arrive bundled on `interestUpdate` notifications when a class is first matched, so this
+   * is typically populated by the time a consumer of an object asks for the class spec.
+   * Synchronous; never round-trips.
+   */
+  getType(qualifiedName: string): CustomTypeSpec | undefined {
+    return this.typeCache.get(qualifiedName);
+  }
+
+  /**
+   * JSON-Schema fragment for a qualified type name from the local cache, or `undefined`
+   * when the wire didn't ship one. Schemas arrive bundled on `interestUpdate.typeSchemas`
+   * for interests opened with `withSchemas: true`, or via `fetchType(qual, { withSchema: true })`.
+   * Synchronous; never round-trips.
+   */
+  getSchema(qualifiedName: string): object | undefined {
+    return this.typeCache.getSchema(qualifiedName);
+  }
+
+  /**
+   * Fetch a `CustomTypeSpec` (and optionally its JSON-Schema fragment) over the wire and
+   * populate the local cache. Prefer the synchronous {@link getType} when the type is expected
+   * to be cached already; this method is for cold lookups (no interest yet matched the class).
+   *
+   * With `withSchema: true`, the returned `schema` is the parsed JSON-Schema fragment, also
+   * stored in the local cache so subsequent `getSchema(qual)` calls resolve synchronously.
+   * Without it, `schema` is `undefined`.
+   */
+  async fetchType(
+    qualifiedName: string,
+    opts: { withSchema?: boolean; timeoutMs?: number; signal?: AbortSignal } = {},
+  ): Promise<{ spec: CustomTypeSpec; schema?: object }> {
+    const call: Parameters<JsonRpcClient["getType"]>[0] = { qualifiedName };
+    if (opts.withSchema === true) call.withSchema = true;
+    if (opts.timeoutMs !== undefined) call.timeoutMs = opts.timeoutMs;
+    if (opts.signal !== undefined) call.signal = opts.signal;
+    const result = await this.protocol.getType(call);
+    this.typeCache.set(result.spec);
+    const out: { spec: CustomTypeSpec; schema?: object } = { spec: result.spec };
+    if (result.schema.length > 0) {
+      const parsed = JSON.parse(result.schema) as object;
+      this.typeCache.setSchema(qualifiedName, parsed);
+      out.schema = parsed;
+    }
+    return out;
+  }
+
+  /** Currently-cached `CustomTypeSpec`s. Synchronous snapshot; never round-trips. */
+  listKnownTypes(): CustomTypeSpec[] {
+    return this.typeCache.values();
+  }
+
+  /** Fetch every qualified type name registered on the server, over the wire. Useful for cold
+   *  type-browser surfaces; pair with {@link fetchType} to pull individual specs on demand. */
+  async fetchTypeNames(opts: { timeoutMs?: number; signal?: AbortSignal } = {}): Promise<string[]> {
+    return await this.protocol.getTypes(opts);
+  }
+
+  /**
+   * Subscribe to type-cache growth. Fires once per `interestUpdate` batch that contained at
+   * least one previously-unseen type. Useful for consumers (e.g., a UI hook that walked a
+   * class inheritance chain and hit a missing parent) that need to retry their walk when the
+   * cache may have learned new names. Returns a cancel function.
+   *
+   * Purely TS-side: the notification is fired from inside the wire-delivery handler after
+   * the cache mutation completes; no wire-level event is involved.
+   */
+  onTypeAdded(handler: () => void): CancelFn {
+    return this.typeCache.subscribe(handler);
+  }
+
+  /**
+   * One-shot snapshot of the currently-detected sessions and their buses. Use
+   * {@link onTopologyChanged} for a live view.
+   */
+  async listTopology(opts: { timeoutMs?: number; signal?: AbortSignal } = {}): Promise<SessionInfo[]> {
+    return await this.protocol.listTopology(opts);
+  }
+
+  /**
+   * Subscribe to topology updates. The handler is invoked with the current full snapshot once
+   * a snapshot is available, then again on every session/bus add/remove. Multi-consumer: the
+   * first call sends the underlying `subscribeTopology`; later calls share the same wire
+   * subscription and the cached snapshot is replayed to new consumers immediately.
+   *
+   * The wire subscription stays open for the lifetime of the connection; there is no
+   * `unsubscribe` half. Topology pushes are tiny and infrequent, and a permanent subscription
+   * sidesteps the subscribe / unsubscribe / subscribe race that would otherwise need
+   * serialization.
+   *
+   * @example
+   * ```ts
+   * const cancel = client.onTopologyChanged((sessions) => {
+   *   for (const s of sessions) console.log(s.name, s.buses);
+   * });
+   * // ... later
+   * cancel();
+   * ```
+   */
+  onTopologyChanged(
+    handler: (sessions: SessionInfo[]) => void,
+    opts: { signal?: AbortSignal } = {},
+  ): CancelFn {
+    this.topologyHandlers.add(handler);
+    if (!this.topologySubscribed) {
+      this.topologySubscribed = true;
+      this.protocol.subscribeTopology().catch((err) => this.reportError(normalizeError(err)));
+    } else if (this.hasTopology) {
+      handler(this.lastTopology);
+    }
+    const cancel = (): void => {
+      this.topologyHandlers.delete(handler);
+    };
+    opts.signal?.addEventListener("abort", cancel, { once: true });
+    return cancel;
+  }
+
+  /** Close the connection. The client cannot be reused afterward. */
+  close(): void {
+    this.cancelInterestUpdateListener();
+    this.cancelPropertyChangedListener();
+    this.cancelEventTriggeredListener();
+    this.cancelTopologyChangedListener();
+    this.topologyHandlers.clear();
+    this.interestHandles.clear();
+    this.typeCache.clearListeners();
+    this.transport.close();
+  }
+
+  /**
+   * Notified when the connection drops unexpectedly (not via `close()`). Interests and
+   * subscriptions are invalidated; while `reconnect.autoReestablish` is on (the default)
+   * they re-declare automatically after the reconnect — wire these handlers for UI state or
+   * custom recovery work, not to call {@link reestablishAll} again.
+   *
+   * @example
+   * ```ts
+   * client.onDisconnect(() => console.warn("offline"));
+   * client.onReconnect(() => console.info("back online"));
+   * ```
+   */
+  onDisconnect(handler: () => void): CancelFn {
+    return this.transport.onDisconnect(handler);
+  }
+
+  /** Notified after a successful reconnect. */
+  onReconnect(handler: () => void): CancelFn {
+    return this.transport.onReconnect(handler);
+  }
+
+  /**
+   * Notified on every connection-state transition with the new state. Convenient for a single
+   * UI indicator that reacts to all transitions; for one-off reconnect work see
+   * {@link onReconnect}. Does not replay the current state on register: read
+   * {@link connectionState} once if you need the starting value.
+   *
+   * @example
+   * ```ts
+   * client.onConnectionStateChange((state) => {
+   *   statusEl.textContent = state;
+   * });
+   * ```
+   */
+  onConnectionStateChange(handler: (state: ConnectionState) => void): CancelFn {
+    return this.transport.onConnectionStateChange(handler);
+  }
+
+  /**
+   * Re-declare every declared interest, in parallel. Subscriptions resume automatically once
+   * interests become active again. Best-effort: per-interest failures surface through
+   * `onError` but don't reject the promise. Typically called from an `onReconnect` handler
+   * (which is wired automatically when `reconnect.autoReestablish` is on, the default).
+   *
+   * Resolves once `createInterest` completes; per-property re-subscribes are then fired
+   * asynchronously from the next `interestUpdate`. Callers needing subscriptions provably
+   * live should await the next `propertyChanged` or round-trip via `getProperty`.
+   *
+   * No-op (resolves immediately) when the transport isn't currently `open`. This avoids a
+   * spurious wave of `TransportError` reports when called during reconnect; the auto-wiring
+   * fires again on the eventual `onReconnect` and does the real work then.
+   *
+   * Single-flight: overlapping calls (the `autoReestablish` wiring racing a manual call, or
+   * two reconnects in quick succession) coalesce into the run already in progress, plus at
+   * most one trailing rerun when the connection changed mid-pass or a re-declare failed.
+   * Interleaved runs used to double-issue `createInterest` for the same names; the loser's
+   * "interest already exists" rejection then left its handle cleared and permanently empty.
+   */
+  async reestablishAll(): Promise<void> {
+    if (this.reestablishRun) {
+      this.reestablishQueued = true;
+      return this.reestablishRun;
+    }
+    this.reestablishRun = (async () => {
+      do {
+        this.reestablishQueued = false;
+        if (this.transport.connectionState !== "open") return;
+        const epochAtStart = this.connectionEpoch;
+        // Don't clear the typeCache: the server re-bundles each interest's `types` on the next
+        // interestUpdate, and clearing first opens a window where parseVar throws for still-active
+        // interests' property pushes.
+        const results = await Promise.allSettled(
+          Array.from(this.interestHandles.values()).map((h) => h.reestablish(epochAtStart)),
+        );
+        let anyRejected = false;
+        for (const result of results) {
+          if (result.status === "rejected") {
+            anyRejected = true;
+            this.reportError(normalizeError(result.reason));
+          }
+        }
+        // A rerun queued while this pass ran on the same, still-healthy connection is already
+        // satisfied by the pass itself; rerunning would re-issue createInterest into
+        // "interest already exists".
+        if (this.reestablishQueued && this.connectionEpoch === epochAtStart && !anyRejected) {
+          this.reestablishQueued = false;
+        }
+      } while (this.reestablishQueued);
+    })();
+    try {
+      await this.reestablishRun;
+    } finally {
+      this.reestablishRun = null;
+    }
+  }
+}

--- a/components/jsonrpc/clients/typescript/src/connect.ts
+++ b/components/jsonrpc/clients/typescript/src/connect.ts
@@ -1,0 +1,124 @@
+// === connect.ts ======================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { Client } from "./client.js";
+import { TransportError } from "./errors.js";
+import { JsonRpcClient } from "./internal/protocol_client.js";
+import { defaultReportError } from "./internal/report_error.js";
+import { Transport, type WebSocketFactory } from "./internal/transport.js";
+import { TypeCache } from "./internal/type_cache.js";
+
+const defaultOpenTimeoutMs = 2_000;
+
+/** Receives errors the library catches in background handlers; passed via {@link ClientOptions.onError}. */
+export type ReportError = (err: Error) => void;
+
+/**
+ * Auto-reconnect tuning for {@link ClientOptions.reconnect}. Defaults: `enabled: true`,
+ * `initialDelayMs: 100`, `maxDelayMs: 5000`, `factor: 2` (exponential backoff capped at
+ * `maxDelayMs`), `autoReestablish: true` (run `client.reestablishAll()` automatically after
+ * each successful reconnect).
+ */
+export interface ReconnectOptions {
+  enabled?: boolean;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  factor?: number;
+  /** Re-issue every active `declareInterest` (which re-arms its property/event subscriptions)
+   *  after each successful reconnect. Default `true`. Set `false` for custom recovery; the
+   *  client still fires `onReconnect` so consumers can do their own work. */
+  autoReestablish?: boolean;
+}
+
+export interface ClientOptions {
+  /** WebSocket URL (e.g. `ws://localhost:8080`). */
+  url: string;
+
+  /** Per-call timeout default. */
+  defaultTimeoutMs?: number;
+
+  /** Time to wait for the first connection before giving up. Defaults to 2 seconds. With
+   *  `initialReconnect: true`, this is the total deadline across all retries (not per try). */
+  openTimeoutMs?: number;
+
+  /** When `true`, retry the initial connect using the same backoff schedule as
+   *  {@link ReconnectOptions} until `openTimeoutMs` elapses. Default `false` (the initial
+   *  connect is one-shot). Set `true` for UIs that should start and wait for Sen to come
+   *  up; leave default for short-lived scripts where one-shot semantics are clearer. */
+  initialReconnect?: boolean;
+
+  /** Auto-reconnect behavior; see {@link ReconnectOptions} for fields and defaults. */
+  reconnect?: ReconnectOptions;
+
+  /** Receives errors the library catches in background handlers. Defaults to `console.error`. */
+  onError?: ReportError;
+
+  /** @internal */
+  webSocketFactory?: WebSocketFactory;
+}
+
+/**
+ * Connect to a Sen JSON-RPC gateway. Resolves once the WebSocket is open and ready for calls.
+ * The returned `Client` owns the connection; close it with `client.close()` when done.
+ *
+ * @example
+ * ```ts
+ * const client = await connect({ url: "ws://127.0.0.1:8080" });
+ * try {
+ *   const interest = await client.declareInterest({ name: "all", query: "SELECT * FROM bus" });
+ *   // ...
+ *   await interest.release();
+ * } finally {
+ *   client.close();
+ * }
+ * ```
+ */
+export async function connect(options: ClientOptions): Promise<Client> {
+  const reportError = options.onError ?? defaultReportError;
+  const transportOpts: ConstructorParameters<typeof Transport>[0] = {
+    url: options.url,
+    reportError,
+  };
+  if (options.defaultTimeoutMs !== undefined) transportOpts.defaultTimeoutMs = options.defaultTimeoutMs;
+  if (options.reconnect !== undefined) transportOpts.reconnect = options.reconnect;
+  if (options.webSocketFactory !== undefined) transportOpts.webSocketFactory = options.webSocketFactory;
+  if (options.initialReconnect === true) transportOpts.retryInitialOpen = true;
+  const transport = new Transport(transportOpts);
+
+  const openTimeoutMs = options.openTimeoutMs ?? defaultOpenTimeoutMs;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(new TransportError(`connect timed out after ${openTimeoutMs}ms (${options.url})`));
+    }, openTimeoutMs);
+  });
+
+  try {
+    await Promise.race([transport.whenOpen(), timeoutPromise]);
+  } catch (err) {
+    transport.close();
+    throw err;
+  } finally {
+    if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+  }
+
+  const protocol = new JsonRpcClient(transport, reportError);
+  const typeCache = new TypeCache(reportError);
+  const client = new Client(transport, protocol, typeCache, reportError);
+
+  const reconnectEnabled = options.reconnect?.enabled ?? true;
+  const autoReestablish = options.reconnect?.autoReestablish ?? true;
+  if (reconnectEnabled && autoReestablish) {
+    client.onReconnect(() => {
+      client.reestablishAll().catch((err: unknown) => {
+        reportError(err instanceof Error ? err : new Error(String(err)));
+      });
+    });
+  }
+
+  return client;
+}

--- a/components/jsonrpc/clients/typescript/src/errors.ts
+++ b/components/jsonrpc/clients/typescript/src/errors.ts
@@ -1,0 +1,84 @@
+// === errors.ts =======================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+/**
+ * Wire error codes the Sen server emits. Use these to switch on `JsonRpcError.code` rather
+ * than hard-coding magic numbers. The first block is the JSON-RPC 2.0 reserved range; the
+ * second block is Sen application codes in the spec's "Server error" -32000..-32099 range,
+ * used when the envelope and params are well-formed but the request semantically fails.
+ */
+export const JsonRpcErrorCode = {
+  parseError: -32700,
+  invalidRequest: -32600,
+  methodNotFound: -32601,
+  invalidParams: -32602,
+  internalError: -32603,
+
+  unknownInterest: -32001,
+  objectNotInInterest: -32002,
+  unknownMember: -32003,
+  unknownType: -32004,
+  notWritable: -32005,
+} as const;
+
+export type JsonRpcErrorCode = (typeof JsonRpcErrorCode)[keyof typeof JsonRpcErrorCode];
+
+/** Base class for all errors thrown by this library. */
+export class SenClientError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = new.target.name;
+  }
+}
+
+/**
+ * The server returned a JSON-RPC error. `code` follows the JSON-RPC 2.0 reserved ranges plus
+ * any application codes the Sen server defines.
+ */
+export class JsonRpcError extends SenClientError {
+  constructor(
+    public readonly code: number,
+    message: string,
+    public readonly data?: unknown,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+  }
+}
+
+/** Connection-level failure: lost connection, malformed frame, call while not connected. */
+export class TransportError extends SenClientError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+  }
+}
+
+/** No response within the per-call timeout. `timeoutMs` is the elapsed deadline. */
+export class TimeoutError extends SenClientError {
+  constructor(
+    message: string,
+    public readonly timeoutMs: number,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+  }
+}
+
+/**
+ * Thrown when an `InterestHandle` method is called after `release()` (or after the initial
+ * `declareInterest` was rejected). Cleanup paths that race release can catch this and
+ * ignore it.
+ */
+export class InterestReleasedError extends SenClientError {
+  constructor(
+    public readonly interestName: string,
+    operation: string,
+    options?: ErrorOptions,
+  ) {
+    super(`Interest "${interestName}" is released; ${operation} is no longer valid`, options);
+  }
+}

--- a/components/jsonrpc/clients/typescript/src/handles.ts
+++ b/components/jsonrpc/clients/typescript/src/handles.ts
@@ -1,0 +1,809 @@
+// === handles.ts ======================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import type { ReportError } from "./connect.js";
+import { InterestReleasedError, TransportError } from "./errors.js";
+import {
+  findMethodInClass,
+  findPropertyInClass,
+  getClassSpec,
+} from "./internal/class_spec_lookup.js";
+import { makeIdempotent } from "./internal/cancel.js";
+import { encodeVar, encodeVarToWire, parseVar } from "./internal/var_codec.js";
+import type { JsonRpcClient } from "./internal/protocol_client.js";
+import { normalizeError } from "./internal/report_error.js";
+import { ObjectSubscriptions } from "./internal/subscription_registry.js";
+import type { TypeCache } from "./internal/type_cache.js";
+import type {
+  EventTriggeredNotification,
+  InterestUpdateNotification,
+  MaybeSubscribeBlock,
+  PropertyChangedNotification,
+} from "./generated/index.js";
+import type { CancelFn, Var } from "./values.js";
+
+/** Per-call overrides. `timeoutMs` overrides `ClientOptions.defaultTimeoutMs`. */
+export interface CallOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+/** Like {@link CallOptions}; `fresh: true` forces a server round-trip instead of returning a cached value. */
+export interface GetOptions extends CallOptions {
+  fresh?: boolean;
+}
+
+/** Receives a property's current value on subscribe and on every change. */
+export type PropertyChangedHandler = (value: Var, info: DeliveryInfo) => void;
+
+/**
+ * Per-delivery metadata that came with a server push (event or property change). Same shape
+ * for both because Sen routes property changes through its event mechanism on the kernel
+ * side and surfaces only the timestamp.
+ */
+export interface DeliveryInfo {
+  /** Server-side emission time. For events: kernel `EventInfo.creationTime`. For property
+   *  changes: the object's `getLastCommitTime()` at bundling. Wire string format
+   *  `"YYYY-MM-DDTHH:MM:SS.nnnnnnnnnZ"` (RFC-3339, UTC, nanosecond precision). Pass
+   *  through {@link parseSenTimestamp} for a `Date` + nanosecond remainder. */
+  timestamp: string;
+}
+
+/** Receives an event's positional arguments each time it fires. */
+export type EventTriggeredHandler = (args: Var[], info: DeliveryInfo) => void;
+
+/**
+ * Parse a Sen wire timestamp (RFC-3339, UTC, nanosecond precision:
+ * `"YYYY-MM-DDTHH:MM:SS.nnnnnnnnnZ"`) into a `Date` (ms precision) and a `nanoseconds`
+ * remainder (the sub-millisecond portion, 0..999999). Returns `null` when the input
+ * doesn't match the exact shape.
+ */
+export function parseSenTimestamp(s: string): { date: Date; nanoseconds: number } | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.(\d{9})Z$/.exec(s.trim());
+  if (!m) return null;
+  const [, yr, mo, dy, hr, mi, sc, ns] = m;
+  const nanos = parseInt(ns!, 10);
+  const millis = Math.floor(nanos / 1_000_000);
+  const remainder = nanos % 1_000_000;
+  const date = new Date(
+    Date.UTC(
+      parseInt(yr!, 10),
+      parseInt(mo!, 10) - 1,
+      parseInt(dy!, 10),
+      parseInt(hr!, 10),
+      parseInt(mi!, 10),
+      parseInt(sc!, 10),
+      millis,
+    ),
+  );
+  return { date, nanoseconds: remainder };
+}
+
+/** Receives one bundle of (property name -> value) per change tick on an object. */
+export type AnyChangeHandler = (changes: Map<string, Var>, info: DeliveryInfo) => void;
+
+function lookupPropertyTypeOn(className: string, propertyName: string, typeCache: TypeCache): string {
+  const classSpec = getClassSpec(className, typeCache);
+  const property = findPropertyInClass(classSpec, propertyName, typeCache);
+  if (!property) {
+    throw new TransportError(`property "${propertyName}" not found on class "${className}"`);
+  }
+  return property.type;
+}
+
+/** Per-object snapshot returned by {@link InterestHandle.getObjectsBatchState}. */
+export interface ObjectBatchState {
+  /** Object name within the interest's match set. */
+  name: string;
+  /** Package-qualified class name at read time. */
+  className: string;
+  /** Successfully read property values, keyed by property name. */
+  properties: Record<string, Var>;
+  /** Per-property read errors, keyed by property name. Empty when nothing failed. */
+  errors: Record<string, string>;
+}
+
+/** Options for {@link InterestHandle.getObjectsBatchState}. */
+export interface GetObjectsBatchStateOptions extends CallOptions {
+  /** Subset of object names to read; omit to read every matched object. */
+  objectNames?: string[];
+  /** Subset of property names to read; omit to read every property of each object. */
+  propertyNames?: string[];
+}
+
+/** Options for the `on*` subscribe-shaped APIs on {@link ObjectHandle}. */
+export interface SubscribeOptions {
+  /** AbortSignal alternative to the returned `CancelFn`. Cancels the subscription when fired. */
+  signal?: AbortSignal;
+}
+
+/** Handle to one object in an interest's match set. */
+export class ObjectHandle {
+  /** @internal */
+  constructor(
+    public readonly name: string,
+    public readonly className: string,
+    private readonly interestName: string,
+    private readonly protocol: JsonRpcClient,
+    private readonly typeCache: TypeCache,
+    private readonly subscriptions: ObjectSubscriptions,
+  ) {}
+
+  /**
+   * Subscribe to a property's value changes. The handler fires whenever the server pushes a
+   * value for the property; the first delivery typically arrives shortly after the wire
+   * subscribe completes, and subsequent deliveries on every change. Returns a cancel function;
+   * pass `{ signal }` for `AbortSignal` cancellation. To read the currently-cached value
+   * without waiting, call `obj.get(name)`.
+   *
+   * @example
+   * ```ts
+   * const cancel = cat.onPropertyChanged("position", (pos) => console.log(pos));
+   * // later: cancel();
+   * ```
+   */
+  onPropertyChanged(
+    name: string,
+    handler: PropertyChangedHandler,
+    opts: SubscribeOptions = {},
+  ): CancelFn {
+    return this.subscriptions.onPropertyChanged(name, handler, opts);
+  }
+
+  /**
+   * Subscribe to an event. The handler receives the event's positional arguments.
+   *
+   * @example
+   * ```ts
+   * cat.onEventTriggered("madeSound", ([content]) => console.log("said:", content));
+   * ```
+   */
+  onEventTriggered(
+    name: string,
+    handler: EventTriggeredHandler,
+    opts: SubscribeOptions = {},
+  ): CancelFn {
+    return this.subscriptions.onEventTriggered(name, handler, opts);
+  }
+
+  /** Resolves once the server has acknowledged the active wire subscribe for `name`.
+   *  Use immediately after onEventTriggered when you need to be sure the subscribe is in
+   *  place before you trigger the event (e.g., subscribe-then-invokeMethod). No-op if no
+   *  one is currently subscribed. */
+  awaitEventSubscribed(name: string): Promise<void> {
+    return this.subscriptions.awaitEventSubscribed(name);
+  }
+
+  /** Symmetric partner to {@link awaitEventSubscribed} for properties. Rejects with the
+   *  server error when the property name is unknown or the subscribe call otherwise fails;
+   *  call this when you need that signal beyond the `onError` side-channel. No-op if no one
+   *  is currently subscribed. */
+  awaitPropertySubscribed(name: string): Promise<void> {
+    return this.subscriptions.awaitPropertySubscribed(name);
+  }
+
+  /** Subscribe to all of this object's property changes at once, delivered as one `Map` per update. */
+  onAnyChange(handler: AnyChangeHandler, opts: SubscribeOptions = {}): CancelFn {
+    return this.subscriptions.onAnyChange(handler, opts);
+  }
+
+  /** Cap how often this object's properties may push updates. Pass `null` to clear the cap. */
+  async setMaxRateHz(hz: number | null): Promise<void> {
+    await this.subscriptions.setMaxRateHz(hz);
+  }
+
+  /**
+   * Read a property's current value. Returns from the local cache when an active subscription
+   * is keeping it fresh; pass `{ fresh: true }` to force a server round-trip.
+   *
+   * @example
+   * ```ts
+   * const pos = await cat.get("position");
+   * ```
+   */
+  async get(name: string, opts: GetOptions = {}): Promise<Var> {
+    if (!opts.fresh) {
+      const cached = this.subscriptions.getCachedValue(name);
+      if (cached !== undefined) return cached;
+    }
+    const propType = this.lookupPropertyType(name);
+    const encoded = await this.protocol.getProperty({
+      interestName: this.interestName,
+      objectName: this.name,
+      propertyName: name,
+      ...this.callOpts(opts),
+    });
+    const value = parseVar(propType, JSON.parse(encoded), this.typeCache);
+    this.subscriptions.setCachedValue(name, value);
+    return value;
+  }
+
+  /**
+   * Write a property's value. Throws {@link JsonRpcError} if the property is not declared
+   * `[writable]` in its STL.
+   *
+   * @example
+   * ```ts
+   * await shape.set("frozen", true);
+   * ```
+   */
+  async set(name: string, value: unknown, opts: CallOptions = {}): Promise<void> {
+    this.subscriptions.invalidateCachedValue(name);
+    const propType = this.lookupPropertyType(name);
+    const encoded = encodeVarToWire(propType, value, this.typeCache);
+    await this.protocol.setProperty({
+      interestName: this.interestName,
+      objectName: this.name,
+      propertyName: name,
+      value: encoded,
+      ...this.callOpts(opts),
+    });
+  }
+
+  /**
+   * Call a method with named arguments. Argument names are validated locally against the
+   * method's declared signature before the call goes on the wire, so a typo throws immediately.
+   * For optional parameters, pass `null` explicitly to mean "absent". Returns the method's
+   * result, or `null` for void methods.
+   *
+   * @example
+   * ```ts
+   * await cat.invoke("jumpToLocation", { x: 42, y: 17 });
+   * const reply = await person.invoke("ask", { question: "what time is it?" });
+   * ```
+   */
+  async invoke(
+    method: string,
+    args: Record<string, unknown> = {},
+    opts: CallOptions = {},
+  ): Promise<Var> {
+    const classSpec = getClassSpec(this.className, this.typeCache);
+    const methodSpec = findMethodInClass(classSpec, method, this.typeCache);
+    if (!methodSpec) {
+      throw new TransportError(`method "${method}" not found on class "${this.className}"`);
+    }
+    const declaredNames = new Set(methodSpec.args.map((a) => a.name));
+    for (const passedName of Object.keys(args)) {
+      if (!declaredNames.has(passedName)) {
+        throw new TransportError(
+          `method "${method}" has no parameter "${passedName}"; expected: [${methodSpec.args.map((a) => a.name).join(", ")}]`,
+        );
+      }
+    }
+    const encodedArgs = methodSpec.args.map((arg) => {
+      if (!(arg.name in args)) {
+        throw new TransportError(`method "${method}" requires parameter "${arg.name}"`);
+      }
+      return encodeVar(arg.type, args[arg.name], this.typeCache);
+    });
+    // User-defined methods have no upper bound on legitimate runtime: a Fibonacci computation,
+    // a long simulation step, a deferred external call. The client-side default of 2s here
+    // would surface false TimeoutErrors mid-call, so invoke defaults to "no client timeout"
+    // (transport.call honors timeoutMs <= 0 as "no timeout"). Connection loss still rejects
+    // pending invocations via Transport.failAllPending. Callers can opt back in by passing an
+    // explicit `timeoutMs` in CallOptions.
+    const effectiveOpts: CallOptions = { timeoutMs: 0, ...opts };
+    const encodedReturn = await this.protocol.invoke({
+      interestName: this.interestName,
+      objectName: this.name,
+      methodName: method,
+      argsJson: JSON.stringify(encodedArgs),
+      ...this.callOpts(effectiveOpts),
+    });
+    if (methodSpec.returnType === "" || methodSpec.returnType === "void") return null;
+    return parseVar(methodSpec.returnType, JSON.parse(encodedReturn), this.typeCache);
+  }
+
+  private lookupPropertyType(propertyName: string): string {
+    return lookupPropertyTypeOn(this.className, propertyName, this.typeCache);
+  }
+
+  private callOpts(opts: CallOptions): { timeoutMs?: number; signal?: AbortSignal } {
+    const out: { timeoutMs?: number; signal?: AbortSignal } = {};
+    if (opts.timeoutMs !== undefined) out.timeoutMs = opts.timeoutMs;
+    if (opts.signal !== undefined) out.signal = opts.signal;
+    return out;
+  }
+}
+
+export type ObjectAddedHandler = (obj: ObjectHandle) => void;
+export type ObjectRemovedHandler = (name: string) => void;
+
+/** @internal */
+export type InterestReleasedCallback = (interestName: string) => void;
+
+/**
+ * Pre-subscription bundled with `Client.declareInterest`. When set, matched objects arrive
+ * with their initial property values already populated, so the first `obj.get(name)` for a
+ * subscribed property returns from cache without a wire round-trip.
+ *
+ * @example
+ * ```ts
+ * await client.declareInterest({
+ *   name: "fleet",
+ *   query: "SELECT aircraft.Aircraft FROM ops",
+ *   subscribe: { properties: ["altitude", "speed"], maxRateHz: 10 },
+ * });
+ * ```
+ */
+export interface PreSubscription {
+  /** `"*"` for every property, an array for specific names. Omit to skip property subscription. */
+  properties?: "*" | string[];
+  /** `"*"` for every event, an array for specific names. Omit to skip event subscription. */
+  events?: "*" | string[];
+  /** Cap on push rate from the server for this interest's subscribed properties. Omit for no throttle. */
+  maxRateHz?: number;
+}
+
+/** @internal */
+export interface InterestDeclaration {
+  query: string;
+  subscribe?: MaybeSubscribeBlock;
+  withSchemas?: boolean;
+}
+
+/**
+ * Lifecycle of an {@link InterestHandle}: `pending` (createInterest in flight), `active`
+ * (server accepted; objects flowing), `releasing` (release in flight), `released` (terminal).
+ */
+export type InterestState = "pending" | "active" | "releasing" | "released";
+
+/**
+ * Handle to a declared interest: the live set of objects matching its query.
+ *
+ * After `release()` (or after the initial `declareInterest` was rejected), the synchronous
+ * read accessors (`objects`, `objectByName`, `state`) keep working but return empty/`released`;
+ * any method that would register a handler, start a wire call, or iterate (`onObjectAdded`,
+ * `onObjectRemoved`, `getObjectsBatchState`, `for await (... of handle)`) throws
+ * {@link InterestReleasedError}. Cleanup paths that race release can catch and ignore it.
+ * `release()` itself stays idempotent.
+ */
+export class InterestHandle {
+  private readonly objectsByName = new Map<string, ObjectHandle>();
+  private readonly subscriptionsByObject = new Map<string, ObjectSubscriptions>();
+  private readonly objectAddedHandlers = new Set<ObjectAddedHandler>();
+  private readonly objectRemovedHandlers = new Set<ObjectRemovedHandler>();
+  private readonly releaseWakers = new Set<() => void>();
+  private cachedObjects: ObjectHandle[] | null = null;
+  // Updates that arrive while the handle is still `pending` (server pushed the initial
+  // match-set before the createInterest response landed). Drained by markActive in arrival
+  // order; cleared by markRejected.
+  private pendingUpdates: InterestUpdateNotification[] = [];
+
+  private currentState: InterestState = "pending";
+  private readonly activeReady: Promise<void>;
+  private resolveActive!: () => void;
+  private rejectActive!: (err: Error) => void;
+  private readonly settledPromise: Promise<void>;
+  private resolveSettled!: () => void;
+
+  /** @internal */
+  constructor(
+    public readonly name: string,
+    private readonly declaration: InterestDeclaration,
+    private readonly protocol: JsonRpcClient,
+    private readonly typeCache: TypeCache,
+    private readonly onReleased: InterestReleasedCallback,
+    private readonly reportError: ReportError,
+  ) {
+    this.activeReady = new Promise<void>((res, rej) => {
+      this.resolveActive = res;
+      this.rejectActive = rej;
+    });
+    // Absorb unhandled-rejection signal; real awaiters still see it via replay.
+    this.activeReady.catch(() => undefined);
+    this.settledPromise = new Promise<void>((res) => {
+      this.resolveSettled = res;
+    });
+  }
+
+  /** @internal Resolves when the handle reaches the terminal `released` state (whether via
+   *  a successful release or a rejected initial declare). The `Client` uses this to chain the
+   *  next declare for the same name. */
+  get settled(): Promise<void> {
+    return this.settledPromise;
+  }
+
+  get state(): InterestState {
+    return this.currentState;
+  }
+
+  /**
+   * Currently-matched objects. Synchronous; reads from the local cache kept in sync by the
+   * server. The returned array reference is stable between membership changes; subsequent
+   * calls return the same array until an `interestUpdate` adds, removes, or the handle is
+   * released. Useful for consumers (React `useSyncExternalStore`, memoization, equality
+   * checks) that rely on reference identity to detect change.
+   *
+   * Treat the returned array as immutable; mutations leak into the cache.
+   */
+  objects(): ObjectHandle[] {
+    if (this.cachedObjects === null) {
+      this.cachedObjects = Array.from(this.objectsByName.values());
+    }
+    return this.cachedObjects;
+  }
+
+  /** Look up a matched object by its Sen name, or `undefined` if no such object is currently in the set. */
+  objectByName(name: string): ObjectHandle | undefined {
+    return this.objectsByName.get(name);
+  }
+
+  /**
+   * Read many objects' properties in a single round-trip. With no filter, returns one entry per
+   * object currently in the match set, each carrying every property of its class hierarchy.
+   * `objectNames` and `propertyNames` narrow the result. Property values are parsed via the
+   * type cache; per-property failures (unknown name, accessor throw) land in `errors` so a
+   * heterogeneous batch still returns useful partial results.
+   *
+   * Throws {@link InterestReleasedError} if the interest is `releasing`/`released`.
+   */
+  async getObjectsBatchState(opts: GetObjectsBatchStateOptions = {}): Promise<ObjectBatchState[]> {
+    this.assertAlive("getObjectsBatchState");
+    const wireOpts: Parameters<JsonRpcClient["getObjectsBatchState"]>[0] = {
+      interestName: this.name,
+      ...this.callOpts(opts),
+    };
+    if (opts.objectNames !== undefined) wireOpts.objectNames = opts.objectNames;
+    if (opts.propertyNames !== undefined) wireOpts.propertyNames = opts.propertyNames;
+    const states = await this.protocol.getObjectsBatchState(wireOpts);
+    return states.map((state) => {
+      const properties: Record<string, Var> = {};
+      const errors: Record<string, string> = {};
+      for (const { propertyName, error } of state.errors) {
+        errors[propertyName] = error;
+      }
+      for (const { propertyName, value: encoded } of state.properties) {
+        try {
+          const propType = lookupPropertyTypeOn(state.qualifiedClassName, propertyName, this.typeCache);
+          properties[propertyName] = parseVar(propType, JSON.parse(encoded), this.typeCache);
+        } catch (err) {
+          errors[propertyName] = err instanceof Error ? err.message : String(err);
+        }
+      }
+      return { name: state.objectName, className: state.qualifiedClassName, properties, errors };
+    });
+  }
+
+  private callOpts(opts: CallOptions): { timeoutMs?: number; signal?: AbortSignal } {
+    const out: { timeoutMs?: number; signal?: AbortSignal } = {};
+    if (opts.timeoutMs !== undefined) out.timeoutMs = opts.timeoutMs;
+    if (opts.signal !== undefined) out.signal = opts.signal;
+    return out;
+  }
+
+  /**
+   * Notified when an object enters the match set. The handler fires immediately for every
+   * object already matched and again for each later arrival. Mirrors the kernel-side
+   * `ObjectList::onAdded` semantics, so the canonical pattern is to declare an interest,
+   * register here, and let the handler drive the work.
+   *
+   * Throws {@link InterestReleasedError} if the interest is `releasing`/`released`.
+   *
+   * @example
+   * ```ts
+   * interest.onObjectAdded((obj) => {
+   *   console.log("got", obj.className, obj.name);
+   *   obj.onPropertyChanged("position", (p) => console.log(p));
+   * });
+   * ```
+   */
+  onObjectAdded(handler: ObjectAddedHandler): CancelFn {
+    this.assertAlive("onObjectAdded");
+    this.objectAddedHandlers.add(handler);
+    // Replay current matches synchronously so a handler registered after declareInterest()
+    // still sees objects that were in the initial server push.
+    for (const obj of this.objectsByName.values()) {
+      try {
+        handler(obj);
+      } catch (err) {
+        this.reportError(normalizeError(err));
+      }
+    }
+    return makeIdempotent(() => {
+      this.objectAddedHandlers.delete(handler);
+    });
+  }
+
+  /**
+   * Notified when an object leaves the match set. Throws {@link InterestReleasedError} if the
+   * interest is `releasing`/`released`.
+   */
+  onObjectRemoved(handler: ObjectRemovedHandler): CancelFn {
+    this.assertAlive("onObjectRemoved");
+    this.objectRemovedHandlers.add(handler);
+    return makeIdempotent(() => {
+      this.objectRemovedHandlers.delete(handler);
+    });
+  }
+
+  /** Release the interest. Idempotent. */
+  async release(): Promise<void> {
+    if (this.currentState === "released" || this.currentState === "releasing") return;
+    if (this.currentState === "pending") {
+      try {
+        await this.activeReady;
+      } catch {
+        return;
+      }
+    }
+    if (this.currentState !== "active") return;
+    this.currentState = "releasing";
+    this.objectsByName.clear();
+    this.cachedObjects = null;
+    this.subscriptionsByObject.clear();
+    this.objectAddedHandlers.clear();
+    this.objectRemovedHandlers.clear();
+    this.wakeReleaseWaiters();
+    this.onReleased(this.name);
+    try {
+      await this.protocol.releaseInterest({ interestName: this.name });
+    } finally {
+      this.currentState = "released";
+      this.resolveSettled();
+    }
+  }
+
+  /** @internal - Client calls this after a successful createInterest. */
+  markActive(): void {
+    if (this.currentState !== "pending") return;
+    this.currentState = "active";
+    this.resolveActive();
+    if (this.pendingUpdates.length > 0) {
+      const drained = this.pendingUpdates;
+      this.pendingUpdates = [];
+      for (const params of drained) this.applyUpdateActive(params);
+    }
+  }
+
+  /** @internal - Client calls this after a failed createInterest. */
+  markRejected(err: Error): void {
+    if (this.currentState !== "pending") return;
+    this.currentState = "released";
+    this.pendingUpdates.length = 0;
+    this.objectsByName.clear();
+    this.cachedObjects = null;
+    this.subscriptionsByObject.clear();
+    this.objectAddedHandlers.clear();
+    this.objectRemovedHandlers.clear();
+    this.rejectActive(err);
+    this.wakeReleaseWaiters();
+    this.onReleased(this.name);
+    this.resolveSettled();
+  }
+
+  /** @internal - Client routes interestUpdate notifications scoped to this.name here. */
+  applyUpdate(params: InterestUpdateNotification): void {
+    if (this.currentState === "releasing" || this.currentState === "released") return;
+    if (this.currentState === "pending") {
+      // Update arrived before createInterest's response; queue and drain on markActive so
+      // the consumer's onObjectAdded handlers (registered after the declare resolves) see
+      // the initial match-set. markRejected drops the queue.
+      this.pendingUpdates.push(params);
+      return;
+    }
+    this.applyUpdateActive(params);
+  }
+
+  private applyUpdateActive(params: InterestUpdateNotification): void {
+    for (const removedName of params.removed) {
+      if (this.objectsByName.delete(removedName)) {
+        this.cachedObjects = null;
+        this.fireRemoved(removedName);
+      }
+      // Subscriptions are sticky across remove/add; clear the value cache so a re-add
+      // doesn't surface stale values. Drop the entry only if no consumer is still attached
+      // (otherwise leaked across an object that never returns).
+      const subs = this.subscriptionsByObject.get(removedName);
+      if (subs) {
+        subs.clearValueCache();
+        if (!subs.hasAnySubscribers()) {
+          this.subscriptionsByObject.delete(removedName);
+        }
+      }
+    }
+    for (const entry of params.added) {
+      let subs = this.subscriptionsByObject.get(entry.objectName);
+      if (subs && subs.qualifiedClassName !== entry.qualifiedClassName) {
+        // Class changed under us; the cached ObjectSubscriptions would dispatch through
+        // the wrong class spec. Drop it and start fresh.
+        this.subscriptionsByObject.delete(entry.objectName);
+        subs = undefined;
+      }
+      if (subs) {
+        subs.invalidateWireState();
+      } else {
+        subs = new ObjectSubscriptions(
+          this.protocol,
+          this.typeCache,
+          this.name,
+          entry.objectName,
+          entry.qualifiedClassName,
+          this.reportError,
+        );
+        this.subscriptionsByObject.set(entry.objectName, subs);
+      }
+      const handle = new ObjectHandle(
+        entry.objectName,
+        entry.qualifiedClassName,
+        this.name,
+        this.protocol,
+        this.typeCache,
+        subs,
+      );
+      this.objectsByName.set(entry.objectName, handle);
+      this.cachedObjects = null;
+
+      subs.seedCurrentValues(entry.currentValues ?? []);
+      subs.replayWireSubscriptions();
+      this.fireAdded(handle);
+    }
+  }
+
+  /** @internal */
+  dispatchPropertyChanged(params: PropertyChangedNotification): void {
+    if (this.currentState === "releasing" || this.currentState === "released") return;
+    this.subscriptionsByObject.get(params.objectName)?.dispatchPropertyChanged(params);
+  }
+
+  /** @internal */
+  dispatchEventTriggered(params: EventTriggeredNotification): void {
+    if (this.currentState === "releasing" || this.currentState === "released") return;
+    this.subscriptionsByObject
+      .get(params.objectName)
+      ?.dispatchEventTriggered(params.eventName, params.args, { timestamp: params.timestamp });
+  }
+
+  /** Connection epoch this interest last (re-)declared on. Makes `reestablish` idempotent
+   *  per connection generation: the second trigger of the same recovery (autoReestablish
+   *  plus a manual `reestablishAll()`, sequential or concurrent) must not clear and
+   *  re-declare an interest that is already live on the current connection — the re-create
+   *  bounces off "interest already exists" and the churn double-fires removed/added. */
+  private lastReestablishedEpoch = Number.NEGATIVE_INFINITY;
+
+  /** @internal - called by Client when the interest is (re-)declared on `epoch`. */
+  noteReestablished(epoch: number): void {
+    this.lastReestablishedEpoch = epoch;
+  }
+
+  /** @internal - called by Client.reestablishAll. */
+  async reestablish(epoch: number): Promise<void> {
+    if (this.currentState !== "active") return;
+    if (epoch === this.lastReestablishedEpoch) return;
+
+    for (const name of Array.from(this.objectsByName.keys())) {
+      this.objectsByName.delete(name);
+      this.cachedObjects = null;
+      this.fireRemoved(name);
+      this.subscriptionsByObject.get(name)?.clearValueCache();
+    }
+    for (const subs of this.subscriptionsByObject.values()) {
+      subs.invalidateWireState();
+    }
+    const call: Parameters<JsonRpcClient["createInterest"]>[0] = {
+      interestName: this.name,
+      query: this.declaration.query,
+    };
+    if (this.declaration.subscribe !== undefined) call.subscribe = this.declaration.subscribe;
+    if (this.declaration.withSchemas === true) call.withSchemas = true;
+    try {
+      await this.protocol.createInterest(call);
+    } catch (err) {
+      await this.resyncAfterFailedReestablish(err);
+    }
+    this.noteReestablished(epoch);
+  }
+
+  /** A rejected re-declare does not have to mean the interest is gone: a racing sibling
+   *  reestablish may already have re-created it server-side ("interest already exists"),
+   *  in which case its interestUpdate landed before our clear above and was wiped. Probe
+   *  `listObjects`: if the interest exists, rebuild the match set from the authoritative
+   *  answer (type specs are already cached — whichever call created the interest shipped
+   *  them on this connection); if it doesn't, surface the original error. */
+  private async resyncAfterFailedReestablish(originalError: unknown): Promise<void> {
+    let infos: Awaited<ReturnType<JsonRpcClient["listObjects"]>>;
+    try {
+      infos = await this.protocol.listObjects({ interestName: this.name });
+    } catch {
+      throw originalError instanceof Error ? originalError : new Error(String(originalError));
+    }
+    this.applyUpdateActive({
+      interestName: this.name,
+      added: infos.map((info) => ({
+        objectName: info.objectName,
+        qualifiedClassName: info.qualifiedClassName,
+        currentValues: [],
+      })),
+      removed: [],
+      types: [],
+      typeSchemas: "",
+    });
+  }
+
+  private fireAdded(obj: ObjectHandle): void {
+    for (const handler of Array.from(this.objectAddedHandlers)) {
+      try {
+        handler(obj);
+      } catch (err) {
+        this.reportError(normalizeError(err));
+      }
+    }
+  }
+
+  private fireRemoved(objectName: string): void {
+    for (const handler of Array.from(this.objectRemovedHandlers)) {
+      try {
+        handler(objectName);
+      } catch (err) {
+        this.reportError(normalizeError(err));
+      }
+    }
+  }
+
+  private wakeReleaseWaiters(): void {
+    const wakers = Array.from(this.releaseWakers);
+    this.releaseWakers.clear();
+    for (const wake of wakers) wake();
+  }
+
+  /**
+   * Async-iterate the match set: yields every currently-matched object, then each later
+   * arrival, until the interest is released or the loop is broken. Thin wrapper over
+   * {@link onObjectAdded} for ergonomic `for await` use.
+   *
+   * Throws {@link InterestReleasedError} if the interest is already `releasing`/`released`
+   * when the iteration starts. If the interest is released mid-iteration, the loop ends
+   * cleanly (no throw).
+   *
+   * @example
+   * ```ts
+   * for await (const cat of interest) {
+   *   console.log(cat.name);
+   *   if (cat.name === "rufus") break;  // break to stop iterating
+   * }
+   * ```
+   */
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<ObjectHandle> {
+    this.assertAlive("asyncIterator");
+    const queue: ObjectHandle[] = [];
+    let waker: (() => void) | null = null;
+    const wake = (): void => {
+      const w = waker;
+      waker = null;
+      w?.();
+    };
+
+    const cancelAdded = this.onObjectAdded((obj) => {
+      queue.push(obj);
+      wake();
+    });
+    this.releaseWakers.add(wake);
+
+    try {
+      while (true) {
+        while (queue.length > 0) {
+          yield queue.shift()!;
+        }
+        if (!this.isAlive()) return;
+        await new Promise<void>((r) => {
+          waker = r;
+        });
+      }
+    } finally {
+      cancelAdded();
+      this.releaseWakers.delete(wake);
+    }
+  }
+
+  private isAlive(): boolean {
+    return this.currentState !== "releasing" && this.currentState !== "released";
+  }
+
+  private assertAlive(operation: string): void {
+    if (!this.isAlive()) throw new InterestReleasedError(this.name, operation);
+  }
+}

--- a/components/jsonrpc/clients/typescript/src/index.ts
+++ b/components/jsonrpc/clients/typescript/src/index.ts
@@ -1,0 +1,103 @@
+// === index.ts ========================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// Public entry point for `@sen/client`.
+
+export {
+  Quantity,
+  Variant,
+  numberFromExact,
+  type Var,
+  type VarList,
+  type VarMap,
+  type CancelFn,
+} from "./values.js";
+export {
+  SenClientError,
+  JsonRpcError,
+  JsonRpcErrorCode,
+  TransportError,
+  TimeoutError,
+  InterestReleasedError,
+} from "./errors.js";
+export { connect, type ClientOptions, type ReconnectOptions, type ReportError } from "./connect.js";
+export { Client, type ConnectionState, type SessionInfo } from "./client.js";
+export { isPrimitive, isQuantity, isSequence, isStruct, isVariant } from "./narrowing.js";
+export {
+  InterestHandle,
+  ObjectHandle,
+  parseSenTimestamp,
+  type AnyChangeHandler,
+  type CallOptions,
+  type DeliveryInfo,
+  type EventTriggeredHandler,
+  type GetObjectsBatchStateOptions,
+  type GetOptions,
+  type InterestState,
+  type ObjectAddedHandler,
+  type ObjectBatchState,
+  type ObjectRemovedHandler,
+  type PreSubscription,
+  type PropertyChangedHandler,
+  type SubscribeOptions,
+} from "./handles.js";
+
+// Curated re-exports from the generated wire types.
+export type {
+  AddedObjectEntry,
+  AddedObjectList,
+  EventTriggeredNotification,
+  Identity,
+  InterestUpdateNotification,
+  ObjectInfo,
+  ObjectInfos,
+  PropertyChangedNotification,
+  PropertyValueList,
+  PropertyValuePair,
+  SessionInfoList,
+  TopologyChangedNotification,
+  UnitCat,
+  UnitInfo,
+} from "./generated/index.js";
+
+// Type-spec system (introspection of class / struct / variant / enum / quantity shapes).
+export type {
+  AliasTypeSpec,
+  ArgSpec,
+  ArgSpecList,
+  BasicType,
+  BuiltInType,
+  ClassTypeSpec,
+  CustomTypeData,
+  CustomTypeSpec,
+  CustomTypeSpecList,
+  EnumTypeSpec,
+  EnumeratorSpec,
+  EnumeratorSpecList,
+  EventSpec,
+  EventSpecList,
+  IntegralType,
+  MethodConstnessSpec,
+  MethodSpec,
+  MethodSpecList,
+  NumericType,
+  OptionalTypeSpec,
+  PropertyCategorySpec,
+  PropertyRelationSpec,
+  PropertySpec,
+  PropertySpecList,
+  QuantityTypeSpec,
+  RealType,
+  SequenceTypeSpec,
+  StructTypeFieldSpec,
+  StructTypeFieldSpecList,
+  StructTypeSpec,
+  TransportModeSpec,
+  VariantTypeFieldSpec,
+  VariantTypeFieldSpecList,
+  VariantTypeSpec,
+} from "./generated/index.js";

--- a/components/jsonrpc/clients/typescript/src/internal/cancel.ts
+++ b/components/jsonrpc/clients/typescript/src/internal/cancel.ts
@@ -1,0 +1,18 @@
+// === cancel.ts =======================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import type { CancelFn } from "../values.js";
+
+/** Wrap a disposer so it runs at most once. */
+export function makeIdempotent(dispose: () => void): CancelFn {
+  let done = false;
+  return () => {
+    if (done) return;
+    done = true;
+    dispose();
+  };
+}

--- a/components/jsonrpc/clients/typescript/src/internal/class_spec_lookup.ts
+++ b/components/jsonrpc/clients/typescript/src/internal/class_spec_lookup.ts
@@ -1,0 +1,109 @@
+// === class_spec_lookup.ts ============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { TransportError } from "../errors.js";
+import type {
+  ClassTypeSpec,
+  EventSpec,
+  MethodSpec,
+  PropertySpec,
+} from "../generated/index.js";
+import type { TypeCache } from "./type_cache.js";
+
+/** Throws if missing or not a class. */
+export function getClassSpec(qualifiedClassName: string, cache: TypeCache): ClassTypeSpec {
+  const spec = cache.get(qualifiedClassName);
+  if (!spec) throw new TransportError(`class spec "${qualifiedClassName}" not cached`);
+  if (spec.data.type !== "sen.kernel.ClassTypeSpec") {
+    throw new TransportError(`type "${qualifiedClassName}" is not a class`);
+  }
+  return spec.data.value;
+}
+
+export function findPropertyInClass(
+  classSpec: ClassTypeSpec,
+  propertyName: string,
+  cache: TypeCache,
+): PropertySpec | undefined {
+  return findClassMember(classSpec, propertyName, cache, "p", (cs) => cs.properties);
+}
+
+export function findMethodInClass(
+  classSpec: ClassTypeSpec,
+  methodName: string,
+  cache: TypeCache,
+): MethodSpec | undefined {
+  return findClassMember(classSpec, methodName, cache, "m", (cs) => cs.methods);
+}
+
+export function findEventInClass(
+  classSpec: ClassTypeSpec,
+  eventName: string,
+  cache: TypeCache,
+): EventSpec | undefined {
+  return findClassMember(classSpec, eventName, cache, "e", (cs) => cs.events);
+}
+
+// Wire-rate consumers (subscription_registry.dispatch*) hit this per delivery, so the
+// parent-chain walk is memoized on TypeCache.derived. Cache lifetime is tied to the spec
+// object reference; if the cache replaces a spec, its old entries die with it.
+function findClassMember<T extends { name: string }>(
+  classSpec: ClassTypeSpec,
+  memberName: string,
+  cache: TypeCache,
+  kind: "p" | "m" | "e",
+  pick: (cs: ClassTypeSpec) => readonly T[],
+): T | undefined {
+  const cacheKey = `${kind}:${memberName}`;
+  let memo = cache.derived.get(classSpec) as Map<string, unknown> | undefined;
+  if (memo && memo.has(cacheKey)) return memo.get(cacheKey) as T | undefined;
+
+  let result: T | undefined;
+  for (const member of pick(classSpec)) {
+    if (member.name === memberName) {
+      result = member;
+      break;
+    }
+  }
+  if (!result) {
+    const seen = new Set<string>();
+    for (const parent of classSpec.parents) {
+      const found = searchParents(parent, memberName, cache, pick, seen);
+      if (found) {
+        result = found;
+        break;
+      }
+    }
+  }
+
+  if (!memo) {
+    memo = new Map();
+    cache.derived.set(classSpec, memo);
+  }
+  memo.set(cacheKey, result);
+  return result;
+}
+
+function searchParents<T extends { name: string }>(
+  parentName: string,
+  memberName: string,
+  cache: TypeCache,
+  pick: (cs: ClassTypeSpec) => readonly T[],
+  seen: Set<string>,
+): T | undefined {
+  if (seen.has(parentName)) return undefined;
+  seen.add(parentName);
+  const parentSpec = getClassSpec(parentName, cache);
+  for (const member of pick(parentSpec)) {
+    if (member.name === memberName) return member;
+  }
+  for (const grandparent of parentSpec.parents) {
+    const found = searchParents(grandparent, memberName, cache, pick, seen);
+    if (found) return found;
+  }
+  return undefined;
+}

--- a/components/jsonrpc/clients/typescript/src/internal/notification_validators.ts
+++ b/components/jsonrpc/clients/typescript/src/internal/notification_validators.ts
@@ -1,0 +1,64 @@
+// === notification_validators.ts ======================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import type {
+  EventTriggeredNotification,
+  InterestUpdateNotification,
+  PropertyChangedNotification,
+  TopologyChangedNotification,
+} from "../generated/index.js";
+
+// Shape-only checks; nested values are parsed later by parseVar.
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function isPropertyChangedNotification(
+  raw: unknown,
+): raw is PropertyChangedNotification {
+  if (!isObject(raw)) return false;
+  return (
+    typeof raw["interestName"] === "string" &&
+    typeof raw["objectName"] === "string" &&
+    Array.isArray(raw["values"]) &&
+    typeof raw["timestamp"] === "string"
+  );
+}
+
+export function isEventTriggeredNotification(
+  raw: unknown,
+): raw is EventTriggeredNotification {
+  if (!isObject(raw)) return false;
+  return (
+    typeof raw["interestName"] === "string" &&
+    typeof raw["objectName"] === "string" &&
+    typeof raw["eventName"] === "string" &&
+    typeof raw["args"] === "string" &&
+    typeof raw["timestamp"] === "string"
+  );
+}
+
+export function isInterestUpdateNotification(
+  raw: unknown,
+): raw is InterestUpdateNotification {
+  if (!isObject(raw)) return false;
+  return (
+    typeof raw["interestName"] === "string" &&
+    Array.isArray(raw["added"]) &&
+    Array.isArray(raw["removed"]) &&
+    Array.isArray(raw["types"]) &&
+    typeof raw["typeSchemas"] === "string"
+  );
+}
+
+export function isTopologyChangedNotification(
+  raw: unknown,
+): raw is TopologyChangedNotification {
+  if (!isObject(raw)) return false;
+  return Array.isArray(raw["sessions"]);
+}

--- a/components/jsonrpc/clients/typescript/src/internal/protocol_client.ts
+++ b/components/jsonrpc/clients/typescript/src/internal/protocol_client.ts
@@ -1,0 +1,432 @@
+// === protocol_client.ts ==============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { TransportError } from "../errors.js";
+import {
+  isEventTriggeredNotification,
+  isInterestUpdateNotification,
+  isPropertyChangedNotification,
+  isTopologyChangedNotification,
+} from "./notification_validators.js";
+import type {
+  EventTriggeredNotification,
+  InterestUpdateNotification,
+  MaybeFlag,
+  MaybeRateHz,
+  MaybeSubscribeBlock,
+  ObjectInfos,
+  ObjectStateList,
+  PropertyChangedNotification,
+  SessionInfoList,
+  StringList,
+  TopologyChangedNotification,
+  TypeLookupResult,
+} from "../generated/index.js";
+import type { ReportError } from "../connect.js";
+import type { CancelFn } from "../values.js";
+
+/** Subset of `Transport` that JsonRpcClient needs; lets tests inject a fake. */
+export interface TransportLike {
+  call(request: {
+    method: string;
+    params?: unknown;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  }): Promise<unknown>;
+  onNotification(args: {
+    method: string;
+    handler: (params: unknown) => void;
+  }): CancelFn;
+}
+
+export interface CallOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+// Omits absent optional keys; required for exactOptionalPropertyTypes.
+function buildRequest(
+  method: string,
+  wireParams: unknown,
+  callOpts: CallOptions,
+): {
+  method: string;
+  params?: unknown;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+} {
+  const req: { method: string; params?: unknown; timeoutMs?: number; signal?: AbortSignal } = {
+    method,
+  };
+  if (wireParams !== undefined) req.params = wireParams;
+  if (callOpts.timeoutMs !== undefined) req.timeoutMs = callOpts.timeoutMs;
+  if (callOpts.signal !== undefined) req.signal = callOpts.signal;
+  return req;
+}
+
+/** One method per RPC in `JsonRpcServer.stl`; wire-faithful naming. */
+export class JsonRpcClient {
+  constructor(
+    private readonly transport: TransportLike,
+    readonly reportError: ReportError = (err) => {
+      console.error(err);
+    },
+  ) {}
+
+  // -- health + introspection ----------------------------------------------------------------
+
+  async ping(opts: CallOptions = {}): Promise<string> {
+    return (await this.transport.call(buildRequest("ping", undefined, opts))) as string;
+  }
+
+  // -- topology (sessions + buses) -----------------------------------------------------------
+
+  async listTopology(opts: CallOptions = {}): Promise<SessionInfoList> {
+    return (await this.transport.call(buildRequest("listTopology", undefined, opts))) as SessionInfoList;
+  }
+
+  async subscribeTopology(opts: CallOptions = {}): Promise<void> {
+    await this.transport.call(buildRequest("subscribeTopology", undefined, opts));
+  }
+
+  async unsubscribeTopology(opts: CallOptions = {}): Promise<void> {
+    await this.transport.call(buildRequest("unsubscribeTopology", undefined, opts));
+  }
+
+  async getTypes(opts: CallOptions = {}): Promise<StringList> {
+    return (await this.transport.call(buildRequest("getTypes", undefined, opts))) as StringList;
+  }
+
+  async getType(
+    params: { qualifiedName: string; withSchema?: MaybeFlag } & CallOptions,
+  ): Promise<TypeLookupResult> {
+    return (await this.transport.call(
+      buildRequest(
+        "getType",
+        {
+          qualifiedName: params.qualifiedName,
+          withSchema: params.withSchema ?? null,
+        },
+        params,
+      ),
+    )) as TypeLookupResult;
+  }
+
+  // -- interests -----------------------------------------------------------------------------
+
+  async createInterest(
+    params: {
+      interestName: string;
+      query: string;
+      subscribe?: MaybeSubscribeBlock;
+      withSchemas?: MaybeFlag;
+    } & CallOptions,
+  ): Promise<void> {
+    await this.transport.call(
+      buildRequest(
+        "createInterest",
+        {
+          interestName: params.interestName,
+          query: params.query,
+          subscribe: params.subscribe ?? null,
+          withSchemas: params.withSchemas ?? null,
+        },
+        params,
+      ),
+    );
+  }
+
+  async releaseInterest(params: { interestName: string } & CallOptions): Promise<void> {
+    await this.transport.call(
+      buildRequest("releaseInterest", { interestName: params.interestName }, params),
+    );
+  }
+
+  async listObjects(params: { interestName: string } & CallOptions): Promise<ObjectInfos> {
+    return (await this.transport.call(
+      buildRequest("listObjects", { interestName: params.interestName }, params),
+    )) as ObjectInfos;
+  }
+
+  // -- read/write (Var is string-encoded on the wire) ---------------------------------------
+
+  async getProperty(
+    params: {
+      interestName: string;
+      objectName: string;
+      propertyName: string;
+    } & CallOptions,
+  ): Promise<string> {
+    return (await this.transport.call(
+      buildRequest(
+        "getProperty",
+        {
+          interestName: params.interestName,
+          objectName: params.objectName,
+          propertyName: params.propertyName,
+        },
+        params,
+      ),
+    )) as string;
+  }
+
+  async getObjectsBatchState(
+    params: {
+      interestName: string;
+      /** Subset of object names to read; omit to read every matched object. */
+      objectNames?: StringList;
+      /** Subset of property names to read; omit to read every property of each object. */
+      propertyNames?: StringList;
+    } & CallOptions,
+  ): Promise<ObjectStateList> {
+    return (await this.transport.call(
+      buildRequest(
+        "getObjectsBatchState",
+        {
+          interestName: params.interestName,
+          objectNames: params.objectNames ?? null,
+          propertyNames: params.propertyNames ?? null,
+        },
+        params,
+      ),
+    )) as ObjectStateList;
+  }
+
+  async setProperty(
+    params: {
+      interestName: string;
+      objectName: string;
+      propertyName: string;
+      /** JSON-encoded Var as string. */
+      value: string;
+    } & CallOptions,
+  ): Promise<void> {
+    await this.transport.call(
+      buildRequest(
+        "setProperty",
+        {
+          interestName: params.interestName,
+          objectName: params.objectName,
+          propertyName: params.propertyName,
+          value: params.value,
+        },
+        params,
+      ),
+    );
+  }
+
+  // -- sticky subscriptions ------------------------------------------------------------------
+
+  async subscribeProperty(
+    params: {
+      interestName: string;
+      objectName: string;
+      propertyName: string;
+      maxRateHz?: MaybeRateHz;
+    } & CallOptions,
+  ): Promise<void> {
+    await this.transport.call(
+      buildRequest(
+        "subscribeProperty",
+        {
+          interestName: params.interestName,
+          objectName: params.objectName,
+          propertyName: params.propertyName,
+          maxRateHz: params.maxRateHz ?? null,
+        },
+        params,
+      ),
+    );
+  }
+
+  async unsubscribeProperty(
+    params: {
+      interestName: string;
+      objectName: string;
+      propertyName: string;
+    } & CallOptions,
+  ): Promise<void> {
+    await this.transport.call(
+      buildRequest(
+        "unsubscribeProperty",
+        {
+          interestName: params.interestName,
+          objectName: params.objectName,
+          propertyName: params.propertyName,
+        },
+        params,
+      ),
+    );
+  }
+
+  async subscribeEvent(
+    params: {
+      interestName: string;
+      objectName: string;
+      eventName: string;
+    } & CallOptions,
+  ): Promise<void> {
+    await this.transport.call(
+      buildRequest(
+        "subscribeEvent",
+        {
+          interestName: params.interestName,
+          objectName: params.objectName,
+          eventName: params.eventName,
+        },
+        params,
+      ),
+    );
+  }
+
+  async unsubscribeEvent(
+    params: {
+      interestName: string;
+      objectName: string;
+      eventName: string;
+    } & CallOptions,
+  ): Promise<void> {
+    await this.transport.call(
+      buildRequest(
+        "unsubscribeEvent",
+        {
+          interestName: params.interestName,
+          objectName: params.objectName,
+          eventName: params.eventName,
+        },
+        params,
+      ),
+    );
+  }
+
+  async subscribeAll(
+    params: {
+      interestName: string;
+      objectName: string;
+      maxRateHz?: MaybeRateHz;
+    } & CallOptions,
+  ): Promise<void> {
+    await this.transport.call(
+      buildRequest(
+        "subscribeAll",
+        {
+          interestName: params.interestName,
+          objectName: params.objectName,
+          maxRateHz: params.maxRateHz ?? null,
+        },
+        params,
+      ),
+    );
+  }
+
+  async unsubscribeAll(
+    params: {
+      interestName: string;
+      objectName: string;
+    } & CallOptions,
+  ): Promise<void> {
+    await this.transport.call(
+      buildRequest(
+        "unsubscribeAll",
+        {
+          interestName: params.interestName,
+          objectName: params.objectName,
+        },
+        params,
+      ),
+    );
+  }
+
+  // -- meta-invoke ---------------------------------------------------------------------------
+
+  async invoke(
+    params: {
+      interestName: string;
+      objectName: string;
+      methodName: string;
+      /** JSON array as string (positional method arguments). */
+      argsJson: string;
+    } & CallOptions,
+  ): Promise<string> {
+    return (await this.transport.call(
+      buildRequest(
+        "invoke",
+        {
+          interestName: params.interestName,
+          objectName: params.objectName,
+          methodName: params.methodName,
+          argsJson: params.argsJson,
+        },
+        params,
+      ),
+    )) as string;
+  }
+
+  // -- notification dispatch -----------------------------------------------------------------
+  // Each helper validates the raw payload against a typed predicate; mismatches route through
+  // reportError so a malformed frame doesn't crash the dispatch loop.
+
+  onPropertyChanged(handler: (params: PropertyChangedNotification) => void): CancelFn {
+    return this.transport.onNotification({
+      method: "propertyChanged",
+      handler: (raw) => {
+        if (!isPropertyChangedNotification(raw)) {
+          this.reportError(
+            new TransportError(`malformed propertyChanged payload: ${JSON.stringify(raw)}`),
+          );
+          return;
+        }
+        handler(raw);
+      },
+    });
+  }
+
+  onEventTriggered(handler: (params: EventTriggeredNotification) => void): CancelFn {
+    return this.transport.onNotification({
+      method: "eventTriggered",
+      handler: (raw) => {
+        if (!isEventTriggeredNotification(raw)) {
+          this.reportError(
+            new TransportError(`malformed eventTriggered payload: ${JSON.stringify(raw)}`),
+          );
+          return;
+        }
+        handler(raw);
+      },
+    });
+  }
+
+  onInterestUpdate(handler: (params: InterestUpdateNotification) => void): CancelFn {
+    return this.transport.onNotification({
+      method: "interestUpdate",
+      handler: (raw) => {
+        if (!isInterestUpdateNotification(raw)) {
+          this.reportError(
+            new TransportError(`malformed interestUpdate payload: ${JSON.stringify(raw)}`),
+          );
+          return;
+        }
+        handler(raw);
+      },
+    });
+  }
+
+  onTopologyChanged(handler: (params: TopologyChangedNotification) => void): CancelFn {
+    return this.transport.onNotification({
+      method: "topologyChanged",
+      handler: (raw) => {
+        if (!isTopologyChangedNotification(raw)) {
+          this.reportError(
+            new TransportError(`malformed topologyChanged payload: ${JSON.stringify(raw)}`),
+          );
+          return;
+        }
+        handler(raw);
+      },
+    });
+  }
+}

--- a/components/jsonrpc/clients/typescript/src/internal/report_error.ts
+++ b/components/jsonrpc/clients/typescript/src/internal/report_error.ts
@@ -1,0 +1,19 @@
+// === report_error.ts =================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import type { ReportError } from "../connect.js";
+
+/** JS permits `throw "x"`; normalize to an Error so consumers can rely on the shape. */
+export function normalizeError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  return new Error(String(err));
+}
+
+/** Default reporter when {@link ClientOptions.onError} is not provided. */
+export const defaultReportError: ReportError = (err) => {
+  console.error(err);
+};

--- a/components/jsonrpc/clients/typescript/src/internal/subscribe_codec.ts
+++ b/components/jsonrpc/clients/typescript/src/internal/subscribe_codec.ts
@@ -1,0 +1,35 @@
+// === subscribe_codec.ts ==============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// Translates the friendly Layer-3 subscribe shape into the wire-level `MaybeSubscribeBlock`.
+// One-way: the wire form is built on the way out; nothing parses it back. Boundary code so
+// callers can write `subscribe: { properties: "*" }` instead of constructing the variant tag.
+
+import type { MaybeMemberSelector, MaybeSubscribeBlock } from "../generated/index.js";
+import type { PreSubscription } from "../handles.js";
+
+export function toWireSubscribeBlock(
+  subscribe: PreSubscription | undefined,
+): MaybeSubscribeBlock {
+  if (subscribe === undefined) return null;
+  return {
+    properties: toMemberSelector(subscribe.properties),
+    events: toMemberSelector(subscribe.events),
+    maxRateHz: subscribe.maxRateHz ?? null,
+  };
+}
+
+function toMemberSelector(selector: "*" | string[] | undefined): MaybeMemberSelector {
+  if (selector === undefined) return null;
+  if (selector === "*") {
+    return { type: "sen.components.jsonrpc.WildcardSelection", value: {} };
+  }
+  return {
+    type: "sen.components.jsonrpc.NamedSelection",
+    value: { memberNames: selector },
+  };
+}

--- a/components/jsonrpc/clients/typescript/src/internal/subscription_registry.ts
+++ b/components/jsonrpc/clients/typescript/src/internal/subscription_registry.ts
@@ -1,0 +1,499 @@
+// === subscription_registry.ts ========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import type { ReportError } from "../connect.js";
+import { TransportError } from "../errors.js";
+import { parseVar } from "./var_codec.js";
+import type { JsonRpcClient } from "./protocol_client.js";
+import { normalizeError } from "./report_error.js";
+import type { TypeCache } from "./type_cache.js";
+import type { PropertyChangedNotification, PropertyValueList } from "../generated/index.js";
+import type {
+  AnyChangeHandler,
+  DeliveryInfo,
+  EventTriggeredHandler,
+  PropertyChangedHandler,
+  SubscribeOptions,
+} from "../handles.js";
+import type { CancelFn, Var } from "../values.js";
+import { findEventInClass, findPropertyInClass, getClassSpec } from "./class_spec_lookup.js";
+
+interface Consumer<H> {
+  handler: H;
+  cancelled: boolean;
+  detachSignal?: () => void;
+}
+
+interface ConsumerSet<H> {
+  consumers: Set<Consumer<H>>;
+  wireSent: boolean;
+  /** Resolves when the most recent first-subscribe wire frame has been ack'd by the server.
+   *  Callers that need "subscribe-then-trigger" semantics (e.g., subscribe to an event then
+   *  fire a method that triggers it) can await this to avoid racing the subscribe RPC. */
+  wireReady: Promise<void> | undefined;
+}
+
+function newConsumerSet<H>(): ConsumerSet<H> {
+  return { consumers: new Set(), wireSent: false, wireReady: undefined };
+}
+
+/**
+ * Per-object subscription state. One wire subscribe per (object, member) regardless of how many
+ * consumers register; refcounted by `consumers.size`. Survives object remove/add cycles within
+ * the interest so subscribers keep firing across the gap.
+ */
+export class ObjectSubscriptions {
+  private readonly properties = new Map<string, ConsumerSet<PropertyChangedHandler>>();
+  private readonly events = new Map<string, ConsumerSet<EventTriggeredHandler>>();
+  private readonly anyChange: ConsumerSet<AnyChangeHandler> = newConsumerSet();
+  /** Last-known value + timestamp per property. Populated from propertyChanged dispatches and
+   *  from interestUpdate `currentValues` seeds. Used to replay to late subscribers so a
+   *  property that won't change again (static) or whose wire subscription was already live
+   *  (server skips its seed) still delivers a value to every consumer. */
+  private readonly valueCache = new Map<string, { value: Var; timestamp: string }>();
+  private maxRateHz: number | null = null;
+
+  constructor(
+    private readonly protocol: JsonRpcClient,
+    private readonly typeCache: TypeCache,
+    private readonly interestName: string,
+    private readonly objectName: string,
+    readonly qualifiedClassName: string,
+    private readonly reportError: ReportError,
+  ) {}
+
+  onPropertyChanged(
+    propertyName: string,
+    handler: PropertyChangedHandler,
+    opts: SubscribeOptions = {},
+  ): CancelFn {
+    let set = this.properties.get(propertyName);
+    if (!set) {
+      set = newConsumerSet();
+      this.properties.set(propertyName, set);
+    }
+    const cancel = this.subscribe(
+      set,
+      handler,
+      opts,
+      () => this.firePropertySubscribe(propertyName),
+      () => {
+        this.properties.delete(propertyName);
+        // No subscribeAll consumer means no wire path is keeping `propertyName`'s value
+        // fresh once we drop the per-property wire sub. Evict so a future resubscribe
+        // waits for the next server push instead of replaying a stale snapshot.
+        if (this.anyChange.consumers.size === 0) {
+          this.invalidateCachedValue(propertyName);
+        }
+        return this.firePropertyUnsubscribe(propertyName);
+      },
+    );
+    this.replayCachedTo(propertyName, handler);
+    return cancel;
+  }
+
+  onEventTriggered(
+    eventName: string,
+    handler: EventTriggeredHandler,
+    opts: SubscribeOptions = {},
+  ): CancelFn {
+    let set = this.events.get(eventName);
+    if (!set) {
+      set = newConsumerSet();
+      this.events.set(eventName, set);
+    }
+    return this.subscribe(
+      set,
+      handler,
+      opts,
+      () => this.fireEventSubscribe(eventName),
+      () => {
+        this.events.delete(eventName);
+        return this.fireEventUnsubscribe(eventName);
+      },
+    );
+  }
+
+  /** Resolves once the server has ack'd the most recent first-subscribe for `eventName`.
+   *  No-op if no one is currently subscribed. Use after onEventTriggered when you need
+   *  subscribe-then-trigger semantics (e.g., a method invocation that fires the event). */
+  awaitEventSubscribed(eventName: string): Promise<void> {
+    return this.events.get(eventName)?.wireReady ?? Promise.resolve();
+  }
+
+  /** Symmetric partner to {@link awaitEventSubscribed}: resolves once the server has ack'd the
+   *  property's first-subscribe, or rejects with the wire error. No-op if no one is currently
+   *  subscribed. A typo'd property name otherwise only surfaces via `reportError`. */
+  awaitPropertySubscribed(propertyName: string): Promise<void> {
+    return this.properties.get(propertyName)?.wireReady ?? Promise.resolve();
+  }
+
+  onAnyChange(handler: AnyChangeHandler, opts: SubscribeOptions = {}): CancelFn {
+    const cancel = this.subscribe(
+      this.anyChange,
+      handler,
+      opts,
+      () => this.fireSubscribeAll(),
+      () => {
+        // Drop any cached value that was only being kept fresh by subscribeAll. Entries
+        // that still have a per-property consumer stay; the per-property wire sub keeps
+        // them fresh.
+        for (const propertyName of Array.from(this.valueCache.keys())) {
+          const propSet = this.properties.get(propertyName);
+          if (!propSet || propSet.consumers.size === 0) {
+            this.invalidateCachedValue(propertyName);
+          }
+        }
+        return this.fireUnsubscribeAll();
+      },
+    );
+    this.replayCachedBundleTo(handler);
+    return cancel;
+  }
+
+  /** Cache update is unconditional: onAnyChange callers may read it without a per-property sub. */
+  dispatchPropertyChanged(params: PropertyChangedNotification): void {
+    let classSpec;
+    try {
+      classSpec = getClassSpec(this.qualifiedClassName, this.typeCache);
+    } catch (err) {
+      this.reportError(normalizeError(err));
+      return;
+    }
+    const info: DeliveryInfo = { timestamp: params.timestamp };
+    const bundleMap = this.anyChange.consumers.size > 0 ? new Map<string, Var>() : null;
+    for (const pair of params.values) {
+      try {
+        const propertySpec = findPropertyInClass(classSpec, pair.propertyName, this.typeCache);
+        if (!propertySpec) {
+          throw new TransportError(
+            `propertyChanged dispatch: "${pair.propertyName}" not found on class "${this.qualifiedClassName}"`,
+          );
+        }
+        const value = parseVar(propertySpec.type, JSON.parse(pair.value), this.typeCache);
+        this.valueCache.set(pair.propertyName, { value, timestamp: params.timestamp });
+        if (bundleMap) bundleMap.set(pair.propertyName, value);
+        const set = this.properties.get(pair.propertyName);
+        if (set && set.consumers.size > 0) {
+          this.fireSet(set, (h) => h(value, info));
+        }
+      } catch (err) {
+        this.reportError(normalizeError(err));
+      }
+    }
+    if (bundleMap) {
+      this.fireSet(this.anyChange, (h) => h(bundleMap, info));
+    }
+  }
+
+  dispatchEventTriggered(eventName: string, argsJson: string, info: { timestamp: string }): void {
+    const set = this.events.get(eventName);
+    if (!set || set.consumers.size === 0) return;
+    try {
+      const classSpec = getClassSpec(this.qualifiedClassName, this.typeCache);
+      const eventSpec = findEventInClass(classSpec, eventName, this.typeCache);
+      if (!eventSpec) {
+        throw new TransportError(
+          `eventTriggered dispatch: "${eventName}" not found on class "${this.qualifiedClassName}"`,
+        );
+      }
+      const rawArgs = JSON.parse(argsJson) as unknown[];
+      const parsed = eventSpec.args.map((arg, i) =>
+        parseVar(arg.type, rawArgs[i], this.typeCache),
+      );
+      this.fireSet(set, (h) => h(parsed, info));
+    } catch (err) {
+      this.reportError(normalizeError(err));
+    }
+  }
+
+  seedCurrentValues(values: PropertyValueList): void {
+    if (values.length === 0) return;
+    let classSpec;
+    try {
+      classSpec = getClassSpec(this.qualifiedClassName, this.typeCache);
+    } catch (err) {
+      this.reportError(normalizeError(err));
+      return;
+    }
+    for (const pair of values) {
+      try {
+        const propertySpec = findPropertyInClass(classSpec, pair.propertyName, this.typeCache);
+        if (!propertySpec) {
+          throw new TransportError(
+            `currentValues seed: "${pair.propertyName}" not found on class "${this.qualifiedClassName}"`,
+          );
+        }
+        const value = parseVar(propertySpec.type, JSON.parse(pair.value), this.typeCache);
+        // No per-value timestamp on interestUpdate.currentValues; empty string is a sentinel
+        // that subsequent propertyChanged dispatches will overwrite.
+        this.valueCache.set(pair.propertyName, { value, timestamp: "" });
+      } catch (err) {
+        this.reportError(normalizeError(err));
+      }
+    }
+  }
+
+  getCachedValue(propertyName: string): Var | undefined {
+    return this.valueCache.get(propertyName)?.value;
+  }
+
+  setCachedValue(propertyName: string, value: Var): void {
+    const existing = this.valueCache.get(propertyName);
+    this.valueCache.set(propertyName, { value, timestamp: existing?.timestamp ?? "" });
+  }
+
+  clearValueCache(): void {
+    this.valueCache.clear();
+  }
+
+  invalidateCachedValue(propertyName: string): void {
+    this.valueCache.delete(propertyName);
+  }
+
+  /**
+   * Asynchronously deliver the cached value for one property to a single new consumer.
+   * Done as a microtask so the consumer's `cancel` is bound before the handler can run and
+   * so the call site sees the same "subscribe returns, then handler fires" ordering it gets
+   * for server-sent values.
+   */
+  private replayCachedTo(propertyName: string, handler: PropertyChangedHandler): void {
+    const cached = this.valueCache.get(propertyName);
+    if (!cached) return;
+    const value = cached.value;
+    const info: DeliveryInfo = { timestamp: cached.timestamp };
+    queueMicrotask(() => {
+      try {
+        handler(value, info);
+      } catch (err) {
+        this.reportError(normalizeError(err));
+      }
+    });
+  }
+
+  /** Same idea for `onAnyChange`: replay every cached property as one bundle. */
+  private replayCachedBundleTo(handler: AnyChangeHandler): void {
+    if (this.valueCache.size === 0) return;
+    const bundle = new Map<string, Var>();
+    let latest = "";
+    for (const [name, entry] of this.valueCache) {
+      bundle.set(name, entry.value);
+      if (entry.timestamp > latest) latest = entry.timestamp;
+    }
+    const info: DeliveryInfo = { timestamp: latest };
+    queueMicrotask(() => {
+      try {
+        handler(bundle, info);
+      } catch (err) {
+        this.reportError(normalizeError(err));
+      }
+    });
+  }
+
+  /**
+   * Refresh every currently-active subscribe with the new rate so the server's interval tracks
+   * the latest ask. Stored on the instance so a later first-subscribe also picks it up.
+   */
+  async setMaxRateHz(hz: number | null): Promise<void> {
+    this.maxRateHz = hz;
+    const refreshes: Promise<void>[] = [];
+    for (const [name, set] of this.properties) {
+      if (set.consumers.size > 0) refreshes.push(this.firePropertySubscribe(name));
+    }
+    if (this.anyChange.consumers.size > 0) {
+      refreshes.push(this.fireSubscribeAll());
+    }
+    await Promise.all(refreshes);
+  }
+
+  /** Re-issue every active wire subscribe after reconnect. The `.catch` suppresses
+   *  unhandledRejection: the fire helpers re-throw so direct awaiters see failures, but
+   *  replay-issued calls have no awaiter and the error already routed through reportError. */
+  replayWireSubscriptions(): void {
+    const swallow = (): void => undefined;
+    for (const [propertyName, set] of this.properties) {
+      if (set.consumers.size > 0) {
+        set.wireSent = true;
+        set.wireReady = this.firePropertySubscribe(propertyName);
+        set.wireReady.catch(swallow);
+      }
+    }
+    for (const [eventName, set] of this.events) {
+      if (set.consumers.size > 0) {
+        set.wireSent = true;
+        set.wireReady = this.fireEventSubscribe(eventName);
+        set.wireReady.catch(swallow);
+      }
+    }
+    if (this.anyChange.consumers.size > 0) {
+      this.anyChange.wireSent = true;
+      this.fireSubscribeAll().catch(swallow);
+    }
+  }
+
+  /** Forget which subscribes the server knows about, without sending unsubscribes. Post-disconnect. */
+  invalidateWireState(): void {
+    for (const set of this.properties.values()) set.wireSent = false;
+    for (const set of this.events.values()) set.wireSent = false;
+    this.anyChange.wireSent = false;
+  }
+
+  /** True iff at least one consumer is currently registered across any property, event,
+   *  or anyChange subscription. Used by `InterestHandle.applyUpdate` to decide whether to
+   *  drop a removed object's subscription entry: keep when consumers remain (sticky), drop
+   *  when no one's listening (so the object never has to come back to release the entry). */
+  hasAnySubscribers(): boolean {
+    for (const set of this.properties.values()) if (set.consumers.size > 0) return true;
+    for (const set of this.events.values()) if (set.consumers.size > 0) return true;
+    return this.anyChange.consumers.size > 0;
+  }
+
+  // -- shared helpers ------------------------------------------------------------------------
+
+  private subscribe<H>(
+    set: ConsumerSet<H>,
+    handler: H,
+    opts: SubscribeOptions,
+    onFirst: () => Promise<void>,
+    onLast: () => Promise<void>,
+  ): CancelFn {
+    const consumer: Consumer<H> = { handler, cancelled: false };
+    set.consumers.add(consumer);
+    if (!set.wireSent) {
+      set.wireSent = true;
+      set.wireReady = onFirst();
+      // Suppress unhandledRejection; the rejection is still observable by anyone awaiting
+      // wireReady, and the underlying RPC also surfaces errors through reportError. The
+      // rejection stays cached on the set until the last consumer cancels and tears the set
+      // down; subsequent subscribes within the same set lifetime see the same failure rather
+      // than retrying.
+      set.wireReady.catch(() => {});
+    }
+    const cancel = (): void => {
+      if (consumer.cancelled) return;
+      consumer.cancelled = true;
+      if (consumer.detachSignal) consumer.detachSignal();
+      set.consumers.delete(consumer);
+      if (set.consumers.size === 0 && set.wireSent) {
+        set.wireSent = false;
+        set.wireReady = undefined;
+        void onLast();
+      }
+    };
+    this.wireSignal(opts.signal, cancel, consumer);
+    return cancel;
+  }
+
+  private fireSet<H>(set: ConsumerSet<H>, invoke: (handler: H) => void): void {
+    for (const consumer of Array.from(set.consumers)) {
+      if (consumer.cancelled) continue;
+      try {
+        invoke(consumer.handler);
+      } catch (err) {
+        this.reportError(normalizeError(err));
+      }
+    }
+  }
+
+  private wireSignal<H>(
+    signal: AbortSignal | undefined,
+    cancel: CancelFn,
+    consumer: Consumer<H>,
+  ): void {
+    if (!signal) return;
+    if (signal.aborted) {
+      cancel();
+      return;
+    }
+    const onAbort = (): void => cancel();
+    signal.addEventListener("abort", onAbort, { once: true });
+    consumer.detachSignal = () => signal.removeEventListener("abort", onAbort);
+  }
+
+  // -- wire ops ------------------------------------------------------------------------------
+
+  private async firePropertySubscribe(propertyName: string): Promise<void> {
+    // Rate sent on every subscribe so the server's interval tracks the latest ask.
+    const call: Parameters<JsonRpcClient["subscribeProperty"]>[0] = {
+      interestName: this.interestName,
+      objectName: this.objectName,
+      propertyName,
+    };
+    if (this.maxRateHz !== null) call.maxRateHz = this.maxRateHz;
+    try {
+      await this.protocol.subscribeProperty(call);
+    } catch (err) {
+      // Surface via reportError for fire-and-forget callers, and re-throw so anyone awaiting
+      // awaitPropertySubscribed sees the failure. Mirrors fireEventSubscribe.
+      this.reportError(normalizeError(err));
+      throw err;
+    }
+  }
+
+  private async firePropertyUnsubscribe(propertyName: string): Promise<void> {
+    try {
+      await this.protocol.unsubscribeProperty({
+        interestName: this.interestName,
+        objectName: this.objectName,
+        propertyName,
+      });
+    } catch (err) {
+      this.reportError(normalizeError(err));
+    }
+  }
+
+  private async fireEventSubscribe(eventName: string): Promise<void> {
+    try {
+      await this.protocol.subscribeEvent({
+        interestName: this.interestName,
+        objectName: this.objectName,
+        eventName,
+      });
+    } catch (err) {
+      // Surface via reportError for fire-and-forget callers, and re-throw so anyone awaiting
+      // awaitEventSubscribed sees the failure.
+      this.reportError(normalizeError(err));
+      throw err;
+    }
+  }
+
+  private async fireEventUnsubscribe(eventName: string): Promise<void> {
+    try {
+      await this.protocol.unsubscribeEvent({
+        interestName: this.interestName,
+        objectName: this.objectName,
+        eventName,
+      });
+    } catch (err) {
+      this.reportError(normalizeError(err));
+    }
+  }
+
+  private async fireSubscribeAll(): Promise<void> {
+    const call: Parameters<JsonRpcClient["subscribeAll"]>[0] = {
+      interestName: this.interestName,
+      objectName: this.objectName,
+    };
+    if (this.maxRateHz !== null) call.maxRateHz = this.maxRateHz;
+    try {
+      await this.protocol.subscribeAll(call);
+    } catch (err) {
+      this.reportError(normalizeError(err));
+    }
+  }
+
+  private async fireUnsubscribeAll(): Promise<void> {
+    try {
+      await this.protocol.unsubscribeAll({
+        interestName: this.interestName,
+        objectName: this.objectName,
+      });
+    } catch (err) {
+      this.reportError(normalizeError(err));
+    }
+  }
+}

--- a/components/jsonrpc/clients/typescript/src/internal/transport.ts
+++ b/components/jsonrpc/clients/typescript/src/internal/transport.ts
@@ -1,0 +1,471 @@
+// === transport.ts ====================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import type { ConnectionState } from "../client.js";
+import type { ReconnectOptions, ReportError } from "../connect.js";
+import { JsonRpcError, TimeoutError, TransportError } from "../errors.js";
+import { makeIdempotent } from "./cancel.js";
+import { defaultReportError, normalizeError } from "./report_error.js";
+import type { CancelFn } from "../values.js";
+
+// Minimal WebSocket shape: avoids DOM-type dependence; native browser/Node 22+ WebSocket and the
+// test MockWebSocket both satisfy it.
+export interface WebSocketLike {
+  readonly readyState: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(type: "open", listener: () => void): void;
+  addEventListener(type: "message", listener: (event: { data: unknown }) => void): void;
+  addEventListener(type: "close", listener: (event: { code: number; reason: string }) => void): void;
+  addEventListener(type: "error", listener: (event: unknown) => void): void;
+}
+
+export type WebSocketFactory = (url: string) => WebSocketLike;
+
+const defaultWebSocketFactory: WebSocketFactory = (url) => {
+  const ctor = (globalThis as { WebSocket?: new (url: string) => WebSocketLike }).WebSocket;
+  if (!ctor) {
+    throw new TransportError(
+      "no global WebSocket implementation available (need a browser or Node >=22)",
+    );
+  }
+  return new ctor(url);
+};
+
+// JSON-RPC 2.0 envelope shapes.
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcSuccessResponse {
+  jsonrpc: "2.0";
+  id: number;
+  result: unknown;
+}
+
+interface JsonRpcErrorResponse {
+  jsonrpc: "2.0";
+  id: number;
+  error: { code: number; message: string; data?: unknown };
+}
+
+interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+}
+
+// 2s = ~120 kernel cycles at 60Hz: well past any legitimate internal protocol op, quick to flag a hang.
+// User-initiated `invoke` calls bypass this default via `timeoutMs: 0` (see ObjectHandle.invoke); the
+// timeoutMs > 0 guard below skips the timer for the no-timeout path.
+const defaultTimeoutMs = 2_000;
+const defaultInitialReconnectDelayMs = 100;
+const defaultMaxReconnectDelayMs = 5_000;
+const defaultReconnectFactor = 2;
+
+interface TransportOptions {
+  url: string;
+  defaultTimeoutMs?: number;
+  reconnect?: ReconnectOptions;
+  webSocketFactory?: WebSocketFactory;
+  reportError?: ReportError;
+  /** When `true`, also retry the *initial* open using the reconnect backoff schedule
+   *  (default: initial open is one-shot, only post-open drops are retried). The whenOpen
+   *  promise stays pending across retries; the surrounding `connect()` budget enforces
+   *  the total deadline via `openTimeoutMs`. */
+  retryInitialOpen?: boolean;
+}
+
+type NotificationHandler = (params: unknown) => void;
+
+
+interface PendingCall {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  timeoutHandle: ReturnType<typeof setTimeout> | null;
+  abortListener: (() => void) | null;
+  signal: AbortSignal | null;
+}
+
+/**
+ * WebSocket + JSON-RPC envelope + request/response correlation + autonomous reconnect.
+ * Application-level state across reconnects is the layer above; signal it via on{Disconnect,Reconnect}.
+ */
+export class Transport {
+  private readonly url: string;
+  private readonly callTimeoutMs: number;
+  private readonly reconnect: Required<ReconnectOptions>;
+  private readonly retryInitialOpen: boolean;
+  private readonly factory: WebSocketFactory;
+  private readonly reportError: ReportError;
+
+  private socket: WebSocketLike | null = null;
+  private state: ConnectionState = "connecting";
+  private nextId = 1;
+  private hasEverConnected = false;
+  private reconnectAttempt = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  // Captured on 'error', consumed as `cause` on the TransportError thrown for the following 'close'.
+  private lastWebSocketError: unknown = null;
+
+  private readonly pending = new Map<number, PendingCall>();
+  private readonly notificationHandlers = new Map<string, Set<NotificationHandler>>();
+  private readonly disconnectHandlers = new Set<() => void>();
+  private readonly reconnectHandlers = new Set<() => void>();
+  private readonly connectionStateHandlers = new Set<(state: ConnectionState) => void>();
+
+  private readonly openPromise: Promise<void>;
+  private resolveOpen!: () => void;
+  private rejectOpen!: (err: Error) => void;
+
+  constructor(options: TransportOptions) {
+    this.url = options.url;
+    this.callTimeoutMs = options.defaultTimeoutMs ?? defaultTimeoutMs;
+    this.reconnect = {
+      enabled: options.reconnect?.enabled ?? true,
+      initialDelayMs: options.reconnect?.initialDelayMs ?? defaultInitialReconnectDelayMs,
+      maxDelayMs: options.reconnect?.maxDelayMs ?? defaultMaxReconnectDelayMs,
+      factor: options.reconnect?.factor ?? defaultReconnectFactor,
+      autoReestablish: options.reconnect?.autoReestablish ?? true,
+    };
+    this.retryInitialOpen = options.retryInitialOpen ?? false;
+    this.factory = options.webSocketFactory ?? defaultWebSocketFactory;
+    this.reportError = options.reportError ?? defaultReportError;
+    this.openPromise = new Promise<void>((resolve, reject) => {
+      this.resolveOpen = resolve;
+      this.rejectOpen = reject;
+    });
+    // Absorb unhandled-rejection; real awaiters still see it via replay.
+    this.openPromise.catch(() => undefined);
+    this.openSocket();
+  }
+
+  /** First-open promise; does not re-fulfill on later reconnects. */
+  whenOpen(): Promise<void> {
+    return this.openPromise;
+  }
+
+  get connectionState(): ConnectionState {
+    return this.state;
+  }
+
+  async call(request: {
+    method: string;
+    params?: unknown;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  }): Promise<unknown> {
+    if (this.state !== "open" || !this.socket) {
+      throw new TransportError(
+        `call rejected: transport state is "${this.state}" (${this.url})`,
+      );
+    }
+    if (request.signal?.aborted) {
+      throw new TransportError(`call rejected: AbortSignal already aborted (${this.url})`);
+    }
+
+    const id = this.nextId++;
+    const envelope: JsonRpcRequest = { jsonrpc: "2.0", id, method: request.method };
+    if (request.params !== undefined) {
+      envelope.params = request.params;
+    }
+
+    const timeoutMs = request.timeoutMs ?? this.callTimeoutMs;
+
+    return new Promise<unknown>((resolve, reject) => {
+      const pendingEntry: PendingCall = {
+        resolve,
+        reject,
+        timeoutHandle: null,
+        abortListener: null,
+        signal: request.signal ?? null,
+      };
+
+      if (timeoutMs > 0) {
+        pendingEntry.timeoutHandle = setTimeout(() => {
+          if (this.pending.delete(id)) {
+            this.detachAbort(pendingEntry);
+            reject(
+              new TimeoutError(
+                `call "${request.method}" timed out after ${timeoutMs}ms (${this.url})`,
+                timeoutMs,
+              ),
+            );
+          }
+        }, timeoutMs);
+      }
+      // timeoutMs <= 0 means "no client-side timeout": the call settles when the server replies
+      // or when the transport closes (failAllPending rejects every entry). Used by ObjectHandle.invoke
+      // so user-defined methods can take arbitrarily long without false TimeoutError rejections.
+
+      if (request.signal) {
+        pendingEntry.abortListener = () => {
+          if (this.pending.delete(id)) {
+            this.clearTimeoutHandle(pendingEntry);
+            reject(
+              new TransportError(
+                `call "${request.method}" aborted via AbortSignal (${this.url})`,
+              ),
+            );
+          }
+        };
+        request.signal.addEventListener("abort", pendingEntry.abortListener, { once: true });
+      }
+
+      this.pending.set(id, pendingEntry);
+
+      try {
+        this.socket!.send(JSON.stringify(envelope));
+      } catch (sendErr) {
+        if (this.pending.delete(id)) {
+          this.clearTimeoutHandle(pendingEntry);
+          this.detachAbort(pendingEntry);
+          reject(
+            new TransportError(`failed to send "${request.method}" (${this.url})`, {
+              cause: sendErr,
+            }),
+          );
+        }
+      }
+    });
+  }
+
+  onNotification(args: { method: string; handler: NotificationHandler }): CancelFn {
+    let handlers = this.notificationHandlers.get(args.method);
+    if (!handlers) {
+      handlers = new Set();
+      this.notificationHandlers.set(args.method, handlers);
+    }
+    handlers.add(args.handler);
+
+    return makeIdempotent(() => {
+      const set = this.notificationHandlers.get(args.method);
+      if (!set) return;
+      set.delete(args.handler);
+      if (set.size === 0) {
+        this.notificationHandlers.delete(args.method);
+      }
+    });
+  }
+
+  onDisconnect(handler: () => void): CancelFn {
+    this.disconnectHandlers.add(handler);
+    return makeIdempotent(() => {
+      this.disconnectHandlers.delete(handler);
+    });
+  }
+
+  onReconnect(handler: () => void): CancelFn {
+    this.reconnectHandlers.add(handler);
+    return makeIdempotent(() => {
+      this.reconnectHandlers.delete(handler);
+    });
+  }
+
+  onConnectionStateChange(handler: (state: ConnectionState) => void): CancelFn {
+    this.connectionStateHandlers.add(handler);
+    return makeIdempotent(() => {
+      this.connectionStateHandlers.delete(handler);
+    });
+  }
+
+  close(): void {
+    if (this.state === "closed") return;
+    const wasPreOpen = !this.hasEverConnected;
+    this.setState("closed");
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.failAllPending(new TransportError(`transport closed (${this.url})`));
+    if (this.socket) {
+      try {
+        this.socket.close();
+      } catch {
+        // ignore: best-effort
+      }
+      this.socket = null;
+    }
+    if (wasPreOpen) {
+      this.rejectOpen(
+        new TransportError(`transport closed before initial open (${this.url})`),
+      );
+    }
+  }
+
+  // -- internals -----------------------------------------------------------------------------
+
+  private openSocket(): void {
+    let socket: WebSocketLike;
+    try {
+      socket = this.factory(this.url);
+    } catch (err) {
+      if (!this.hasEverConnected && !this.retryInitialOpen) throw normalizeError(err);
+      if (this.state !== "reconnecting") this.setState("reconnecting");
+      this.scheduleReconnect();
+      return;
+    }
+    this.socket = socket;
+
+    socket.addEventListener("open", this.handleOpen);
+    socket.addEventListener("message", this.handleMessage);
+    socket.addEventListener("close", this.handleClose);
+    socket.addEventListener("error", this.handleError);
+  }
+
+  private readonly handleOpen = (): void => {
+    if (this.state === "closed") return;
+    const wasReconnecting = this.state === "reconnecting";
+    const isFirstOpen = !this.hasEverConnected;
+    this.setState("open");
+    this.reconnectAttempt = 0;
+    this.hasEverConnected = true;
+    if (wasReconnecting) {
+      this.fireSnapshot(this.reconnectHandlers);
+    }
+    if (isFirstOpen) {
+      this.resolveOpen();
+    }
+  };
+
+  private readonly handleMessage = (event: { data: unknown }): void => {
+    if (typeof event.data !== "string") return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(event.data);
+    } catch {
+      return;
+    }
+    if (!parsed || typeof parsed !== "object") return;
+    const message = parsed as Partial<JsonRpcSuccessResponse & JsonRpcErrorResponse & JsonRpcNotification>;
+
+    if (typeof message.id === "number") {
+      const entry = this.pending.get(message.id);
+      if (!entry) return;
+      this.pending.delete(message.id);
+      this.clearTimeoutHandle(entry);
+      this.detachAbort(entry);
+      if ("error" in message && message.error) {
+        entry.reject(new JsonRpcError(message.error.code, message.error.message, message.error.data));
+      } else if ("result" in message) {
+        entry.resolve(message.result);
+      } else {
+        entry.reject(new TransportError(`response for id ${message.id} has neither result nor error`));
+      }
+      return;
+    }
+
+    if (typeof message.method === "string") {
+      const handlers = this.notificationHandlers.get(message.method);
+      if (!handlers || handlers.size === 0) return;
+      // Snapshot in case a handler cancels itself during dispatch.
+      for (const handler of Array.from(handlers)) {
+        try {
+          handler(message.params);
+        } catch (err) {
+          this.reportError(normalizeError(err));
+        }
+      }
+    }
+  };
+
+  private readonly handleClose = (_event: { code: number; reason: string }): void => {
+    if (this.state === "closed") return;
+    this.socket = null;
+    const cause = this.lastWebSocketError ?? undefined;
+    this.lastWebSocketError = null;
+    const lostOpts: ErrorOptions = {};
+    if (cause !== undefined) lostOpts.cause = cause;
+    this.failAllPending(new TransportError(`connection lost (${this.url})`, lostOpts));
+    const shouldRetry =
+      this.reconnect.enabled && (this.hasEverConnected || this.retryInitialOpen);
+    if (shouldRetry) {
+      this.setState("reconnecting");
+      if (this.hasEverConnected) {
+        this.fireSnapshot(this.disconnectHandlers);
+      }
+      this.scheduleReconnect();
+    } else {
+      this.setState("closed");
+      if (this.hasEverConnected) {
+        this.fireSnapshot(this.disconnectHandlers);
+      } else {
+        const initOpts: ErrorOptions = {};
+        if (cause !== undefined) initOpts.cause = cause;
+        this.rejectOpen(new TransportError(`initial connect failed (${this.url})`, initOpts));
+      }
+    }
+  };
+
+  private readonly handleError = (event: unknown): void => {
+    this.lastWebSocketError = event;
+  };
+
+  private scheduleReconnect(): void {
+    if (this.state !== "reconnecting") return;
+    const delay = Math.min(
+      this.reconnect.initialDelayMs * Math.pow(this.reconnect.factor, this.reconnectAttempt),
+      this.reconnect.maxDelayMs,
+    );
+    this.reconnectAttempt += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.state !== "reconnecting") return;
+      this.openSocket();
+    }, delay);
+  }
+
+  private failAllPending(err: Error): void {
+    for (const entry of this.pending.values()) {
+      this.clearTimeoutHandle(entry);
+      this.detachAbort(entry);
+      entry.reject(err);
+    }
+    this.pending.clear();
+  }
+
+  private clearTimeoutHandle(entry: PendingCall): void {
+    if (entry.timeoutHandle !== null) {
+      clearTimeout(entry.timeoutHandle);
+      entry.timeoutHandle = null;
+    }
+  }
+
+  private detachAbort(entry: PendingCall): void {
+    if (entry.signal && entry.abortListener) {
+      entry.signal.removeEventListener("abort", entry.abortListener);
+      entry.abortListener = null;
+    }
+  }
+
+  private fireSnapshot(set: Set<() => void>): void {
+    const snapshot = Array.from(set);
+    for (const handler of snapshot) {
+      try {
+        handler();
+      } catch (err) {
+        this.reportError(normalizeError(err));
+      }
+    }
+  }
+
+  private setState(next: ConnectionState): void {
+    if (this.state === next) return;
+    this.state = next;
+    const snapshot = Array.from(this.connectionStateHandlers);
+    for (const handler of snapshot) {
+      try {
+        handler(next);
+      } catch (err) {
+        this.reportError(normalizeError(err));
+      }
+    }
+  }
+}

--- a/components/jsonrpc/clients/typescript/src/internal/type_cache.ts
+++ b/components/jsonrpc/clients/typescript/src/internal/type_cache.ts
@@ -1,0 +1,125 @@
+// === type_cache.ts ===================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { TransportError } from "../errors.js";
+import { defaultReportError } from "./report_error.js";
+import type { CustomTypeSpec, CustomTypeSpecList } from "../generated/index.js";
+import type { ReportError } from "../connect.js";
+
+/**
+ * Type-spec store for the Var parser. Filled from `interestUpdate.types` before any handle
+ * needs it, so consumers read it synchronously. Observers can subscribe via {@link subscribe}
+ * to be notified when the cache grows; the Client exposes this through `Client.onTypeAdded`.
+ *
+ * `derived` is a per-cache scratch space the Var codec uses for memoized lookups that depend
+ * on this cache's contents (e.g., flattened struct field lists). Per-cache because the result
+ * of those lookups varies with what's in this cache; a shared global WeakMap would leak stale
+ * results across caches with different parent sets.
+ */
+export class TypeCache {
+  private readonly cache = new Map<string, CustomTypeSpec>();
+  private readonly schemas = new Map<string, object>();
+  private readonly listeners = new Set<() => void>();
+  public readonly derived = new WeakMap<object, unknown>();
+
+  constructor(private readonly reportError: ReportError = defaultReportError) {}
+
+  get(qualifiedName: string): CustomTypeSpec | undefined {
+    return this.cache.get(qualifiedName);
+  }
+
+  /** JSON-Schema fragment for a qualified name, or undefined when the wire didn't ship one
+   *  (interest opened without `withSchemas` / type fetched without `withSchema`). */
+  getSchema(qualifiedName: string): object | undefined {
+    return this.schemas.get(qualifiedName);
+  }
+
+  /** Stores one schema fragment. Does not fire listeners on its own; schemas always arrive
+   *  alongside specs, so the spec-side `fire()` already covers observers. */
+  setSchema(qualifiedName: string, fragment: object): void {
+    this.schemas.set(qualifiedName, fragment);
+  }
+
+  /** Decodes the `typeSchemas` string from an `interestUpdate` (a JSON-encoded map keyed by
+   *  qualified name) and stores every fragment. Empty strings are no-ops. Malformed JSON is
+   *  surfaced via reportError rather than thrown: a bad schema must never break the wire-
+   *  delivery path, but a misbehaving server should not silently lose every schema either. */
+  setSchemasFromBlob(blob: string): void {
+    if (blob.length === 0) return;
+    try {
+      const parsed = JSON.parse(blob) as Record<string, object>;
+      for (const [qual, fragment] of Object.entries(parsed)) {
+        this.schemas.set(qual, fragment);
+      }
+    } catch (err) {
+      this.reportError(
+        new TransportError("interestUpdate.typeSchemas blob failed to parse as JSON", {
+          cause: err,
+        }),
+      );
+    }
+  }
+
+  set(spec: CustomTypeSpec): void {
+    const present = this.cache.has(spec.qualifiedName);
+    this.cache.set(spec.qualifiedName, spec);
+    if (!present) this.fire();
+  }
+
+  setMany(specs: CustomTypeSpecList): void {
+    if (specs.length === 0) return;
+    let added = false;
+    for (const spec of specs) {
+      if (!this.cache.has(spec.qualifiedName)) added = true;
+      this.cache.set(spec.qualifiedName, spec);
+    }
+    if (added) this.fire();
+  }
+
+  has(qualifiedName: string): boolean {
+    return this.cache.has(qualifiedName);
+  }
+
+  size(): number {
+    return this.cache.size;
+  }
+
+  values(): CustomTypeSpec[] {
+    return Array.from(this.cache.values());
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  /** Drop every subscriber. Called from `Client.close()` so listeners registered against
+   *  a closed client are released even when their owning React components stay mounted. */
+  clearListeners(): void {
+    this.listeners.clear();
+  }
+
+  /** Subscribe to cache growth. Fires once per batch in which at least one previously-unseen
+   *  type name was added; existing entries being overwritten don't fire. Returns an unsubscribe
+   *  function. Listeners that throw have their exception swallowed: an observer must never
+   *  break the wire-delivery path that fed the cache. */
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private fire(): void {
+    for (const listener of this.listeners) {
+      try {
+        listener();
+      } catch {
+        /* observer threw; ignore so the wire handler stays alive */
+      }
+    }
+  }
+}

--- a/components/jsonrpc/clients/typescript/src/internal/var_codec.ts
+++ b/components/jsonrpc/clients/typescript/src/internal/var_codec.ts
@@ -1,0 +1,433 @@
+// === var_codec.ts ====================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { TransportError } from "../errors.js";
+import { Quantity, Variant, type Var } from "../values.js";
+import type {
+  ClassTypeSpec,
+  CustomTypeSpec,
+  EnumTypeSpec,
+  OptionalTypeSpec,
+  QuantityTypeSpec,
+  SequenceTypeSpec,
+  StructTypeSpec,
+  VariantTypeFieldSpec,
+  VariantTypeSpec,
+} from "../generated/index.js";
+import type { TypeCache } from "./type_cache.js";
+
+// -- shared: built-in primitive type tags and helpers --------------------------------------------
+
+const builtInScalarTypes = new Set<string>([
+  "bool",
+  "string",
+  "i8",
+  "i16",
+  "i32",
+  "i64",
+  "u8",
+  "u16",
+  "u32",
+  "u64",
+  "f32",
+  "f64",
+  // TimeStamp arrives as an RFC-3339 ns string; Duration as a decimal-string nanosecond count.
+  "TimeStamp",
+  "Duration",
+]);
+
+const stringBuiltIns = new Set(["string", "TimeStamp", "Duration"]);
+// `i64`/`u64` cross the wire as JSON decimal strings to preserve precision above
+// `Number.MAX_SAFE_INTEGER`; consumers see `bigint`. Smaller integers + floats stay `number`.
+const numberBuiltIns = new Set(["i8", "i16", "i32", "u8", "u16", "u32", "f32", "f64"]);
+const bigintBuiltIns = new Set(["i64", "u64"]);
+
+interface FieldRef {
+  name: string;
+  type: string;
+}
+
+// `findArm` is purely a function of the spec (no cache reads), so a global WeakMap is safe.
+// `collectStructFields` reads parent specs from the cache, so its memo lives on the cache.
+const variantArmsCache = new WeakMap<VariantTypeSpec, Map<string, VariantTypeFieldSpec>>();
+
+/** Parent fields first, then child fields, so child wins on name collision. */
+function collectStructFields(
+  spec: StructTypeSpec,
+  cache: TypeCache,
+  startQualifiedName: string,
+  side: "parser" | "encoder",
+): FieldRef[] {
+  const cached = cache.derived.get(spec) as FieldRef[] | undefined;
+  if (cached) return cached;
+
+  const chain: StructTypeSpec[] = [];
+  let current: StructTypeSpec | undefined = spec;
+  const seen = new Set<string>();
+  seen.add(startQualifiedName);
+  while (current) {
+    chain.unshift(current);
+    if (!current.parent) break;
+    if (seen.has(current.parent)) {
+      throw new TransportError(`Var ${side}: cycle in struct parent chain at "${current.parent}"`);
+    }
+    seen.add(current.parent);
+    const parentSpec = cache.get(current.parent);
+    if (!parentSpec) {
+      throw new TransportError(`Var ${side}: parent struct "${current.parent}" not cached`);
+    }
+    if (parentSpec.data.type !== "sen.kernel.StructTypeSpec") {
+      throw new TransportError(`Var ${side}: parent "${current.parent}" is not a StructTypeSpec`);
+    }
+    current = parentSpec.data.value;
+  }
+  const fields: FieldRef[] = [];
+  for (const layer of chain) {
+    for (const field of layer.fields) {
+      fields.push({ name: field.name, type: field.type });
+    }
+  }
+  cache.derived.set(spec, fields);
+  return fields;
+}
+
+function findArm(spec: VariantTypeSpec, qualifiedName: string): VariantTypeFieldSpec | undefined {
+  let armMap = variantArmsCache.get(spec);
+  if (!armMap) {
+    armMap = new Map<string, VariantTypeFieldSpec>();
+    for (const f of spec.fields) {
+      armMap.set(f.type, f);
+    }
+    variantArmsCache.set(spec, armMap);
+  }
+  return armMap.get(qualifiedName);
+}
+
+// -- parser --------------------------------------------------------------------------------------
+
+/** Parse a JSON value into a `Var` driven by its declared type. Type spec must already be cached. */
+export function parseVar(typeName: string, raw: unknown, cache: TypeCache): Var {
+  if (builtInScalarTypes.has(typeName)) return parseBuiltIn(typeName, raw);
+  const spec = cache.get(typeName);
+  if (!spec) {
+    throw new TransportError(`Var parser: no type spec cached for "${typeName}"`);
+  }
+  return parseCustom(spec, raw, cache);
+}
+
+function parseBuiltIn(typeName: string, raw: unknown): Var {
+  if (typeName === "bool") return raw as boolean;
+  if (stringBuiltIns.has(typeName)) return raw as string;
+  if (numberBuiltIns.has(typeName)) return raw as number;
+  if (bigintBuiltIns.has(typeName)) {
+    if (typeof raw !== "string") {
+      throw new TransportError(
+        `Var parser: ${typeName} expected a decimal string, got ${typeof raw}`,
+      );
+    }
+    try {
+      return BigInt(raw);
+    } catch (err) {
+      throw new TransportError(
+        `Var parser: ${typeName} value ${JSON.stringify(raw)} is not a decimal integer`,
+        { cause: err },
+      );
+    }
+  }
+  throw new TransportError(`Var parser: unknown built-in type "${typeName}"`);
+}
+
+function parseCustom(spec: CustomTypeSpec, raw: unknown, cache: TypeCache): Var {
+  const qn = spec.qualifiedName;
+  switch (spec.data.type) {
+    case "sen.kernel.EnumTypeSpec":
+      return parseEnum(spec.data.value, raw, qn, cache);
+    case "sen.kernel.QuantityTypeSpec":
+      return parseQuantity(spec.data.value, raw, qn);
+    case "sen.kernel.SequenceTypeSpec":
+      return parseSequence(spec.data.value, raw, cache, qn);
+    case "sen.kernel.StructTypeSpec":
+      return parseStruct(spec.data.value, raw, cache, qn);
+    case "sen.kernel.VariantTypeSpec":
+      return parseVariant(spec.data.value, raw, cache, qn);
+    case "sen.kernel.AliasTypeSpec":
+      return parseVar(spec.data.value.aliasedType, raw, cache);
+    case "sen.kernel.OptionalTypeSpec":
+      return parseOptional(spec.data.value, raw, cache);
+    case "sen.kernel.ClassTypeSpec":
+      return classNotAValue(spec.data.value, qn, "parser");
+  }
+}
+
+function enumNames(spec: EnumTypeSpec, cache: TypeCache): Set<string> {
+  const cached = cache.derived.get(spec) as Set<string> | undefined;
+  if (cached) return cached;
+  const set = new Set(spec.enums.map((e) => e.name));
+  cache.derived.set(spec, set);
+  return set;
+}
+
+function parseEnum(spec: EnumTypeSpec, raw: unknown, qn: string, cache: TypeCache): Var {
+  if (typeof raw !== "string") {
+    throw new TransportError(`Var parser: enum "${qn}" expected a string, got ${typeof raw}`);
+  }
+  if (!enumNames(spec, cache).has(raw)) {
+    throw new TransportError(`Var parser: enum "${qn}" has no enumerator "${raw}"`);
+  }
+  return raw;
+}
+
+function parseQuantity(spec: QuantityTypeSpec, raw: unknown, qn: string): Var {
+  if (typeof raw !== "number") {
+    throw new TransportError(`Var parser: quantity "${qn}" expected a number, got ${typeof raw}`);
+  }
+  return new Quantity(raw, spec.unit, spec.minValue, spec.maxValue);
+}
+
+function parseSequence(spec: SequenceTypeSpec, raw: unknown, cache: TypeCache, qn: string): Var {
+  if (!Array.isArray(raw)) {
+    throw new TransportError(`Var parser: sequence "${qn}" expected an array, got ${typeof raw}`);
+  }
+  return raw.map((elem) => parseVar(spec.elementType, elem, cache));
+}
+
+function parseStruct(spec: StructTypeSpec, raw: unknown, cache: TypeCache, qn: string): Var {
+  const fields = collectStructFields(spec, cache, qn, "parser");
+  // Empty structs (e.g. variant arms with no payload like `struct SystemSleep;`) come across
+  // the wire as `null`. Accept that as an empty value.
+  if (raw === null && fields.length === 0) {
+    return {};
+  }
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    const shape = raw === null ? "null" : Array.isArray(raw) ? "array" : typeof raw;
+    throw new TransportError(`Var parser: struct "${qn}" expected an object, got ${shape}`);
+  }
+  const rawObj = raw as Record<string, unknown>;
+  const result: Record<string, Var> = {};
+  for (const field of fields) {
+    result[field.name] = parseVar(field.type, rawObj[field.name], cache);
+  }
+  return result;
+}
+
+function parseVariant(spec: VariantTypeSpec, raw: unknown, cache: TypeCache, qn: string): Var {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    const shape = raw === null ? "null" : Array.isArray(raw) ? "array" : typeof raw;
+    throw new TransportError(`Var parser: variant "${qn}" expected {type, value}, got ${shape}`);
+  }
+  const rawObj = raw as Record<string, unknown>;
+  const tag = rawObj["type"];
+  if (typeof tag !== "string") {
+    throw new TransportError(
+      `Var parser: variant "${qn}" requires string "type" tag, got ${typeof tag}`,
+    );
+  }
+  const arm = findArm(spec, tag);
+  if (!arm) {
+    throw new TransportError(`Var parser: variant "${qn}" has no arm matching tag "${tag}"`);
+  }
+  return new Variant(tag, parseVar(arm.type, rawObj["value"], cache));
+}
+
+function parseOptional(spec: OptionalTypeSpec, raw: unknown, cache: TypeCache): Var {
+  if (raw === null) return null;
+  return parseVar(spec.type, raw, cache);
+}
+
+// -- encoder -------------------------------------------------------------------------------------
+
+/** Inverse of `parseVar`. Accepts both runtime-class instances (Quantity, Variant) and plain objects. */
+export function encodeVar(typeName: string, value: unknown, cache: TypeCache): unknown {
+  if (builtInScalarTypes.has(typeName)) return encodeBuiltIn(typeName, value);
+  const spec = cache.get(typeName);
+  if (!spec) {
+    throw new TransportError(`Var encoder: no type spec cached for "${typeName}"`);
+  }
+  return encodeCustom(spec, value, cache);
+}
+
+/** Encode and stringify, ready for the wire. */
+export function encodeVarToWire(typeName: string, value: unknown, cache: TypeCache): string {
+  return JSON.stringify(encodeVar(typeName, value, cache));
+}
+
+function encodeBuiltIn(typeName: string, value: unknown): unknown {
+  if (typeName === "bool") {
+    if (typeof value !== "boolean") {
+      throw new TransportError(`Var encoder: type "${typeName}" expected boolean, got ${typeof value}`);
+    }
+    return value;
+  }
+  if (stringBuiltIns.has(typeName)) {
+    if (typeof value !== "string") {
+      throw new TransportError(`Var encoder: type "${typeName}" expected string, got ${typeof value}`);
+    }
+    return value;
+  }
+  if (numberBuiltIns.has(typeName)) {
+    if (typeof value !== "number") {
+      throw new TransportError(`Var encoder: type "${typeName}" expected number, got ${typeof value}`);
+    }
+    return value;
+  }
+  if (bigintBuiltIns.has(typeName)) {
+    let asBigInt: bigint;
+    if (typeof value === "bigint") {
+      asBigInt = value;
+    } else if (typeof value === "number") {
+      if (!Number.isInteger(value)) {
+        throw new TransportError(
+          `Var encoder: type "${typeName}" got non-integer number ${value}`,
+        );
+      }
+      if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER) {
+        throw new TransportError(
+          `Var encoder: type "${typeName}" got number ${value} outside safe-integer range; pass a bigint to preserve precision`,
+        );
+      }
+      asBigInt = BigInt(value);
+    } else {
+      throw new TransportError(
+        `Var encoder: type "${typeName}" expected bigint or safe-integer number, got ${typeof value}`,
+      );
+    }
+    if (typeName === "u64" && asBigInt < 0n) {
+      throw new TransportError(`Var encoder: type "u64" got negative value ${asBigInt}`);
+    }
+    return asBigInt.toString();
+  }
+  throw new TransportError(`Var encoder: unknown built-in type "${typeName}"`);
+}
+
+function encodeCustom(spec: CustomTypeSpec, value: unknown, cache: TypeCache): unknown {
+  const qn = spec.qualifiedName;
+  switch (spec.data.type) {
+    case "sen.kernel.EnumTypeSpec":
+      return encodeEnum(spec.data.value, value, qn, cache);
+    case "sen.kernel.QuantityTypeSpec":
+      return encodeQuantity(spec.data.value, value, qn);
+    case "sen.kernel.SequenceTypeSpec":
+      return encodeSequence(spec.data.value, value, cache, qn);
+    case "sen.kernel.StructTypeSpec":
+      return encodeStruct(spec.data.value, value, cache, qn);
+    case "sen.kernel.VariantTypeSpec":
+      return encodeVariant(spec.data.value, value, cache, qn);
+    case "sen.kernel.AliasTypeSpec":
+      return encodeVar(spec.data.value.aliasedType, value, cache);
+    case "sen.kernel.OptionalTypeSpec":
+      return encodeOptional(spec.data.value, value, cache);
+    case "sen.kernel.ClassTypeSpec":
+      return classNotAValue(spec.data.value, qn, "encoder");
+  }
+}
+
+function encodeEnum(spec: EnumTypeSpec, value: unknown, qn: string, cache: TypeCache): unknown {
+  if (typeof value !== "string") {
+    throw new TransportError(`Var encoder: enum "${qn}" expected a string, got ${typeof value}`);
+  }
+  if (!enumNames(spec, cache).has(value)) {
+    throw new TransportError(`Var encoder: enum "${qn}" has no enumerator "${value}"`);
+  }
+  return value;
+}
+
+function encodeQuantity(spec: QuantityTypeSpec, value: unknown, qn: string): unknown {
+  let numeric: number;
+  if (value instanceof Quantity) {
+    if (
+      value.unit.name !== spec.unit.name ||
+      value.unit.abbreviation !== spec.unit.abbreviation ||
+      value.unit.category !== spec.unit.category
+    ) {
+      const want = spec.unit.abbreviation || spec.unit.name;
+      const got = value.unit.abbreviation || value.unit.name;
+      throw new TransportError(
+        `Var encoder: quantity "${qn}" expects unit "${want}", got "${got}"`,
+      );
+    }
+    numeric = value.value;
+  } else if (typeof value === "number") {
+    numeric = value;
+  } else {
+    throw new TransportError(
+      `Var encoder: quantity "${qn}" expected a Quantity or number, got ${typeof value}`,
+    );
+  }
+  if (spec.minValue !== null && numeric < spec.minValue) {
+    throw new TransportError(
+      `Var encoder: quantity "${qn}" value ${numeric} below minimum ${spec.minValue}`,
+    );
+  }
+  if (spec.maxValue !== null && numeric > spec.maxValue) {
+    throw new TransportError(
+      `Var encoder: quantity "${qn}" value ${numeric} above maximum ${spec.maxValue}`,
+    );
+  }
+  return numeric;
+}
+
+function encodeSequence(spec: SequenceTypeSpec, value: unknown, cache: TypeCache, qn: string): unknown {
+  if (!Array.isArray(value)) {
+    throw new TransportError(`Var encoder: sequence "${qn}" expected an array, got ${typeof value}`);
+  }
+  return value.map((elem) => encodeVar(spec.elementType, elem, cache));
+}
+
+function encodeStruct(spec: StructTypeSpec, value: unknown, cache: TypeCache, qn: string): unknown {
+  const fields = collectStructFields(spec, cache, qn, "encoder");
+  // Empty struct (e.g. `struct SystemSleep;`) serializes as `null` on the wire; accept the
+  // editor's `{}` representation, and accept `null` round-tripped from the parser.
+  if (fields.length === 0) return null;
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    const shape = value === null ? "null" : Array.isArray(value) ? "array" : typeof value;
+    throw new TransportError(`Var encoder: struct "${qn}" expected an object, got ${shape}`);
+  }
+  const valueObj = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const field of fields) {
+    result[field.name] = encodeVar(field.type, valueObj[field.name], cache);
+  }
+  return result;
+}
+
+function encodeVariant(spec: VariantTypeSpec, value: unknown, cache: TypeCache, qn: string): unknown {
+  let tag: string;
+  let inner: unknown;
+  if (value instanceof Variant) {
+    tag = value.type;
+    inner = value.value;
+  } else if (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>)["type"] === "string"
+  ) {
+    const obj = value as Record<string, unknown>;
+    tag = obj["type"] as string;
+    inner = obj["value"];
+  } else {
+    throw new TransportError(
+      `Var encoder: variant "${qn}" expected a Variant or {type, value} object`,
+    );
+  }
+  const arm = findArm(spec, tag);
+  if (!arm) {
+    throw new TransportError(`Var encoder: variant "${qn}" has no arm matching tag "${tag}"`);
+  }
+  return { type: tag, value: encodeVar(arm.type, inner, cache) };
+}
+
+function encodeOptional(spec: OptionalTypeSpec, value: unknown, cache: TypeCache): unknown {
+  if (value === null || value === undefined) return null;
+  return encodeVar(spec.type, value, cache);
+}
+
+function classNotAValue(_spec: ClassTypeSpec, qn: string, side: "parser" | "encoder"): never {
+  throw new TransportError(
+    `Var ${side}: class "${qn}" is not a value type (object refs aren't embedded in Var)`,
+  );
+}

--- a/components/jsonrpc/clients/typescript/src/narrowing.ts
+++ b/components/jsonrpc/clients/typescript/src/narrowing.ts
@@ -1,0 +1,42 @@
+// === narrowing.ts ====================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { Quantity, Variant, type Var, type VarMap } from "./values.js";
+
+// Type guards for walking a `Var` of unknown shape. Use these instead of structural checks
+// at call sites; `Quantity` and `Variant` would otherwise look like plain objects.
+
+/** True if `v` is a {@link Quantity}. */
+export function isQuantity(v: Var): v is Quantity {
+  return v instanceof Quantity;
+}
+
+/** True if `v` is a {@link Variant}. */
+export function isVariant(v: Var): v is Variant {
+  return v instanceof Variant;
+}
+
+/** True if `v` is a plain struct (object with string keys, not a sequence, Quantity, or Variant). */
+export function isStruct(v: Var): v is VarMap {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    !Array.isArray(v) &&
+    !(v instanceof Quantity) &&
+    !(v instanceof Variant)
+  );
+}
+
+/** True if `v` is a sequence (array). */
+export function isSequence(v: Var): v is Var[] {
+  return Array.isArray(v);
+}
+
+/** True if `v` is a primitive: `string`, `number`, `boolean`, or `null`. */
+export function isPrimitive(v: Var): v is string | number | boolean | null {
+  return v === null || typeof v === "string" || typeof v === "number" || typeof v === "boolean";
+}

--- a/components/jsonrpc/clients/typescript/src/react/index.ts
+++ b/components/jsonrpc/clients/typescript/src/react/index.ts
@@ -1,0 +1,38 @@
+// === index.ts ========================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// Public entry point for the React adapter (`@sen/client/react`). Thin reactive bindings over
+// the Layer-3 surface; React is a peer dependency, kept out of the core import path so non-React
+// consumers pay no cost.
+
+export { useConnectionState } from "./use_connection_state.js";
+export { useEvents, type EventDelivery, type UseEventsOptions } from "./use_events.js";
+export { useInterest, type UseInterestArgs, type UseInterestResult } from "./use_interest.js";
+export { useInvoke, type InvokeStatus, type UseInvokeResult } from "./use_invoke.js";
+export { useObject } from "./use_object.js";
+export { useObjects } from "./use_objects.js";
+export { useProperty } from "./use_property.js";
+export { useSetProperty, type SetPropertyStatus, type UseSetPropertyResult } from "./use_set_property.js";
+export { useTopology, type UseTopologyResult } from "./use_topology.js";
+export { useTypeSpec } from "./use_type_spec.js";
+
+// Reactive store primitive. See `store/README.md` for the API surface.
+export {
+  makeStore,
+  makeBufferStore,
+  makeBufferCell,
+  useStore,
+  useSelector,
+  useView,
+  useViews,
+  useCell,
+  type Store,
+  type BufferStore,
+  type BufferStoreOptions,
+  type BufferCell,
+  type BufferCellOptions,
+} from "./store/index.js";

--- a/components/jsonrpc/clients/typescript/src/react/store/README.md
+++ b/components/jsonrpc/clients/typescript/src/react/store/README.md
@@ -1,0 +1,66 @@
+# Sen reactive store primitives
+
+Small reactive-state layer for `@sen/client/react`. Two flavors covering high-frequency
+mutable backing (sample buffers, event logs) and ordinary replaced-on-update state
+(selection, prefs, layout).
+
+```ts
+import {
+  makeStore, makeBufferStore, makeBufferCell,
+  useStore, useSelector, useView, useViews, useCell,
+} from "@sen/client/react";
+```
+
+## `makeStore<T>`
+
+Immutable replacement on update. `setState((prev) => next)`; if `next` is `Object.is`-equal
+to `prev`, no listener fires.
+
+`useStore(store)` returns the whole state. `useSelector(store, sel)` re-renders only when
+`sel`'s output changes by `Object.is`; return primitives, stable refs, or pre-cached
+derived values on the state object.
+
+## `makeBufferStore<K, V>`
+
+Per-key cached views over consumer-owned mutable backing. The consumer pushes into its
+own data structure and calls `invalidate(key)`; the store flushes notifications coalesced
+per `requestAnimationFrame` (pass `rafBatch: false` for synchronous flush in tests).
+
+```ts
+const store = makeBufferStore<PlotKey, BufferView>({
+  produce: (key) => viewOf(backing.get(key)) ?? EMPTY_VIEW,
+});
+
+pushToBuffer(buf, sample);
+store.invalidate(key);
+
+// React:
+const view = useView(store, key);   // single key
+const views = useViews(store, keys); // multi
+```
+
+`subscribeKey(key, fn)` fires only on that key. `subscribeAll(fn)` fires once per flush.
+`dropKey(key)` clears the cache entry silently (use on eviction / unsubscribe).
+
+## `makeBufferCell<T>`
+
+Single-key sugar over `makeBufferStore`. `invalidate()` with no key, `useCell(cell)` to
+read.
+
+## Mutable-backing gotcha
+
+The view returned from a buffer store wraps **live mutable data**. Reading per render or
+in a draw hook is safe. Stashing it in a ref to "freeze this moment" is not; later
+backing mutations will alter the data behind the ref. If you need a snapshot, copy at the
+boundary:
+
+```ts
+if (paused && ref.current === null) ref.current = liveEvents.slice();
+```
+
+## Conventions
+
+Actions are plain TS functions closing over the store: stable identity, no memoization
+needed. Selectors live alongside the store and return primitives or cached refs. Stores
+are module-scoped values; a Provider is only useful when the store has lifecycle (e.g. a
+retention-trim timer) or per-tree isolation is required.

--- a/components/jsonrpc/clients/typescript/src/react/store/index.ts
+++ b/components/jsonrpc/clients/typescript/src/react/store/index.ts
@@ -1,0 +1,24 @@
+// === index.ts ========================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// Reactive-store primitive for Sen-based React apps. Re-exported from `@sen/client/react`;
+// the typical consumer imports from there, not from this subpath directly.
+
+export { makeStore, type Store } from "./make_store.js";
+export {
+  makeBufferStore,
+  type BufferStore,
+  type BufferStoreOptions,
+} from "./make_buffer_store.js";
+export {
+  makeBufferCell,
+  type BufferCell,
+  type BufferCellOptions,
+} from "./make_buffer_cell.js";
+export { useStore, useSelector } from "./use_store.js";
+export { useView, useViews } from "./use_view.js";
+export { useCell } from "./use_cell.js";

--- a/components/jsonrpc/clients/typescript/src/react/store/make_buffer_cell.ts
+++ b/components/jsonrpc/clients/typescript/src/react/store/make_buffer_cell.ts
@@ -1,0 +1,59 @@
+// === make_buffer_cell.ts =============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import type { CancelFn } from "../../values.js";
+import { makeBufferStore, type BufferStoreOptions } from "./make_buffer_store.js";
+
+/**
+ * Single-cell buffer store: same semantics as {@link BufferStore} but with a single
+ * implicit key. Use this when there is no per-key dimension to the data (e.g., a global
+ * merged event log, a session-wide aggregate).
+ *
+ * @example
+ *   const allEvents: EventDelivery[] = [];
+ *   const cell = makeBufferCell({ produce: () => ({ events: allEvents }) });
+ *   // On append:
+ *   allEvents.push(event);
+ *   cell.invalidate();
+ *   // Consumer:
+ *   const { events } = cell.getView();
+ */
+export type BufferCellOptions<T> = Omit<BufferStoreOptions<symbol, T>, "produce"> & {
+  produce: () => T;
+};
+
+/** Single-cell variant of {@link BufferStore}. See {@link makeBufferCell}. */
+export interface BufferCell<T> {
+  /** Same reference until {@link invalidate} is called. */
+  getView(): T;
+  /** Schedule a flush; subscribers fire once per rAF (or synchronously when rafBatch is false). */
+  invalidate(): void;
+  /** Subscribe to invalidations. */
+  subscribe(listener: () => void): CancelFn;
+  /** Clear listeners and cancel any pending flush. */
+  dispose(): void;
+}
+
+/** The single sentinel key used by every {@link BufferCell} under the hood. */
+const CELL_KEY: unique symbol = Symbol("BufferCell");
+
+/**
+ * Create a {@link BufferCell}. Implemented as a thin wrapper over {@link makeBufferStore}
+ * with one sentinel key; no separate code path.
+ */
+export function makeBufferCell<T>(opts: BufferCellOptions<T>): BufferCell<T> {
+  const inner = makeBufferStore<symbol, T>({
+    produce: () => opts.produce(),
+    ...(opts.rafBatch !== undefined ? { rafBatch: opts.rafBatch } : {}),
+  });
+  return {
+    getView: () => inner.getView(CELL_KEY),
+    invalidate: () => inner.invalidate(CELL_KEY),
+    subscribe: (l) => inner.subscribeKey(CELL_KEY, l),
+    dispose: () => inner.dispose(),
+  };
+}

--- a/components/jsonrpc/clients/typescript/src/react/store/make_buffer_store.ts
+++ b/components/jsonrpc/clients/typescript/src/react/store/make_buffer_store.ts
@@ -1,0 +1,202 @@
+// === make_buffer_store.ts ============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import type { CancelFn } from "../../values.js";
+
+/**
+ * Per-key cached view store over mutable backing data, with rAF-coalesced notifications.
+ *
+ * Designed for high-frequency wire deliveries (property changes, event triggers, sample
+ * pushes) where the underlying buffers are mutated in place and consumers need a snapshot-
+ * style view that satisfies React 18's `useSyncExternalStore` stability requirements.
+ *
+ * The store does not own the backing data; the consumer manages its own storage and calls
+ * {@link BufferStore.invalidate} when a key's data has changed. The store caches the result
+ * of `produce(key)` until invalidation; the cached reference is what every consumer reads.
+ *
+ * `subscribeKey(key, fn)` fires when `key` is invalidated. `subscribeAll(fn)` fires once
+ * per flush (one rAF) regardless of how many keys were dirtied within that frame. Both are
+ * used by the React hooks ({@link useView}, {@link useViews}).
+ *
+ * @example
+ *   const buffers = new Map<string, number[]>();
+ *   const store = makeBufferStore<string, readonly number[]>({
+ *     produce: (key) => buffers.get(key) ?? [],
+ *   });
+ *   // High-frequency append from wire delivery:
+ *   buffers.get("x")!.push(value);
+ *   store.invalidate("x"); // coalesced into next rAF flush
+ */
+export interface BufferStoreOptions<K, V> {
+  /**
+   * Compute a view of `key`'s current backing data. Called on cache miss (first read after
+   * creation or after {@link BufferStore.invalidate}). Should be cheap: typically wraps the
+   * live mutable backing without copying. Consumers treat the returned `V` as immutable by
+   * convention.
+   */
+  produce: (key: K) => V;
+  /**
+   * Coalesce {@link BufferStore.invalidate} notifications into a single per-frame flush.
+   * Default: true. Set false for tests, SSR, or any non-browser environment without
+   * `requestAnimationFrame`; in that mode every `invalidate` fires listeners synchronously.
+   */
+  rafBatch?: boolean;
+}
+
+/** Per-key cached view store. See {@link makeBufferStore}. */
+export interface BufferStore<K, V> {
+  /**
+   * Return the cached view for `key`, computing it via the producer on cache miss. Same
+   * reference is returned for repeated calls until {@link invalidate} or {@link dropKey}
+   * is called for that key.
+   */
+  getView(key: K): V;
+  /**
+   * Mark `key`'s cached view as invalid. The cache entry is cleared on the next flush; on
+   * that same flush, per-key and global listeners fire. Default mode (`rafBatch: true`)
+   * batches all invalidations within a frame into one flush; set false at construction to
+   * flush synchronously.
+   */
+  invalidate(key: K): void;
+  /** Subscribe to invalidations of a specific key. */
+  subscribeKey(key: K, listener: () => void): CancelFn;
+  /**
+   * Subscribe to any invalidation. Fires once per flush regardless of how many keys were
+   * dirtied. Used for aggregate views (e.g. multi-key snapshots).
+   */
+  subscribeAll(listener: () => void): CancelFn;
+  /**
+   * Drop the cache entry for `key` without firing listeners. Used when the underlying
+   * backing for `key` has been released (eviction, unsubscribe). After dropKey, the next
+   * `getView(key)` re-runs the producer.
+   */
+  dropKey(key: K): void;
+  /**
+   * Current store version. Bumps once per flush (once per rAF batch regardless of how many
+   * keys were dirtied). Hooks that want to short-circuit per-render work without
+   * re-walking key sets (see {@link useViews}) cache this and skip when the version is
+   * unchanged.
+   */
+  getVersion(): number;
+  /** Cancel any pending rAF flush, clear all caches and listeners. */
+  dispose(): void;
+}
+
+/**
+ * Create a {@link BufferStore}. The producer is the only mandatory option; everything else
+ * has working defaults aimed at browser high-frequency consumers.
+ */
+export function makeBufferStore<K, V>(opts: BufferStoreOptions<K, V>): BufferStore<K, V> {
+  const cache = new Map<K, V>();
+  const keyListeners = new Map<K, Set<() => void>>();
+  const allListeners = new Set<() => void>();
+  const dirty = new Set<K>();
+  let rafId: number | null = null;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let disposed = false;
+  let version = 0;
+  const rafBatch = opts.rafBatch ?? true;
+
+  const fireSafely = (l: () => void): void => {
+    try {
+      l();
+    } catch (err) {
+      // One subscriber's exception must not break the rest of the flush fan-out. Logged
+      // (not swallowed) so the bug stays visible during development.
+      console.error("makeBufferStore: listener threw during flush", err);
+    }
+  };
+
+  const flush = (): void => {
+    rafId = null;
+    timeoutId = null;
+    if (dirty.size === 0) return;
+    // Bump version BEFORE notifications fire so subscribers that read `getVersion()` from
+    // inside their listener see the post-flush value.
+    version++;
+    const drained = Array.from(dirty);
+    dirty.clear();
+    for (const key of drained) {
+      cache.delete(key);
+      const set = keyListeners.get(key);
+      if (set) for (const l of set) fireSafely(l);
+    }
+    // Global listeners fire once after all per-key fan-out so a consumer of subscribeAll
+    // sees one notification per flush, not one per dirtied key.
+    for (const l of allListeners) fireSafely(l);
+  };
+
+  const schedule = (): void => {
+    if (!rafBatch) {
+      flush();
+      return;
+    }
+    if (rafId !== null || timeoutId !== null) return;
+    if (typeof requestAnimationFrame === "function") {
+      rafId = requestAnimationFrame(flush);
+    } else {
+      // Non-browser environment (Node test runner, SSR). Match rAF's 60-Hz cadence so timer
+      // tests behave like the browser path.
+      timeoutId = setTimeout(flush, 16);
+    }
+  };
+
+  return {
+    getView(key) {
+      if (cache.has(key)) return cache.get(key) as V;
+      const view = opts.produce(key);
+      cache.set(key, view);
+      return view;
+    },
+    invalidate(key) {
+      if (disposed) return;
+      dirty.add(key);
+      schedule();
+    },
+    subscribeKey(key, listener) {
+      let set = keyListeners.get(key);
+      if (!set) {
+        set = new Set();
+        keyListeners.set(key, set);
+      }
+      set.add(listener);
+      return () => {
+        const s = keyListeners.get(key);
+        if (!s) return;
+        s.delete(listener);
+        if (s.size === 0) keyListeners.delete(key);
+      };
+    },
+    subscribeAll(listener) {
+      allListeners.add(listener);
+      return () => {
+        allListeners.delete(listener);
+      };
+    },
+    dropKey(key) {
+      cache.delete(key);
+    },
+    getVersion() {
+      return version;
+    },
+    dispose() {
+      disposed = true;
+      if (rafId !== null && typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      cache.clear();
+      keyListeners.clear();
+      allListeners.clear();
+      dirty.clear();
+    },
+  };
+}

--- a/components/jsonrpc/clients/typescript/src/react/store/make_store.ts
+++ b/components/jsonrpc/clients/typescript/src/react/store/make_store.ts
@@ -1,0 +1,78 @@
+// === make_store.ts ===================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import type { CancelFn } from "../../values.js";
+
+/**
+ * Plain reactive store: holds a single value of type `T`, notifies subscribers when
+ * setState swaps the value to a non-Object.is-equal one, and exposes the current value
+ * through a stable getter.
+ *
+ * Lives outside React. Subscribe / read via the React hooks ({@link useStore},
+ * {@link useSelector}); non-React consumers can use {@link Store.subscribe} directly.
+ *
+ * `T` must not be a function type (the setState updater overload uses `typeof === "function"`
+ * to distinguish a value from an updater). All practical Sen-app state values are objects,
+ * primitives, or arrays.
+ *
+ * @example
+ *   const counter = makeStore({ count: 0 });
+ *   counter.setState((s) => ({ count: s.count + 1 }));
+ *   counter.getState(); // => { count: 1 }
+ */
+export interface Store<T> {
+  /** Current state. Same reference until {@link setState} swaps it for a non-equal value. */
+  getState(): T;
+  /**
+   * Replace the state. Accepts a new value directly or an updater function that receives
+   * the previous state. The updater can return the previous reference (or any Object.is-equal
+   * value) to no-op; in that case no listeners fire.
+   */
+  setState(updater: T | ((prev: T) => T)): void;
+  /** Subscribe to state changes. Returns a cancel function. */
+  subscribe(listener: () => void): CancelFn;
+  /**
+   * Clear all listeners and mark the store inert (subsequent setState calls are silently
+   * ignored). Optional for module-scoped stores (they live until page unload); useful for
+   * provider-scoped stores whose lifetime tracks a React component.
+   */
+  dispose(): void;
+}
+
+/**
+ * Create a {@link Store} seeded with `initial`. The store is just a value plus a listener
+ * set; no React involvement until a hook subscribes.
+ */
+export function makeStore<T>(initial: T): Store<T> {
+  let state = initial;
+  const listeners = new Set<() => void>();
+  let disposed = false;
+
+  return {
+    getState: () => state,
+    setState(updater) {
+      if (disposed) return;
+      const next =
+        typeof updater === "function"
+          ? (updater as (prev: T) => T)(state)
+          : updater;
+      if (Object.is(next, state)) return;
+      state = next;
+      for (const l of listeners) l();
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    dispose() {
+      disposed = true;
+      listeners.clear();
+    },
+  };
+}

--- a/components/jsonrpc/clients/typescript/src/react/store/use_cell.ts
+++ b/components/jsonrpc/clients/typescript/src/react/store/use_cell.ts
@@ -1,0 +1,25 @@
+// === use_cell.ts =====================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { useSyncExternalStore } from "react";
+
+import type { BufferCell } from "./make_buffer_cell.js";
+
+/**
+ * Subscribe to a {@link BufferCell}. Returns the cell's current view; re-renders only when
+ * the cell is invalidated.
+ *
+ * The cell wraps its data in a producer-returned shape (typically `{ items, ... }`); the
+ * consumer unwraps via the documented field. See {@link makeBufferCell} for the wrapper
+ * convention.
+ *
+ * @example
+ *   const { events } = useCell(allEventsCell);
+ */
+export function useCell<T>(cell: BufferCell<T>): T {
+  return useSyncExternalStore(cell.subscribe, cell.getView);
+}

--- a/components/jsonrpc/clients/typescript/src/react/store/use_store.ts
+++ b/components/jsonrpc/clients/typescript/src/react/store/use_store.ts
@@ -1,0 +1,93 @@
+// === use_store.ts ====================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { useCallback, useRef, useSyncExternalStore } from "react";
+
+import type { Store } from "./make_store.js";
+
+/**
+ * Subscribe to the whole state. The component re-renders whenever the store's state
+ * reference changes (`setState` calls that pass Object.is do not trigger re-renders).
+ *
+ * Prefer {@link useSelector} when reading a slice; selectors avoid re-rendering on state
+ * changes that don't affect the slice you actually consume.
+ */
+export function useStore<T>(store: Store<T>): T {
+  return useSyncExternalStore(store.subscribe, store.getState);
+}
+
+/**
+ * Memo-cell holding the last (state, selector, selected) triple the selector produced.
+ * Exposed for tests; the hook below threads it through a ref.
+ *
+ * Invalidation contract:
+ *  - If both `state` AND the `selector` reference are unchanged, return the cached
+ *    `selected` directly. (StrictMode-safe.)
+ *  - Otherwise the selector must run again. Inline-arrow selectors get a fresh closure
+ *    every render, and that closure may capture changed values (e.g. a different `key`).
+ *    Skipping the run because `state` alone is unchanged returns a stale slice keyed on
+ *    a previous capture.
+ *  - After re-running, if the new output is value-equal to the prior `selected`, keep the
+ *    prior `selected` reference but refresh the cached state + selector.
+ *
+ * @internal
+ */
+export function __selectorMemoStep<T, S>(
+  state: T,
+  selector: (state: T) => S,
+  memo: { state: T; selector: (state: T) => S; selected: S } | null,
+): { state: T; selector: (state: T) => S; selected: S } {
+  if (
+    memo !== null &&
+    Object.is(memo.state, state) &&
+    Object.is(memo.selector, selector)
+  ) {
+    return memo;
+  }
+  const next = selector(state);
+  if (memo !== null && Object.is(memo.selected, next)) {
+    return { state, selector, selected: memo.selected };
+  }
+  return { state, selector, selected: next };
+}
+
+/**
+ * Subscribe to a slice of state via a selector. Re-renders only when the selector's output
+ * changes by Object.is.
+ *
+ * The selector is called on every notification AND on every render; keep it cheap and pure
+ * (no side effects, no allocations of fresh references for unchanged input). Returning the
+ * same reference for value-equal results is what makes this hook efficient: a selector that
+ * returns `s.someBoolean` only re-renders consumers when that boolean actually flips, even
+ * if other parts of state change every frame.
+ *
+ * Selectors can change identity across renders (an inline arrow is fine); the hook tracks
+ * the latest selector via a ref so a per-render arrow doesn't trigger re-subscription.
+ *
+ * @example
+ *   const userName = useSelector(authStore, (s) => s.user?.name ?? "guest");
+ */
+export function useSelector<T, S>(store: Store<T>, selector: (state: T) => S): S {
+  // Track the latest selector across renders so per-render-arrow closures don't break
+  // memoization. We read it through the ref inside getSnapshot.
+  const selectorRef = useRef(selector);
+  selectorRef.current = selector;
+
+  // Memo cell: see __selectorMemoStep above.
+  const memoRef = useRef<{ state: T; selector: (state: T) => S; selected: S } | null>(null);
+
+  const getSnapshot = useCallback((): S => {
+    memoRef.current = __selectorMemoStep(
+      store.getState(),
+      selectorRef.current,
+      memoRef.current,
+    );
+    return memoRef.current.selected;
+  }, [store]);
+
+  return useSyncExternalStore(store.subscribe, getSnapshot);
+}

--- a/components/jsonrpc/clients/typescript/src/react/store/use_view.ts
+++ b/components/jsonrpc/clients/typescript/src/react/store/use_view.ts
@@ -1,0 +1,117 @@
+// === use_view.ts =====================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { useCallback, useRef, useSyncExternalStore } from "react";
+
+import type { BufferStore } from "./make_buffer_store.js";
+
+/**
+ * Subscribe to one key's view from a {@link BufferStore}. Re-renders when the store
+ * invalidates `key`. Passing `null` short-circuits to undefined and a no-op subscription,
+ * useful for conditional reads (e.g. `useView(store, name ? name : null)`).
+ *
+ * @example
+ *   const samples = useView(sampleStore, propertyKey);
+ *   // samples is the BufferView for that key, or undefined when propertyKey is null.
+ */
+export function useView<K, V>(store: BufferStore<K, V>, key: K | null): V | undefined {
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      if (key === null) return () => undefined;
+      return store.subscribeKey(key, listener);
+    },
+    [store, key],
+  );
+  const getSnapshot = useCallback((): V | undefined => {
+    if (key === null) return undefined;
+    return store.getView(key);
+  }, [store, key]);
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/**
+ * Subscribe to a set of keys from a {@link BufferStore}. Returns a Map keyed by `K` whose
+ * values are the per-key views; per-key view identities follow the store's cache, so
+ * unchanged keys keep stable references across renders.
+ *
+ * The returned Map identity stays stable across notifications that don't change any of the
+ * requested keys' values. The Map is rebuilt only when at least one key's view actually
+ * changed (or when the keys list contents change).
+ *
+ * Callers should memoize the `keys` array if it's computed from another collection;
+ * passing a fresh array per render still works but skips the Map-identity-stability
+ * optimization (the hook walks the keys to detect changes regardless).
+ *
+ * @example
+ *   const keys = useMemo(() => series.map(seriesKey), [series]);
+ *   const views = useViews(sampleStore, keys);
+ *   for (const k of keys) {
+ *     const v = views.get(k);
+ *     // ...
+ *   }
+ */
+export function useViews<K, V>(store: BufferStore<K, V>, keys: readonly K[]): ReadonlyMap<K, V> {
+  // Track the latest keys via ref so an inline-array caller doesn't re-subscribe to
+  // subscribeAll on every render. subscribe identity only flips on store change.
+  const keysRef = useRef(keys);
+  keysRef.current = keys;
+
+  const subscribe = useCallback(
+    (listener: () => void) => store.subscribeAll(listener),
+    [store],
+  );
+
+  // Map cache: returned Map is reused as long as every requested key's view is identical
+  // to the previous render's.
+  //
+  // Two-tier short-circuit:
+  //  - **Version + keys-ref fast path**: when the store version is unchanged AND the caller
+  //    passed the same keys array as last render, return the cached Map without walking
+  //    the keys list. This is the dominant case (parent re-renders without any store
+  //    notification, e.g. unrelated state change in a sibling).
+  //  - **Walk-detection path**: when version OR keys-ref changed, walk the keys to compare
+  //    each cached value against the store's current view. Allocate a fresh Map only when
+  //    something actually changed.
+  const memoRef = useRef<{
+    map: ReadonlyMap<K, V>;
+    version: number;
+    keys: readonly K[];
+  } | null>(null);
+
+  const getSnapshot = useCallback((): ReadonlyMap<K, V> => {
+    const ks = keysRef.current;
+    const currentVersion = store.getVersion();
+    const cached = memoRef.current;
+    // Fast path: nothing has changed since the last render.
+    if (cached !== null && cached.version === currentVersion && cached.keys === ks) {
+      return cached.map;
+    }
+    // Walk-detection: either the store changed or the keys array did.
+    let needsRebuild = cached === null || cached.map.size !== ks.length;
+    if (!needsRebuild) {
+      for (const k of ks) {
+        if ((cached as { map: ReadonlyMap<K, V> }).map.get(k) !== store.getView(k)) {
+          needsRebuild = true;
+          break;
+        }
+      }
+    }
+    if (!needsRebuild) {
+      // Walk confirmed no change. Refresh the cached version + keys ref so the fast path
+      // hits next time, but reuse the Map.
+      const cachedMap = (cached as { map: ReadonlyMap<K, V> }).map;
+      memoRef.current = { map: cachedMap, version: currentVersion, keys: ks };
+      return cachedMap;
+    }
+    const next = new Map<K, V>();
+    for (const k of ks) next.set(k, store.getView(k));
+    memoRef.current = { map: next, version: currentVersion, keys: ks };
+    return next;
+  }, [store]);
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/components/jsonrpc/clients/typescript/src/react/use_connection_state.ts
+++ b/components/jsonrpc/clients/typescript/src/react/use_connection_state.ts
@@ -1,0 +1,27 @@
+// === use_connection_state.ts =========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { useEffect, useState } from "react";
+
+import type { Client, ConnectionState } from "../index.js";
+
+/**
+ * Reactive view of `client.connectionState`. Returns the current state and re-renders on every
+ * transition. When `client` is `null`, returns `"connecting"` (the initial state of a freshly
+ * created client) so consumers can render a placeholder while `connect()` is in flight.
+ */
+export function useConnectionState(client: Client | null): ConnectionState {
+  const [state, setState] = useState<ConnectionState>(() => client?.connectionState ?? "connecting");
+
+  useEffect(() => {
+    if (!client) return;
+    setState(client.connectionState);
+    return client.onConnectionStateChange(setState);
+  }, [client]);
+
+  return state;
+}

--- a/components/jsonrpc/clients/typescript/src/react/use_events.ts
+++ b/components/jsonrpc/clients/typescript/src/react/use_events.ts
@@ -1,0 +1,70 @@
+// === use_events.ts ===================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { useEffect, useState } from "react";
+
+import type { ObjectHandle, Var } from "../index.js";
+
+/** One delivery of an event. */
+export interface EventDelivery {
+  args: Var[];
+  /** Server-side emission timestamp (kernel `EventInfo.creationTime`); wire string format. */
+  timestamp: string;
+  /** Local-wall-clock ms at which the React handler saw the delivery. Use for relative
+   *  ordering when wire timestamps are missing or unreliable. */
+  at: number;
+}
+
+/** Bounded ring of recent deliveries. */
+export interface UseEventsOptions {
+  /** Cap on the returned array; older entries fall off the front. Default 200. */
+  max?: number;
+  /** Optional predicate evaluated on the wire-side handler; deliveries returning `false`
+   *  are dropped before the React state update, so they don't trigger a re-render or count
+   *  against `max`. Useful for narrow consumers (e.g. only events whose first arg matches
+   *  a target). */
+  filter?: (delivery: EventDelivery) => boolean;
+}
+
+/**
+ * Subscribe to one named event on an object and keep a bounded ring of recent deliveries.
+ * Returns the newest-last array; `obj === null` returns an empty array. The full retention
+ * model from the brief (large virtualized buffer) lives in the explorer's events view,
+ * not in this leaf hook.
+ *
+ * Every accepted delivery triggers a React state update + array reallocation; fine for
+ * dashboards/logs at human-readable rates. For high-rate streams (sensors, chart sources)
+ * use `makeBufferStore` + a narrow `useView` selector; see `react/store/README.md`.
+ */
+export function useEvents(
+  obj: ObjectHandle | null,
+  name: string,
+  opts: UseEventsOptions = {},
+): EventDelivery[] {
+  const [log, setLog] = useState<EventDelivery[]>([]);
+  const max = opts.max ?? 200;
+  const filter = opts.filter;
+
+  useEffect(() => {
+    if (!obj) {
+      setLog([]);
+      return;
+    }
+    setLog([]);
+    return obj.onEventTriggered(name, (args, info) => {
+      const delivery: EventDelivery = { args, timestamp: info.timestamp, at: Date.now() };
+      if (filter && !filter(delivery)) return;
+      setLog((prev) => {
+        const next = prev.length >= max ? prev.slice(prev.length - max + 1) : prev.slice();
+        next.push(delivery);
+        return next;
+      });
+    });
+  }, [obj, name, max, filter]);
+
+  return log;
+}

--- a/components/jsonrpc/clients/typescript/src/react/use_interest.ts
+++ b/components/jsonrpc/clients/typescript/src/react/use_interest.ts
@@ -1,0 +1,79 @@
+// === use_interest.ts =================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import type { Client, InterestHandle, PreSubscription } from "../index.js";
+
+/** Inputs to {@link useInterest}; `name` must be unique for the lifetime of the client. */
+export interface UseInterestArgs {
+  name: string;
+  query: string;
+  subscribe?: PreSubscription;
+}
+
+/** What {@link useInterest} returns. `error` is set when `declareInterest` rejects. */
+export interface UseInterestResult {
+  handle: InterestHandle | null;
+  error: Error | null;
+}
+
+/**
+ * Declares an interest for the lifetime of the calling component and releases it on unmount.
+ * Re-declares when `name`, `query`, or `subscribe` change. Use {@link useObjects} or
+ * {@link useObject} to react to the match set; this hook is only the lifecycle wrapper.
+ */
+export function useInterest(client: Client | null, args: UseInterestArgs): UseInterestResult {
+  const [handle, setHandle] = useState<InterestHandle | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Stabilize `subscribe` on content rather than reference so callers can pass an inline
+  // object without forcing release+re-declare on every render. JSON.stringify only runs when
+  // the reference itself changes; a memoized parent pays the cost once.
+  const subKeyRef = useRef<{ ref: PreSubscription | undefined; key: string }>({
+    ref: undefined,
+    key: "null",
+  });
+  if (!Object.is(subKeyRef.current.ref, args.subscribe)) {
+    subKeyRef.current = { ref: args.subscribe, key: JSON.stringify(args.subscribe ?? null) };
+  }
+  const subscribeKey = subKeyRef.current.key;
+  const subscribe = useMemo(() => args.subscribe, [subscribeKey]);
+
+  useEffect(() => {
+    if (!client) return;
+    let released = false;
+    let local: InterestHandle | null = null;
+    setError(null);
+    setHandle(null);
+
+    (async () => {
+      try {
+        local = await client.declareInterest({
+          name: args.name,
+          query: args.query,
+          ...(subscribe !== undefined ? { subscribe } : {}),
+        });
+        if (released) {
+          await local.release();
+          return;
+        }
+        setHandle(local);
+      } catch (err) {
+        if (!released) setError(err instanceof Error ? err : new Error(String(err)));
+      }
+    })();
+
+    return () => {
+      released = true;
+      setHandle(null);
+      void local?.release();
+    };
+  }, [client, args.name, args.query, subscribe]);
+
+  return { handle, error };
+}

--- a/components/jsonrpc/clients/typescript/src/react/use_invoke.ts
+++ b/components/jsonrpc/clients/typescript/src/react/use_invoke.ts
@@ -1,0 +1,69 @@
+// === use_invoke.ts ===================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { useCallback, useState } from "react";
+
+import type { CallOptions, ObjectHandle, Var } from "../index.js";
+
+/** State of the most recent invoke call. `idle` until the first call. */
+export type InvokeStatus = "idle" | "pending" | "ok" | "error";
+
+export interface UseInvokeResult {
+  invoke: (method: string, args?: Record<string, unknown>, opts?: CallOptions) => Promise<Var>;
+  /** Return `status` to `idle` and clear `result` / `error`. For dismissing a sticky error
+   *  on an Invoke button without issuing a new call. No-op when status is already `idle`. */
+  reset: () => void;
+  status: InvokeStatus;
+  result: Var | undefined;
+  error: Error | null;
+}
+
+/**
+ * Wraps `obj.invoke()` with reactive pending/result/error state suitable for an Invoke
+ * button in a method form. The library validates argument names against the method's
+ * declared signature before the call goes on the wire; that and any backend rejection both
+ * surface here as `status: "error"` with the original `error` set.
+ */
+export function useInvoke(obj: ObjectHandle | null): UseInvokeResult {
+  const [status, setStatus] = useState<InvokeStatus>("idle");
+  const [result, setResult] = useState<Var | undefined>(undefined);
+  const [error, setError] = useState<Error | null>(null);
+
+  const invoke = useCallback(
+    async (method: string, args?: Record<string, unknown>, opts?: CallOptions): Promise<Var> => {
+      if (!obj) {
+        const err = new Error("useInvoke: object handle is null");
+        setStatus("error");
+        setError(err);
+        throw err;
+      }
+      setStatus("pending");
+      setError(null);
+      setResult(undefined);
+      try {
+        const r = await obj.invoke(method, args ?? {}, opts ?? {});
+        setResult(r);
+        setStatus("ok");
+        return r;
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error(String(err));
+        setStatus("error");
+        setError(e);
+        throw e;
+      }
+    },
+    [obj],
+  );
+
+  const reset = useCallback(() => {
+    setStatus("idle");
+    setResult(undefined);
+    setError(null);
+  }, []);
+
+  return { invoke, reset, status, result, error };
+}

--- a/components/jsonrpc/clients/typescript/src/react/use_object.ts
+++ b/components/jsonrpc/clients/typescript/src/react/use_object.ts
@@ -1,0 +1,43 @@
+// === use_object.ts ===================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { useEffect, useState } from "react";
+
+import type { InterestHandle, ObjectHandle } from "../index.js";
+
+/**
+ * Track a single named object within an interest. Returns the current handle (or `undefined`
+ * if the name isn't in the match set). Re-renders when the object enters or leaves the set.
+ *
+ * The lookup is read synchronously on every render (never trailed through `useState`) so
+ * when `name` or `interest` change the returned handle reflects the new identity in the very
+ * same render. The kept state is purely a re-render trigger for add/remove notifications;
+ * shadowing the lookup in state would let a consumer see a stale handle for one render after
+ * a `name` change, which causes subscriptions intended for the new object to land on the old
+ * one (e.g. an event subscription with the new class's event name issued against the
+ * previous object; the server then rejects it as "unknown event").
+ */
+export function useObject(interest: InterestHandle | null, name: string): ObjectHandle | undefined {
+  const [, forceRender] = useState(0);
+
+  useEffect(() => {
+    if (!interest) return;
+    const bump = () => forceRender((n) => n + 1);
+    const cancelAdded = interest.onObjectAdded((o) => {
+      if (o.name === name) bump();
+    });
+    const cancelRemoved = interest.onObjectRemoved((removedName) => {
+      if (removedName === name) bump();
+    });
+    return () => {
+      cancelAdded();
+      cancelRemoved();
+    };
+  }, [interest, name]);
+
+  return interest?.objectByName(name);
+}

--- a/components/jsonrpc/clients/typescript/src/react/use_objects.ts
+++ b/components/jsonrpc/clients/typescript/src/react/use_objects.ts
@@ -1,0 +1,47 @@
+// === use_objects.ts ==================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { useCallback, useSyncExternalStore } from "react";
+
+import type { InterestHandle, ObjectHandle } from "../index.js";
+
+/**
+ * Reactive view of an interest's currently-matched object set. The returned array reference
+ * is stable across renders until the interest's membership actually changes (an object is
+ * added or removed); downstream `useMemo([objects, ...])` calls see a stable dep and hit
+ * their memo cache. Returns the empty array (stable reference) when `interest` is null.
+ *
+ * Backed by `useSyncExternalStore` over the interest's `onObjectAdded` / `onObjectRemoved`
+ * signals plus `InterestHandle.objects()`, which the Layer-3 handle now caches between
+ * mutations. The hook does not need to allocate any state of its own.
+ */
+const EMPTY_OBJECTS: readonly ObjectHandle[] = Object.freeze([]);
+
+export function useObjects(interest: InterestHandle | null): ObjectHandle[] {
+  const subscribe = useCallback(
+    (listener: () => void): (() => void) => {
+      if (!interest) return () => undefined;
+      // onObjectAdded fires synchronously for every existing match during subscribe; that's
+      // fine for our purposes (useSyncExternalStore re-reads getSnapshot and skips re-render
+      // when the cached array reference is unchanged).
+      const cancelAdded = interest.onObjectAdded(listener);
+      const cancelRemoved = interest.onObjectRemoved(listener);
+      return () => {
+        cancelAdded();
+        cancelRemoved();
+      };
+    },
+    [interest],
+  );
+
+  const getSnapshot = useCallback(
+    (): ObjectHandle[] => (interest ? interest.objects() : (EMPTY_OBJECTS as ObjectHandle[])),
+    [interest],
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/components/jsonrpc/clients/typescript/src/react/use_property.ts
+++ b/components/jsonrpc/clients/typescript/src/react/use_property.ts
@@ -1,0 +1,26 @@
+// === use_property.ts =================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { useEffect, useState } from "react";
+
+import type { ObjectHandle, Var } from "../index.js";
+
+/**
+ * Subscribe to one property on an object. Returns `undefined` until the first server push,
+ * then the latest value. Unsubscribes on unmount or when `obj` / `name` change.
+ */
+export function useProperty(obj: ObjectHandle | null, name: string): Var | undefined {
+  const [value, setValue] = useState<Var | undefined>(undefined);
+
+  useEffect(() => {
+    if (!obj) return;
+    setValue(undefined);
+    return obj.onPropertyChanged(name, setValue);
+  }, [obj, name]);
+
+  return value;
+}

--- a/components/jsonrpc/clients/typescript/src/react/use_set_property.ts
+++ b/components/jsonrpc/clients/typescript/src/react/use_set_property.ts
@@ -1,0 +1,55 @@
+// === use_set_property.ts =============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { useCallback, useState } from "react";
+
+import type { CallOptions, ObjectHandle } from "../index.js";
+
+/** State of the most recent setProperty call. `idle` until the first call. */
+export type SetPropertyStatus = "idle" | "pending" | "ok" | "error";
+
+export interface UseSetPropertyResult {
+  setProperty: (name: string, value: unknown, opts?: CallOptions) => Promise<void>;
+  status: SetPropertyStatus;
+  error: Error | null;
+}
+
+/**
+ * Wraps `obj.set()` with reactive pending/error state suitable for an Apply button. The
+ * library validates the value against the property's wire type and rejects with
+ * {@link JsonRpcError} for non-writable properties; both surface here as `status: "error"`
+ * with the original `error` set.
+ */
+export function useSetProperty(obj: ObjectHandle | null): UseSetPropertyResult {
+  const [status, setStatus] = useState<SetPropertyStatus>("idle");
+  const [error, setError] = useState<Error | null>(null);
+
+  const setProperty = useCallback(
+    async (name: string, value: unknown, opts?: CallOptions): Promise<void> => {
+      if (!obj) {
+        const err = new Error("useSetProperty: object handle is null");
+        setStatus("error");
+        setError(err);
+        throw err;
+      }
+      setStatus("pending");
+      setError(null);
+      try {
+        await obj.set(name, value, opts ?? {});
+        setStatus("ok");
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error(String(err));
+        setStatus("error");
+        setError(e);
+        throw e;
+      }
+    },
+    [obj],
+  );
+
+  return { setProperty, status, error };
+}

--- a/components/jsonrpc/clients/typescript/src/react/use_topology.ts
+++ b/components/jsonrpc/clients/typescript/src/react/use_topology.ts
@@ -1,0 +1,41 @@
+// === use_topology.ts =================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { useEffect, useState } from "react";
+
+import type { Client, SessionInfo } from "../index.js";
+
+export interface UseTopologyResult {
+  sessions: SessionInfo[];
+  /** True until the first snapshot arrives. */
+  loading: boolean;
+}
+
+/**
+ * Reactive view of the connection's session/bus topology. Mounts a subscription to
+ * `client.onTopologyChanged` and re-renders on every change. While `client` is `null` or
+ * the initial snapshot hasn't arrived yet, `loading` is `true` and `sessions` is empty.
+ */
+export function useTopology(client: Client | null): UseTopologyResult {
+  const [sessions, setSessions] = useState<SessionInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!client) {
+      setSessions([]);
+      setLoading(true);
+      return;
+    }
+    setLoading(true);
+    return client.onTopologyChanged((next) => {
+      setSessions(next);
+      setLoading(false);
+    });
+  }, [client]);
+
+  return { sessions, loading };
+}

--- a/components/jsonrpc/clients/typescript/src/react/use_type_spec.ts
+++ b/components/jsonrpc/clients/typescript/src/react/use_type_spec.ts
@@ -1,0 +1,36 @@
+// === use_type_spec.ts ================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { useEffect, useState } from "react";
+
+import type { Client, CustomTypeSpec } from "../index.js";
+
+/**
+ * Reactive lookup for a `CustomTypeSpec` by qualified name. Returns the spec if cached now,
+ * `undefined` otherwise; re-renders when the spec lands in the cache.
+ */
+export function useTypeSpec(
+  client: Client | null,
+  qualifiedName: string | null,
+): CustomTypeSpec | undefined {
+  const [spec, setSpec] = useState<CustomTypeSpec | undefined>(() =>
+    client && qualifiedName ? client.getType(qualifiedName) : undefined,
+  );
+
+  useEffect(() => {
+    if (!client || !qualifiedName) {
+      setSpec(undefined);
+      return;
+    }
+    setSpec(client.getType(qualifiedName));
+    return client.onTypeAdded(() => {
+      setSpec(client.getType(qualifiedName));
+    });
+  }, [client, qualifiedName]);
+
+  return spec;
+}

--- a/components/jsonrpc/clients/typescript/src/values.ts
+++ b/components/jsonrpc/clients/typescript/src/values.ts
@@ -1,0 +1,108 @@
+// === values.ts =======================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import type { UnitInfo } from "./generated/index.js";
+
+/** Cancel function returned by subscribe-shaped APIs. Idempotent. */
+export type CancelFn = () => void;
+
+/**
+ * A numeric value paired with its unit. `minValue` and `maxValue` come from the type spec
+ * (the STL definition) and may be `null` if unconstrained.
+ *
+ * @example
+ * ```ts
+ * const altitude = await aircraft.get("altitude");
+ * if (isQuantity(altitude)) {
+ *   console.log(`${altitude.value} ${altitude.unit.abbreviation}`);
+ * }
+ * ```
+ */
+export class Quantity {
+  constructor(
+    public readonly value: number,
+    public readonly unit: UnitInfo,
+    public readonly minValue: number | null = null,
+    public readonly maxValue: number | null = null,
+  ) {}
+
+  /** Render as `<value> <abbreviation>` (e.g. `"100 m"`), or just `<value>` if no abbreviation. */
+  toString(): string {
+    return this.unit.abbreviation ? `${this.value} ${this.unit.abbreviation}` : String(this.value);
+  }
+
+  /** Structural equality across value, unit, and bounds. */
+  equals(other: Quantity): boolean {
+    return (
+      this.value === other.value &&
+      this.unit.name === other.unit.name &&
+      this.unit.abbreviation === other.unit.abbreviation &&
+      this.unit.category === other.unit.category &&
+      this.minValue === other.minValue &&
+      this.maxValue === other.maxValue
+    );
+  }
+}
+
+/**
+ * A tagged union value: pick which arm with `type`, the payload is `value`. Kept distinct from
+ * a plain struct so `instanceof` narrowing works and code can tell `{type, value}` payloads
+ * apart from structs that happen to have those field names.
+ *
+ * @example
+ * ```ts
+ * const status = await student.get("status");
+ * if (isVariant(status)) {
+ *   if (status.type === "Sleeping") console.log("zzz");
+ * }
+ * ```
+ */
+export class Variant<T = unknown> {
+  constructor(
+    public readonly type: string,
+    public readonly value: T,
+  ) {}
+}
+
+/**
+ * Any value the library returns (property reads, event args, method results). TypeScript analogue
+ * of C++ `sen::Var`. Enums appear as bare strings; `i64` / `u64` properties appear as `bigint`
+ * (they cross the wire as decimal strings to preserve precision past `Number.MAX_SAFE_INTEGER`).
+ */
+export type Var =
+  | string
+  | number
+  | bigint
+  | boolean
+  | null
+  | Var[]
+  | { [field: string]: Var }
+  | Variant
+  | Quantity;
+
+/**
+ * Narrow a `bigint` (typically from a `u64` / `i64` property) down to a `number`, throwing
+ * `RangeError` if the value would lose precision (outside `[Number.MIN_SAFE_INTEGER,
+ * MAX_SAFE_INTEGER]`). `context` is included in the error message.
+ *
+ * Use at boundaries where downstream APIs need a `number` (uPlot x-axes, `Date(ms)`,
+ * ms-range counters). Implicit `bigint -> number` is already a TS type error; this is the
+ * loud explicit downgrade.
+ */
+export function numberFromExact(value: bigint, context?: string): number {
+  if (value > BigInt(Number.MAX_SAFE_INTEGER) || value < BigInt(Number.MIN_SAFE_INTEGER)) {
+    const where = context ? ` (${context})` : "";
+    throw new RangeError(`Cannot represent ${value} as a safe Number${where}`);
+  }
+  return Number(value);
+}
+
+/** Sequence of `Var`s. */
+export type VarList = Var[];
+
+/** String-keyed map of `Var`s. */
+export type VarMap = { [field: string]: Var };

--- a/components/jsonrpc/clients/typescript/test/client.test.ts
+++ b/components/jsonrpc/clients/typescript/test/client.test.ts
@@ -1,0 +1,564 @@
+// === client.test.ts ==================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, vi } from "vitest";
+import { connect } from "../src/connect.js";
+import { TransportError } from "../src/errors.js";
+import type { WebSocketFactory } from "../src/internal/transport.js";
+import { MockWebSocket, tick } from "./test_helpers/mock_websocket.js";
+import type { InterestUpdateNotification } from "../src/index.js";
+
+/** Make a connect() call that uses the mock factory and let it open. */
+async function makeConnectedClient() {
+  const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+  const pending = connect({
+    url: "ws://test",
+    reconnect: { enabled: false },
+      onError: () => undefined,
+    webSocketFactory: factory,
+  });
+  // simulate open on the just-created socket
+  await tick();
+  MockWebSocket.lastInstance!.simulateOpen();
+  const client = await pending;
+  const socket = MockWebSocket.lastInstance!;
+  return { client, socket };
+}
+
+describe("connect()", () => {
+  it("resolves with a Client once the wire is open", async () => {
+    const { client } = await makeConnectedClient();
+    expect(client.connectionState).toBe("open");
+    client.close();
+  });
+
+  it("rejects with TransportError if the initial connect closes before opening", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const pending = connect({
+      url: "ws://test",
+      reconnect: { enabled: false },
+      onError: () => undefined,
+      webSocketFactory: factory,
+    });
+    await tick();
+    MockWebSocket.lastInstance!.simulateClose(1006, "server down");
+    await expect(pending).rejects.toBeInstanceOf(TransportError);
+  });
+
+  it("rejects with TransportError if openTimeoutMs elapses", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const pending = connect({
+      url: "ws://test",
+      reconnect: { enabled: false },
+      openTimeoutMs: 20,
+      onError: () => undefined,
+      webSocketFactory: factory,
+    });
+    // never simulate open
+    await expect(pending).rejects.toBeInstanceOf(TransportError);
+    await expect(pending).rejects.toThrow(/timed out/);
+  });
+
+});
+
+describe("Client lifecycle", () => {
+  it("close() transitions to 'closed' state", async () => {
+    const { client } = await makeConnectedClient();
+    client.close();
+    expect(client.connectionState).toBe("closed");
+  });
+
+  it("onDisconnect fires on unexpected wire loss", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const disconnected = vi.fn();
+    client.onDisconnect(disconnected);
+    socket.simulateClose(1006);
+    expect(disconnected).toHaveBeenCalledTimes(1);
+    client.close();
+  });
+
+  it("onDisconnect does NOT fire on explicit close()", async () => {
+    const { client } = await makeConnectedClient();
+    const disconnected = vi.fn();
+    client.onDisconnect(disconnected);
+    client.close();
+    await tick();
+    expect(disconnected).not.toHaveBeenCalled();
+  });
+
+  it("onReconnect fires after a successful reconnect, not on initial open", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const pending = connect({
+      url: "ws://test",
+      reconnect: { enabled: true, initialDelayMs: 1, maxDelayMs: 1 },
+      onError: () => undefined,
+      webSocketFactory: factory,
+    });
+    await tick();
+    MockWebSocket.lastInstance!.simulateOpen();
+    const client = await pending;
+    const reconnected = vi.fn();
+    client.onReconnect(reconnected);
+    expect(reconnected).not.toHaveBeenCalled();
+
+    MockWebSocket.lastInstance!.simulateClose(1006);
+    // wait past the reconnect delay
+    await tick(20);
+    MockWebSocket.lastInstance!.simulateOpen();
+    expect(reconnected).toHaveBeenCalledTimes(1);
+    client.close();
+  });
+
+  it("reestablishAll() resolves (no-op in 4a, no state to replay yet)", async () => {
+    const { client } = await makeConnectedClient();
+    await expect(client.reestablishAll()).resolves.toBeUndefined();
+    client.close();
+  });
+});
+
+describe("Client.onTopologyChanged", () => {
+  it("first consumer triggers wire subscribeTopology; later consumers don't", async () => {
+    const { client, socket } = await makeConnectedClient();
+    socket.clearFrames();
+
+    const h1 = vi.fn();
+    client.onTopologyChanged(h1);
+    await tick();
+    const methods1 = socket.sentFrames.map((f) => JSON.parse(f).method);
+    expect(methods1).toContain("subscribeTopology");
+    expect(methods1.filter((m) => m === "subscribeTopology")).toHaveLength(1);
+
+    const before = socket.sentFrames.length;
+    const h2 = vi.fn();
+    client.onTopologyChanged(h2);
+    await tick();
+    const methods2 = socket.sentFrames.slice(before).map((f) => JSON.parse(f).method);
+    expect(methods2).not.toContain("subscribeTopology");
+
+    client.close();
+  });
+
+  it("delivers initial snapshot + later changes to all consumers; replays cache to new ones", async () => {
+    const { client, socket } = await makeConnectedClient();
+
+    const h1 = vi.fn();
+    client.onTopologyChanged(h1);
+    await tick();
+
+    // Initial snapshot from the server (sent in response to subscribeTopology).
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "topologyChanged",
+      params: { sessions: [{ name: "local", buses: ["jsonrpc"] }] },
+    });
+    expect(h1).toHaveBeenLastCalledWith([{ name: "local", buses: ["jsonrpc"] }]);
+
+    // New consumer joining after the snapshot is replayed from cache.
+    const h2 = vi.fn();
+    client.onTopologyChanged(h2);
+    expect(h2).toHaveBeenCalledWith([{ name: "local", buses: ["jsonrpc"] }]);
+
+    // Subsequent change fans out to both.
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "topologyChanged",
+      params: { sessions: [{ name: "local", buses: ["jsonrpc", "telemetry"] }] },
+    });
+    expect(h1).toHaveBeenLastCalledWith([{ name: "local", buses: ["jsonrpc", "telemetry"] }]);
+    expect(h2).toHaveBeenLastCalledWith([{ name: "local", buses: ["jsonrpc", "telemetry"] }]);
+
+    client.close();
+  });
+
+  it("cancel() stops fan-out to the cancelled consumer but keeps delivering to others", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    client.onTopologyChanged(h1);
+    const cancel2 = client.onTopologyChanged(h2);
+    await tick();
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "topologyChanged",
+      params: { sessions: [{ name: "s", buses: [] }] },
+    });
+    expect(h1).toHaveBeenCalled();
+    expect(h2).toHaveBeenCalled();
+
+    h1.mockClear();
+    h2.mockClear();
+    cancel2();
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "topologyChanged",
+      params: { sessions: [{ name: "s", buses: ["b"] }] },
+    });
+    expect(h1).toHaveBeenCalled();
+    expect(h2).not.toHaveBeenCalled();
+
+    client.close();
+  });
+});
+
+describe("Client type cache pre-fill from interestUpdate", () => {
+  it("interestUpdate.types primes the cache so subsequent operations don't refetch the spec", async () => {
+    const { client, socket } = await makeConnectedClient();
+
+    // Declare an interest and ack.
+    const declarePending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    const createReq = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    socket.simulateMessage({ jsonrpc: "2.0", id: createReq.id, result: null });
+    const interest = await declarePending;
+
+    // Server pushes an interestUpdate with a class spec bundled. After this the cache holds
+    // the class spec, so any operation that needs it (get / set / invoke) won't issue a wire
+    // getType call.
+    const classSpec: InterestUpdateNotification["types"][number] = {
+      name: "Aircraft",
+      qualifiedName: "demo.Aircraft",
+      description: "",
+      data: {
+        type: "sen.kernel.ClassTypeSpec",
+        value: {
+          properties: [
+            {
+              name: "altitude",
+              description: "",
+              category: "dynamicRO",
+              type: "f64",
+              transportMode: "unicast",
+              tags: [],
+              checkedSet: false,
+            },
+          ],
+          methods: [],
+          events: [],
+          constructor: {
+            name: "Aircraft",
+            description: "",
+            args: [],
+            transportMode: "unicast",
+            constness: "nonConstant",
+            deferred: false,
+            returnType: "",
+            propertyRelation: "nonPropertyRelated",
+            localOnly: false,
+          },
+          parents: [],
+          isInterface: false,
+        },
+      },
+    };
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a1", qualifiedClassName: "demo.Aircraft", currentValues: [] }],
+        removed: [],
+        types: [classSpec], typeSchemas: "",
+      },
+    });
+    await tick();
+
+    // Observable behavior: get() on the new object's property triggers a getProperty (cache is
+    // empty for the value), but does NOT trigger a getType wire call (the class spec is
+    // cached). The absence of getType is the test of "interestUpdate.types pre-filled the cache."
+    const obj = interest.objectByName("a1")!;
+    const before = socket.sentFrames.length;
+    const pendingGet = obj.get("altitude");
+    await tick();
+    const recent = socket.sentFrames
+      .slice(before)
+      .map((f) => JSON.parse(f))
+      .map((r: { method: string }) => r.method);
+    expect(recent).toContain("getProperty");
+    expect(recent).not.toContain("getType");
+
+    // Settle the wire fetch so close() doesn't leave a hanging promise.
+    const getReq = socket.sentFrames
+      .slice(before)
+      .map((f) => JSON.parse(f))
+      .find((r: { method: string }) => r.method === "getProperty");
+    socket.simulateMessage({ jsonrpc: "2.0", id: getReq!.id, result: "42" });
+    await expect(pendingGet).resolves.toBe(42);
+    client.close();
+  });
+});
+
+describe("connect() autoReestablish + initialReconnect", () => {
+  it("auto-fires reestablishAll after a reconnect by default", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const pending = connect({
+      url: "ws://test",
+      reconnect: { enabled: true, initialDelayMs: 1, maxDelayMs: 1 },
+      onError: () => undefined,
+      webSocketFactory: factory,
+    });
+    await tick();
+    MockWebSocket.lastInstance!.simulateOpen();
+    const client = await pending;
+    const socket = MockWebSocket.lastInstance!;
+
+    // Declare an interest so reestablishAll has something to re-issue.
+    const declarePending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    const createReq = JSON.parse(socket.sentFrames[0]!);
+    expect(createReq.method).toBe("createInterest");
+    socket.simulateMessage({ jsonrpc: "2.0", id: createReq.id, result: null });
+    await declarePending;
+
+    // Drop and reconnect; the new socket should receive a fresh createInterest.
+    socket.simulateClose(1006);
+    await tick(20);
+    const newSocket = MockWebSocket.lastInstance!;
+    newSocket.simulateOpen();
+    await tick();
+    const replayedCreate = newSocket.sentFrames
+      .map((f) => JSON.parse(f))
+      .find((r: { method: string }) => r.method === "createInterest");
+    expect(replayedCreate).toBeDefined();
+    client.close();
+  });
+
+  it("autoReestablish: false skips the auto-call after reconnect", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const pending = connect({
+      url: "ws://test",
+      reconnect: { enabled: true, initialDelayMs: 1, maxDelayMs: 1, autoReestablish: false },
+      onError: () => undefined,
+      webSocketFactory: factory,
+    });
+    await tick();
+    MockWebSocket.lastInstance!.simulateOpen();
+    const client = await pending;
+    const socket = MockWebSocket.lastInstance!;
+
+    const declarePending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    const createReq = JSON.parse(socket.sentFrames[0]!);
+    socket.simulateMessage({ jsonrpc: "2.0", id: createReq.id, result: null });
+    await declarePending;
+
+    socket.simulateClose(1006);
+    await tick(20);
+    const newSocket = MockWebSocket.lastInstance!;
+    newSocket.simulateOpen();
+    await tick();
+    const replayedCreate = newSocket.sentFrames
+      .map((f) => JSON.parse(f))
+      .find((r: { method: string }) => r.method === "createInterest");
+    expect(replayedCreate).toBeUndefined();
+    client.close();
+  });
+
+  it("initialReconnect: true retries the initial open until a subsequent attempt succeeds", async () => {
+    let attempt = 0;
+    const factory: WebSocketFactory = (url) => {
+      attempt++;
+      return new MockWebSocket(url);
+    };
+    const pending = connect({
+      url: "ws://test",
+      reconnect: { enabled: true, initialDelayMs: 1, maxDelayMs: 1 },
+      initialReconnect: true,
+      openTimeoutMs: 5_000,
+      onError: () => undefined,
+      webSocketFactory: factory,
+    });
+    await tick();
+    expect(attempt).toBe(1);
+    // First attempt fails before open.
+    MockWebSocket.lastInstance!.simulateClose(1006);
+    await tick(20);
+    expect(attempt).toBe(2);
+    // Second attempt succeeds.
+    MockWebSocket.lastInstance!.simulateOpen();
+    const client = await pending;
+    expect(client.connectionState).toBe("open");
+    client.close();
+  });
+
+  it("initialReconnect: false (default) still rejects on first-attempt close", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const pending = connect({
+      url: "ws://test",
+      reconnect: { enabled: true, initialDelayMs: 1, maxDelayMs: 1 },
+      openTimeoutMs: 5_000,
+      onError: () => undefined,
+      webSocketFactory: factory,
+    });
+    await tick();
+    MockWebSocket.lastInstance!.simulateClose(1006);
+    await expect(pending).rejects.toBeInstanceOf(TransportError);
+  });
+});
+
+describe("Client.reestablishAll while transport not open", () => {
+  it("returns immediately without firing any wire call when the transport is reconnecting", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const pending = connect({
+      url: "ws://test",
+      reconnect: { enabled: true, initialDelayMs: 60_000, maxDelayMs: 60_000, autoReestablish: false },
+      onError: () => undefined,
+      webSocketFactory: factory,
+    });
+    await tick();
+    MockWebSocket.lastInstance!.simulateOpen();
+    const client = await pending;
+    const socket = MockWebSocket.lastInstance!;
+
+    // Declare an interest so reestablishAll has work it would otherwise try to do.
+    const declarePending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    const createReq = JSON.parse(socket.sentFrames[0]!);
+    socket.simulateMessage({ jsonrpc: "2.0", id: createReq.id, result: null });
+    await declarePending;
+
+    // Drop the socket; backoff is 60s so we stay in "reconnecting" for this test.
+    socket.simulateClose(1006);
+    expect(client.connectionState).toBe("reconnecting");
+
+    const framesBefore = socket.sentFrames.length;
+    await expect(client.reestablishAll()).resolves.toBeUndefined();
+    expect(socket.sentFrames.length).toBe(framesBefore);
+
+    client.close();
+  });
+});
+
+describe("Client.reestablishAll single-flight + epoch idempotence + failure resync", () => {
+  /** Connect with reconnect enabled, declare one interest, and settle it. */
+  async function makeReconnectingClientWithInterest(errors: string[], autoReestablish: boolean) {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const pending = connect({
+      url: "ws://test",
+      reconnect: { enabled: true, initialDelayMs: 1, maxDelayMs: 1, autoReestablish },
+      onError: (e) => errors.push(String(e)),
+      webSocketFactory: factory,
+    });
+    await tick();
+    MockWebSocket.lastInstance!.simulateOpen();
+    const client = await pending;
+    const socket = MockWebSocket.lastInstance!;
+
+    const declarePending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    const createReq = JSON.parse(socket.sentFrames[0]!);
+    socket.simulateMessage({ jsonrpc: "2.0", id: createReq.id, result: null });
+    const interest = await declarePending;
+    return { client, socket, interest };
+  }
+
+  function frames(socket: MockWebSocket, method: string) {
+    return socket.sentFrames
+      .map((f) => JSON.parse(f) as { method?: string; id?: number })
+      .filter((r) => r.method === method);
+  }
+
+  /** Bounce the connection and return the new socket (opened). */
+  async function bounce() {
+    MockWebSocket.lastInstance!.simulateClose(1006);
+    await tick(20);
+    const next = MockWebSocket.lastInstance!;
+    next.simulateOpen();
+    await tick();
+    return next;
+  }
+
+  it("manual calls during and after the auto pass cause no extra createInterest and no churn", async () => {
+    const errors: string[] = [];
+    const { client, interest } = await makeReconnectingClientWithInterest(errors, true);
+    const removed: string[] = [];
+    interest.onObjectRemoved((name) => removed.push(name));
+
+    const socket2 = await bounce(); // auto pass fires and sends createInterest
+
+    // Manual call while the auto pass is in flight: coalesces (single-flight).
+    const manualDuring = client.reestablishAll();
+    await tick();
+    const creates = frames(socket2, "createInterest");
+    expect(creates.length).toBe(1);
+    socket2.simulateMessage({ jsonrpc: "2.0", id: creates[0]!.id, result: null });
+    await manualDuring;
+    await tick(5);
+    expect(frames(socket2, "createInterest").length).toBe(1);
+
+    // Manual call after the pass settled: same epoch, already re-declared -> per-handle no-op.
+    const removedBefore = removed.length;
+    await client.reestablishAll();
+    await tick();
+    expect(frames(socket2, "createInterest").length).toBe(1);
+    expect(removed.length).toBe(removedBefore);
+    expect(errors).toEqual([]);
+    client.close();
+  });
+
+  it("re-declare rejected but interest alive server-side: resyncs from listObjects", async () => {
+    const errors: string[] = [];
+    const { client, interest } = await makeReconnectingClientWithInterest(errors, false);
+    const added: string[] = [];
+    interest.onObjectAdded((obj) => added.push(obj.name));
+
+    const socket2 = await bounce(); // autoReestablish off: nothing fires on its own
+
+    const run = client.reestablishAll();
+    await tick();
+    const create = frames(socket2, "createInterest")[0]!;
+    socket2.simulateMessage({
+      jsonrpc: "2.0",
+      id: create.id,
+      error: { code: -32602, message: "createInterest: interest already exists: i1" },
+    });
+    await tick();
+    const list = frames(socket2, "listObjects")[0]!;
+    expect(list).toBeDefined();
+    socket2.simulateMessage({
+      jsonrpc: "2.0",
+      id: list.id,
+      result: [{ objectName: "o9", qualifiedClassName: "pkg.C" }],
+    });
+    await run;
+
+    expect(interest.objects().map((o) => o.name)).toEqual(["o9"]);
+    expect(added).toEqual(["o9"]);
+    expect(errors).toEqual([]);
+    client.close();
+  });
+
+  it("re-declare rejected and interest gone server-side: surfaces the original error", async () => {
+    const errors: string[] = [];
+    const { client, interest } = await makeReconnectingClientWithInterest(errors, false);
+
+    const socket2 = await bounce();
+
+    const run = client.reestablishAll();
+    await tick();
+    const create = frames(socket2, "createInterest")[0]!;
+    socket2.simulateMessage({
+      jsonrpc: "2.0",
+      id: create.id,
+      error: { code: -32602, message: "createInterest: interest already exists: i1" },
+    });
+    await tick();
+    const list = frames(socket2, "listObjects")[0]!;
+    socket2.simulateMessage({
+      jsonrpc: "2.0",
+      id: list.id,
+      error: { code: -32011, message: "listObjects: unknown interest: i1" },
+    });
+    await run;
+
+    expect(interest.objects()).toEqual([]);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("already exists");
+    client.close();
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/encode_var.test.ts
+++ b/components/jsonrpc/clients/typescript/test/encode_var.test.ts
@@ -1,0 +1,283 @@
+// === encode_var.test.ts ==============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect } from "vitest";
+import { encodeVar, encodeVarToWire } from "../src/internal/var_codec.js";
+import { TypeCache } from "../src/internal/type_cache.js";
+import { Quantity, Variant, TransportError } from "../src/index.js";
+import type { CustomTypeSpec } from "../src/index.js";
+
+function cacheOf(...specs: CustomTypeSpec[]): TypeCache {
+  const cache = new TypeCache();
+  for (const s of specs) cache.set(s);
+  return cache;
+}
+
+const meters = { name: "meter", abbreviation: "m", category: "length" as const };
+
+describe("encodeVar -- built-in primitives", () => {
+  it("passes primitives through verbatim", () => {
+    expect(encodeVar("string", "x", new TypeCache())).toBe("x");
+    expect(encodeVar("bool", true, new TypeCache())).toBe(true);
+    expect(encodeVar("i32", 42, new TypeCache())).toBe(42);
+    expect(encodeVar("f64", 3.14, new TypeCache())).toBe(3.14);
+    expect(encodeVar("TimeStamp", "2026-05-24", new TypeCache())).toBe("2026-05-24");
+  });
+
+  it("throws when the value doesn't match the declared primitive", () => {
+    expect(() => encodeVar("string", 42, new TypeCache())).toThrow(TransportError);
+    expect(() => encodeVar("i32", "42", new TypeCache())).toThrow(TransportError);
+    expect(() => encodeVar("bool", 1, new TypeCache())).toThrow(TransportError);
+  });
+
+  it("encodeVarToWire stringifies the encoded form", () => {
+    expect(encodeVarToWire("string", "hello", new TypeCache())).toBe('"hello"');
+    expect(encodeVarToWire("i32", 7, new TypeCache())).toBe("7");
+  });
+
+  it("i64/u64 encode bigint as a decimal-string JSON value", () => {
+    expect(encodeVar("i64", -9007199254740993n, new TypeCache())).toBe("-9007199254740993");
+    expect(encodeVar("u64", 18446744073709551615n, new TypeCache())).toBe("18446744073709551615");
+    expect(encodeVarToWire("u64", 42n, new TypeCache())).toBe('"42"');
+  });
+
+  it("i64/u64 accept safe-integer numbers, reject unsafe or non-integer numbers", () => {
+    expect(encodeVar("i64", 42, new TypeCache())).toBe("42");
+    expect(() => encodeVar("u64", 1.5, new TypeCache())).toThrow(/non-integer/);
+    expect(() => encodeVar("u64", Number.MAX_SAFE_INTEGER + 1, new TypeCache())).toThrow(
+      /safe-integer range/,
+    );
+  });
+
+  it("u64 rejects negative bigints", () => {
+    expect(() => encodeVar("u64", -1n, new TypeCache())).toThrow(/negative/);
+  });
+});
+
+describe("encodeVar -- enum", () => {
+  const colorSpec: CustomTypeSpec = {
+    name: "Color",
+    qualifiedName: "demo.Color",
+    description: "",
+    data: {
+      type: "sen.kernel.EnumTypeSpec",
+      value: {
+        storageType: "uint8Type",
+        enums: [
+          { name: "red", key: 0, description: "" },
+          { name: "green", key: 1, description: "" },
+          { name: "blue", key: 2, description: "" },
+        ],
+      },
+    },
+  };
+
+  it("passes a known enumerator through verbatim", () => {
+    expect(encodeVar("demo.Color", "red", cacheOf(colorSpec))).toBe("red");
+  });
+
+  it("throws if the value is not a string", () => {
+    expect(() => encodeVar("demo.Color", 0, cacheOf(colorSpec))).toThrow(TransportError);
+  });
+
+  it("throws if the value isn't one of the spec's enumerators", () => {
+    expect(() => encodeVar("demo.Color", "crimson", cacheOf(colorSpec))).toThrow(
+      /enum "demo\.Color" has no enumerator "crimson"/,
+    );
+  });
+});
+
+describe("encodeVar -- Quantity", () => {
+  const altSpec: CustomTypeSpec = {
+    name: "Altitude",
+    qualifiedName: "demo.Altitude",
+    description: "",
+    data: {
+      type: "sen.kernel.QuantityTypeSpec",
+      value: {
+        elementType: { type: "sen.kernel.RealType", value: "float64Type" },
+        unit: meters,
+        minValue: null,
+        maxValue: null,
+      },
+    },
+  };
+
+  it("unwraps a Quantity instance to its .value", () => {
+    const q = new Quantity(1234, meters);
+    expect(encodeVar("demo.Altitude", q, cacheOf(altSpec))).toBe(1234);
+  });
+
+  it("accepts a plain number as the wire-shape equivalent", () => {
+    expect(encodeVar("demo.Altitude", 999.5, cacheOf(altSpec))).toBe(999.5);
+  });
+
+  it("throws on incompatible value", () => {
+    expect(() => encodeVar("demo.Altitude", "high", cacheOf(altSpec))).toThrow(TransportError);
+  });
+
+  it("rejects a Quantity whose unit does not match the spec", () => {
+    const milesPerHour = { name: "mile_per_hour", abbreviation: "mph", category: "velocity" as const };
+    const q = new Quantity(10, milesPerHour);
+    expect(() => encodeVar("demo.Altitude", q, cacheOf(altSpec))).toThrow(
+      /quantity "demo\.Altitude" expects unit "m", got "mph"/,
+    );
+  });
+
+  it("rejects a numeric value outside the spec's bounds", () => {
+    const boundedSpec: CustomTypeSpec = {
+      name: "BoundedAltitude",
+      qualifiedName: "demo.BoundedAltitude",
+      description: "",
+      data: {
+        type: "sen.kernel.QuantityTypeSpec",
+        value: {
+          elementType: { type: "sen.kernel.RealType", value: "float64Type" },
+          unit: meters,
+          minValue: 0,
+          maxValue: 100,
+        },
+      },
+    };
+    expect(() => encodeVar("demo.BoundedAltitude", -1, cacheOf(boundedSpec))).toThrow(
+      /below minimum 0/,
+    );
+    expect(() => encodeVar("demo.BoundedAltitude", 200, cacheOf(boundedSpec))).toThrow(
+      /above maximum 100/,
+    );
+    expect(encodeVar("demo.BoundedAltitude", 50, cacheOf(boundedSpec))).toBe(50);
+  });
+});
+
+describe("encodeVar -- Variant", () => {
+  const armSpec: CustomTypeSpec = {
+    name: "Sleeping",
+    qualifiedName: "school.Sleeping",
+    description: "",
+    data: {
+      type: "sen.kernel.StructTypeSpec",
+      value: {
+        parent: "",
+        fields: [{ name: "since", description: "", type: "TimeStamp" }],
+      },
+    },
+  };
+  const statusSpec: CustomTypeSpec = {
+    name: "StudentStatus",
+    qualifiedName: "school.StudentStatus",
+    description: "",
+    data: {
+      type: "sen.kernel.VariantTypeSpec",
+      value: { fields: [{ key: 0, description: "", type: "school.Sleeping" }] },
+    },
+  };
+
+  it("accepts a Variant instance and writes {type, value}", () => {
+    const v = new Variant("school.Sleeping", { since: "2026-05-24" });
+    const encoded = encodeVar("school.StudentStatus", v, cacheOf(armSpec, statusSpec));
+    expect(encoded).toEqual({ type: "school.Sleeping", value: { since: "2026-05-24" } });
+  });
+
+  it("accepts a plain {type, value} object", () => {
+    const encoded = encodeVar(
+      "school.StudentStatus",
+      { type: "school.Sleeping", value: { since: "2026-05-24" } },
+      cacheOf(armSpec, statusSpec),
+    );
+    expect(encoded).toEqual({ type: "school.Sleeping", value: { since: "2026-05-24" } });
+  });
+
+  it("throws when the tag doesn't match any arm", () => {
+    expect(() =>
+      encodeVar(
+        "school.StudentStatus",
+        { type: "school.Walking", value: {} },
+        cacheOf(armSpec, statusSpec),
+      ),
+    ).toThrow(/no arm matching tag "school.Walking"/);
+  });
+});
+
+describe("encodeVar -- sequence + struct + optional + alias", () => {
+  const pointSpec: CustomTypeSpec = {
+    name: "Point",
+    qualifiedName: "demo.Point",
+    description: "",
+    data: {
+      type: "sen.kernel.StructTypeSpec",
+      value: {
+        parent: "",
+        fields: [
+          { name: "x", description: "", type: "f64" },
+          { name: "y", description: "", type: "f64" },
+        ],
+      },
+    },
+  };
+  const seqSpec: CustomTypeSpec = {
+    name: "Points",
+    qualifiedName: "demo.Points",
+    description: "",
+    data: {
+      type: "sen.kernel.SequenceTypeSpec",
+      value: { elementType: "demo.Point", maxSize: null, fixedSize: false },
+    },
+  };
+  const aliasSpec: CustomTypeSpec = {
+    name: "Speed",
+    qualifiedName: "demo.Speed",
+    description: "",
+    data: { type: "sen.kernel.AliasTypeSpec", value: { aliasedType: "f64" } },
+  };
+  const optionalSpec: CustomTypeSpec = {
+    name: "MaybeName",
+    qualifiedName: "demo.MaybeName",
+    description: "",
+    data: { type: "sen.kernel.OptionalTypeSpec", value: { type: "string" } },
+  };
+
+  it("struct encodes each declared field", () => {
+    expect(
+      encodeVar("demo.Point", { x: 1, y: 2 }, cacheOf(pointSpec)),
+    ).toEqual({ x: 1, y: 2 });
+  });
+
+  it("sequence encodes each element", () => {
+    expect(
+      encodeVar(
+        "demo.Points",
+        [
+          { x: 1, y: 2 },
+          { x: 3, y: 4 },
+        ],
+        cacheOf(pointSpec, seqSpec),
+      ),
+    ).toEqual([
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+    ]);
+  });
+
+  it("alias delegates to its aliased type", () => {
+    expect(encodeVar("demo.Speed", 250, cacheOf(aliasSpec))).toBe(250);
+  });
+
+  it("optional emits null for null or undefined input", () => {
+    expect(encodeVar("demo.MaybeName", null, cacheOf(optionalSpec))).toBeNull();
+    expect(encodeVar("demo.MaybeName", undefined, cacheOf(optionalSpec))).toBeNull();
+  });
+
+  it("optional delegates to inner type when non-null", () => {
+    expect(encodeVar("demo.MaybeName", "abc", cacheOf(optionalSpec))).toBe("abc");
+  });
+});
+
+describe("encodeVar -- missing-spec invariant", () => {
+  it("throws TransportError when a referenced custom type has no cached spec", () => {
+    expect(() => encodeVar("pkg.Missing", {}, new TypeCache())).toThrow(/no type spec/);
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/integration/basic.test.ts
+++ b/components/jsonrpc/clients/typescript/test/integration/basic.test.ts
@@ -1,0 +1,27 @@
+// === basic.test.ts ===================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect } from "vitest";
+import { openClient } from "./helpers.js";
+
+describe("connect + close against a real Sen subprocess", () => {
+  it("opens a WebSocket connection and reports state 'open'", async () => {
+    const client = await openClient();
+    try {
+      expect(client.connectionState).toBe("open");
+    } finally {
+      client.close();
+    }
+  });
+
+  it("close() makes connectionState 'closed' and is safe to call twice", async () => {
+    const client = await openClient();
+    client.close();
+    expect(client.connectionState).toBe("closed");
+    expect(() => client.close()).not.toThrow();
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/integration/configs/inheritance.yaml
+++ b/components/jsonrpc/clients/typescript/test/integration/configs/inheritance.yaml
@@ -1,0 +1,39 @@
+# Sen YAML config used by the @sen/client integration suite. Loads two test packages from
+# test/util so the suite never depends on the examples build axis (with_examples).
+#
+# `test.primary` carries a `my_package.MyClass` instance: rich writable surface (prop2 struct,
+# prop3 variant, prop5 i32, prop7 i32, etc.) and a [static] prop1 for the RO rejection check.
+# `my_package`'s update tick leaves the test-facing writable props alone, so the set+observe
+# round-trip is deterministic.
+#
+# `test.secondary` carries an `inheritance.MySubClass` instance for the event tests: the impl
+# fires `somethingElseHappened(arg)` from `doSomethingElse(arg)`, so subscribers see the event
+# in response to a client-driven invoke (more deterministic than tick-driven autonomous emit).
+#
+# Both instances live under a single component (one group, one tick loop). Splitting them into
+# separate components surfaces a backend race where queries against the second component's bus
+# can return zero matches even after the createInterest call resolves.
+#
+# Port 8080 matches helpers.ts (senPort). Bound on 0.0.0.0 so a containerised CI runner can
+# still reach the server from the loopback the host probes.
+
+load:
+  - name: jsonrpc
+    address: "0.0.0.0"
+    port: 8080
+
+build:
+  - name: testInstances
+    group: 3
+    freqHz: 30
+    imports: [my_package, inheritance]
+    objects:
+      - name: instance1
+        class: my_package.MyClassImpl
+        prop1: instance1-static
+        bus: test.primary
+      - name: instance2
+        class: inheritance.MySubClassImpl
+        prop1: instance2-static
+        aString: subclass-static
+        bus: test.secondary

--- a/components/jsonrpc/clients/typescript/test/integration/configs/reconnect.yaml
+++ b/components/jsonrpc/clients/typescript/test/integration/configs/reconnect.yaml
@@ -1,0 +1,22 @@
+# Sen YAML config for the reconnect integration test. Minimal surface is enough to verify
+# that an interest re-establishes after the server is bounced: one `inheritance.MyClass`
+# instance on `test.primary`.
+#
+# Port 8081 so it can run alongside the suite-wide Sen on 8080 without colliding (the
+# reconnect test owns its own subprocess; the globalSetup Sen stays up the whole time).
+
+load:
+  - name: jsonrpc
+    address: "0.0.0.0"
+    port: 8081
+
+build:
+  - name: primaryComponent
+    group: 3
+    freqHz: 30
+    imports: [my_package]
+    objects:
+      - name: instance1
+        class: my_package.MyClassImpl
+        prop1: instance1-static
+        bus: test.primary

--- a/components/jsonrpc/clients/typescript/test/integration/events.test.ts
+++ b/components/jsonrpc/clients/typescript/test/integration/events.test.ts
@@ -1,0 +1,46 @@
+// === events.test.ts ==================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { firstMatch, openClient } from "./helpers.js";
+import type { Client, Var } from "../../src/index.js";
+
+describe("event subscriptions against inheritance.MySubClass", () => {
+  let client: Client;
+  beforeAll(async () => {
+    client = await openClient();
+  });
+  afterAll(() => {
+    client.close();
+  });
+
+  // doSomethingElse(arg) fires somethingElseHappened(arg) synchronously on the server side. We
+  // pre-subscribe to the event in the interest declaration (atomic with interest creation, so
+  // the wire subscription is up before any invoke fires) and assert the event lands with the
+  // same arg after invoking doSomethingElse.
+  it("delivers somethingElseHappened(arg) after invoking doSomethingElse(arg)", async () => {
+    const interest = await client.declareInterest({
+      name: "subclass_for_events",
+      query: "SELECT inheritance.MySubClass FROM test.secondary",
+      subscribe: { events: ["somethingElseHappened"] },
+    });
+    try {
+      const obj = await firstMatch(interest);
+      const seen: Var[][] = [];
+      const cancel = obj.onEventTriggered("somethingElseHappened", (args) => {
+        seen.push(args);
+      });
+      await obj.invoke("doSomethingElse", { arg: 7 });
+      await vi.waitFor(() => expect(seen.length).toBeGreaterThanOrEqual(1), { timeout: 5_000 });
+      const [arg] = seen[0]!;
+      expect(arg).toBe(7);
+      cancel();
+    } finally {
+      await interest.release();
+    }
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/integration/globalSetup.ts
+++ b/components/jsonrpc/clients/typescript/test/integration/globalSetup.ts
@@ -1,0 +1,49 @@
+// === globalSetup.ts ==================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// Vitest globalSetup for integration tests. Spawns a Sen subprocess against the YAML config
+// supplied by SEN_CONFIG, waits for the WebSocket port to be open, returns a teardown function
+// that signals the subprocess down on POSIX and TerminateProcess on Windows.
+//
+// SEN_BINARY and SEN_CONFIG are required, supplied by the CMake target
+// jsonrpc_ts_client_integration (see CMakeLists.txt). There are no hard-coded fallbacks: the
+// binary location depends on the build profile (gcc/clang/msvc, Debug/Release, custom presets),
+// and CMake already knows the answer authoritatively via $<TARGET_FILE:sen::cli_sen>. Running
+// this suite outside ctest is supported; set the two vars by hand.
+//   SEN_BINARY  full path to the `sen` executable
+//   SEN_CONFIG  full path to the YAML config (typically test/integration/configs/inheritance.yaml)
+//   SEN_PORT    port the WebSocket server binds to (default 8080; must match the config)
+
+import { senPort } from "./helpers.js";
+import { spawnSen, type SenHandle } from "./subprocess.js";
+
+function requiredEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    throw new Error(
+      `${name} is not set. The CMake target jsonrpc_ts_client_integration sets it ` +
+        `automatically; to run this suite outside ctest, set both SEN_BINARY and SEN_CONFIG by ` +
+        `hand (e.g. SEN_BINARY=<build>/bin/sen ` +
+        `SEN_CONFIG=<repo>/components/jsonrpc/clients/typescript/test/integration/configs/inheritance.yaml).`,
+    );
+  }
+  return v;
+}
+
+let handle: SenHandle | undefined;
+
+export async function setup(): Promise<void> {
+  handle = await spawnSen({
+    binary: requiredEnv("SEN_BINARY"),
+    config: requiredEnv("SEN_CONFIG"),
+    port: senPort,
+  });
+}
+
+export async function teardown(): Promise<void> {
+  await handle?.stop();
+}

--- a/components/jsonrpc/clients/typescript/test/integration/helpers.ts
+++ b/components/jsonrpc/clients/typescript/test/integration/helpers.ts
@@ -1,0 +1,51 @@
+// === helpers.ts ======================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { connect, type Client, type InterestHandle, type ObjectHandle } from "../../src/index.js";
+
+export const senPort = Number(process.env.SEN_PORT ?? 8080);
+export const senUrl = `ws://127.0.0.1:${senPort}`;
+
+/** Open a connection to the Sen subprocess spawned by globalSetup. Throws on timeout. */
+export async function openClient(): Promise<Client> {
+  return connect({
+    url: senUrl,
+    // Tight timeouts: loopback round-trips are sub-ms; surface test failures fast rather than
+    // hanging the suite. Reconnect is off for the same reason.
+    defaultTimeoutMs: 2_000,
+    openTimeoutMs: 3_000,
+    reconnect: { enabled: false },
+    // Suppress the default console.error so a single intentional failure does not pollute the
+    // test output. Per-test code can override if needed.
+    onError: () => undefined,
+  });
+}
+
+/**
+ * Resolve with the first object the interest matches, whether the match was already in the
+ * initial server push or arrives later. Uses the idiomatic `onObjectAdded` callback (which
+ * replays for already-present objects), so it avoids the race a synchronous
+ * `interest.objects()[0]` would have when the createInterest response and the initial
+ * interestUpdate notification arrive out of order. Rejects with a clear message after
+ * `timeoutMs`, instead of letting the surrounding test timeout swallow the cause.
+ */
+export function firstMatch(interest: InterestHandle, timeoutMs = 5_000): Promise<ObjectHandle> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `firstMatch: no object arrived within ${timeoutMs}ms (interest=${interest.name}, ` +
+            `state=${interest.state}, objects=${interest.objects().length})`,
+        ),
+      );
+    }, timeoutMs);
+    interest.onObjectAdded((obj) => {
+      clearTimeout(timer);
+      resolve(obj);
+    });
+  });
+}

--- a/components/jsonrpc/clients/typescript/test/integration/interest.test.ts
+++ b/components/jsonrpc/clients/typescript/test/integration/interest.test.ts
@@ -1,0 +1,45 @@
+// === interest.test.ts ================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { firstMatch, openClient } from "./helpers.js";
+import type { Client } from "../../src/index.js";
+
+describe("declareInterest against inheritance.yaml", () => {
+  let client: Client;
+  beforeAll(async () => {
+    client = await openClient();
+  });
+  afterAll(() => {
+    client.close();
+  });
+
+  it("matches a MyClass on test.primary", async () => {
+    const interest = await client.declareInterest({
+      name: "myclass_primary",
+      query: "SELECT my_package.MyClass FROM test.primary",
+    });
+    try {
+      const obj = await firstMatch(interest);
+      expect(interest.state).toBe("active");
+      expect(obj.className).toBe("my_package.MyClass");
+      expect(obj.name).toBe("instance1");
+    } finally {
+      await interest.release();
+    }
+  });
+
+  it("release() drops the interest and stops tracking the match set", async () => {
+    const interest = await client.declareInterest({
+      name: "release_check",
+      query: "SELECT my_package.MyClass FROM test.primary",
+    });
+    await interest.release();
+    expect(interest.state).toBe("released");
+    expect(interest.objects().length).toBe(0);
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/integration/invoke.test.ts
+++ b/components/jsonrpc/clients/typescript/test/integration/invoke.test.ts
@@ -1,0 +1,34 @@
+// === invoke.test.ts ==================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { firstMatch, openClient } from "./helpers.js";
+import type { Client } from "../../src/index.js";
+
+describe("invoke against my_package.MyClass", () => {
+  let client: Client;
+  beforeAll(async () => {
+    client = await openClient();
+  });
+  afterAll(() => {
+    client.close();
+  });
+
+  it("calls addNumbers(a, b) and returns the sum", async () => {
+    const interest = await client.declareInterest({
+      name: "myclass_for_invoke",
+      query: "SELECT my_package.MyClass FROM test.primary",
+    });
+    try {
+      const obj = await firstMatch(interest);
+      const reply = await obj.invoke("addNumbers", { a: 2, b: 3 });
+      expect(reply).toBe(5);
+    } finally {
+      await interest.release();
+    }
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/integration/reconnect.test.ts
+++ b/components/jsonrpc/clients/typescript/test/integration/reconnect.test.ts
@@ -1,0 +1,105 @@
+// === reconnect.test.ts ===============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// Verifies the disconnect / reconnect / reestablishAll round-trip end to end: take down the
+// server, watch the client notice, bring the server back up, watch the client reconnect, and
+// confirm that re-declared interests resolve to live objects again.
+//
+// Owns its own Sen subprocess on a separate port from the suite-wide Sen so the bounce here
+// does not affect other tests. SEN_BINARY comes from CMake (same as globalSetup); the YAML
+// fixture is resolved relative to this file.
+
+import { describe, it, expect, vi } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { connect } from "../../src/index.js";
+import type { Client } from "../../src/index.js";
+import { spawnSen, waitForPortClosed } from "./subprocess.js";
+
+const reconnectPort = 8081;
+const here = dirname(fileURLToPath(import.meta.url));
+const reconnectConfig = join(here, "configs", "reconnect.yaml");
+
+function requiredEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`${name} is not set; set it before running reconnect.test.ts.`);
+  return v;
+}
+
+describe("reconnect + reestablishAll", () => {
+  it("re-resolves interests after the server is bounced", async () => {
+    const senBinary = requiredEnv("SEN_BINARY");
+
+    let sen = await spawnSen({ binary: senBinary, config: reconnectConfig, port: reconnectPort });
+
+    // Reconnect enabled and aggressive: loopback respawn is sub-second, so tight delays keep the
+    // test from waiting on the default backoff.
+    const client: Client = await connect({
+      url: `ws://127.0.0.1:${reconnectPort}`,
+      defaultTimeoutMs: 2_000,
+      openTimeoutMs: 3_000,
+      reconnect: { enabled: true, initialDelayMs: 100, maxDelayMs: 500, factor: 2 },
+      onError: () => undefined,
+    });
+
+    try {
+      let disconnects = 0;
+      let reconnects = 0;
+      const cancelDisc = client.onDisconnect(() => {
+        disconnects += 1;
+      });
+      const cancelReco = client.onReconnect(() => {
+        reconnects += 1;
+      });
+
+      const interest = await client.declareInterest({
+        name: "reconnect_myclass",
+        query: "SELECT my_package.MyClass FROM test.primary",
+      });
+      await vi.waitFor(() => expect(interest.objects().length).toBeGreaterThanOrEqual(1));
+
+      // Register both lifecycle handlers BEFORE the bounce so we can check the contract:
+      // every onObjectAdded across a reestablish is matched by a prior onObjectRemoved.
+      const addedNames: string[] = [];
+      const removedNames: string[] = [];
+      interest.onObjectAdded((obj) => addedNames.push(obj.name));
+      interest.onObjectRemoved((name) => removedNames.push(name));
+      // onObjectAdded replays for current matches, so we expect one initial add here.
+      const initialAdds = addedNames.length;
+      expect(initialAdds).toBeGreaterThanOrEqual(1);
+
+      await sen.stop();
+      await waitForPortClosed(reconnectPort, 5_000);
+      await vi.waitFor(() => expect(disconnects).toBeGreaterThanOrEqual(1), { timeout: 5_000 });
+
+      sen = await spawnSen({ binary: senBinary, config: reconnectConfig, port: reconnectPort });
+      await vi.waitFor(() => expect(reconnects).toBeGreaterThanOrEqual(1), { timeout: 10_000 });
+
+      // reestablishAll re-declares the interest against the fresh Sen; the resulting object set
+      // should look the same as before the bounce. This manual call deliberately races the
+      // autoReestablish pass the client fires on its own — single-flight must coalesce them
+      // (two interleaved passes used to strand the handle empty on "interest already exists").
+      await client.reestablishAll();
+      await vi.waitFor(() => expect(interest.objects().length).toBeGreaterThanOrEqual(1), {
+        timeout: 5_000,
+      });
+      expect(interest.objects()[0]?.className).toBe("my_package.MyClass");
+
+      // Contract: each previously-matched object fired onObjectRemoved when reestablish ran,
+      // then onObjectAdded again when the new interestUpdate landed. The pairs match by name.
+      expect(removedNames).toEqual(["instance1"]);
+      expect(addedNames.length).toBe(initialAdds + 1);
+      expect(addedNames[addedNames.length - 1]).toBe("instance1");
+
+      cancelDisc();
+      cancelReco();
+    } finally {
+      client.close();
+      await sen.stop();
+    }
+  }, 30_000);
+});

--- a/components/jsonrpc/clients/typescript/test/integration/set.test.ts
+++ b/components/jsonrpc/clients/typescript/test/integration/set.test.ts
@@ -1,0 +1,58 @@
+// === set.test.ts =====================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { firstMatch, openClient } from "./helpers.js";
+import { JsonRpcError } from "../../src/index.js";
+import type { Client } from "../../src/index.js";
+
+describe("setProperty against my_package.MyClass", () => {
+  let client: Client;
+  beforeAll(async () => {
+    client = await openClient();
+  });
+  afterAll(() => {
+    client.close();
+  });
+
+  // prop7 is `i32 [writable]` and is not modified by MyClassImpl::update, so the value we
+  // write stays put long enough for the subscription notification to fire. The impl's
+  // `prop7AcceptsSet` callback accepts values in [-5, 5]; we pick 3 to stay in-range.
+  it("writes prop7 (i32) and observes the new value via subscription", async () => {
+    const interest = await client.declareInterest({
+      name: "myclass_for_set",
+      query: "SELECT my_package.MyClass FROM test.primary",
+    });
+    try {
+      const obj = await firstMatch(interest);
+      const seen: number[] = [];
+      const cancel = obj.onPropertyChanged("prop7", (value) => {
+        seen.push(value as number);
+      });
+      await vi.waitFor(() => expect(seen.length).toBeGreaterThanOrEqual(1));
+      await obj.set("prop7", 3);
+      await vi.waitFor(() => expect(seen[seen.length - 1]).toBe(3));
+      cancel();
+    } finally {
+      await interest.release();
+    }
+  });
+
+  it("rejects writes to a read-only property with JsonRpcError", async () => {
+    const interest = await client.declareInterest({
+      name: "myclass_ro_check",
+      query: "SELECT my_package.MyClass FROM test.primary",
+    });
+    try {
+      const obj = await firstMatch(interest);
+      // `prop1` is declared `[static]`; the server should refuse runtime writes.
+      await expect(obj.set("prop1", "nope")).rejects.toBeInstanceOf(JsonRpcError);
+    } finally {
+      await interest.release();
+    }
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/integration/subprocess.ts
+++ b/components/jsonrpc/clients/typescript/test/integration/subprocess.ts
@@ -1,0 +1,128 @@
+// === subprocess.ts ===================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// Shared spawn/teardown logic for Sen subprocesses. Used by globalSetup.ts for the suite-wide
+// Sen and by tests that need to manage their own Sen (notably the reconnect test, which needs
+// to kill and respawn one mid-test on a separate port).
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { Socket } from "node:net";
+import { once } from "node:events";
+
+const defaultStartupTimeoutMs = 10_000;
+const defaultShutdownGraceMs = 2_000;
+
+export interface SpawnSenOptions {
+  binary: string;
+  config: string;
+  port: number;
+  startupTimeoutMs?: number;
+}
+
+export interface SenHandle {
+  readonly process: ChildProcess;
+  readonly port: number;
+  stop(opts?: { graceMs?: number }): Promise<void>;
+}
+
+export async function waitForPort(port: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      await new Promise<void>((resolveProbe, rejectProbe) => {
+        const socket = new Socket();
+        socket.once("error", (err) => {
+          socket.destroy();
+          rejectProbe(err);
+        });
+        socket.once("connect", () => {
+          socket.end();
+          resolveProbe();
+        });
+        socket.connect(port, "127.0.0.1");
+      });
+      return;
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+  throw new Error(
+    `Sen did not open port ${port} within ${timeoutMs}ms. Last connect error: ${String(lastErr)}`,
+  );
+}
+
+export async function waitForPortClosed(port: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const open = await new Promise<boolean>((resolveProbe) => {
+      const socket = new Socket();
+      socket.once("error", () => {
+        socket.destroy();
+        resolveProbe(false);
+      });
+      socket.once("connect", () => {
+        socket.end();
+        resolveProbe(true);
+      });
+      socket.connect(port, "127.0.0.1");
+    });
+    if (!open) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`Port ${port} did not close within ${timeoutMs}ms.`);
+}
+
+export async function spawnSen(opts: SpawnSenOptions): Promise<SenHandle> {
+  if (!existsSync(opts.binary)) {
+    throw new Error(
+      `Sen binary not found at ${opts.binary}. Build the 'sen' target (cmake --build <build-dir> --target sen).`,
+    );
+  }
+  if (!existsSync(opts.config)) {
+    throw new Error(`Sen config not found at ${opts.config}.`);
+  }
+
+  const child = spawn(opts.binary, ["run", opts.config], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  // Capture stderr so a port-open timeout error includes the server's logs instead of just
+  // ECONNREFUSED. Bounded by the startup window of normal log output.
+  const stderrChunks: Buffer[] = [];
+  child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+  try {
+    await waitForPort(opts.port, opts.startupTimeoutMs ?? defaultStartupTimeoutMs);
+  } catch (err) {
+    child.kill("SIGKILL");
+    throw new Error(`${String(err)}\nSen stderr so far:\n${Buffer.concat(stderrChunks).toString()}`);
+  }
+
+  return {
+    process: child,
+    port: opts.port,
+    async stop({ graceMs = defaultShutdownGraceMs } = {}) {
+      if (child.exitCode !== null) return;
+      if (process.platform === "win32") {
+        // Windows has no real SIGINT; child.kill() invokes TerminateProcess.
+        child.kill();
+        return;
+      }
+      child.kill("SIGINT");
+      const exited = await Promise.race([
+        once(child, "exit").then(() => true),
+        new Promise<boolean>((r) => setTimeout(() => r(false), graceMs)),
+      ]);
+      if (!exited) {
+        child.kill("SIGKILL");
+      }
+    },
+  };
+}

--- a/components/jsonrpc/clients/typescript/test/integration/subscribe.test.ts
+++ b/components/jsonrpc/clients/typescript/test/integration/subscribe.test.ts
@@ -1,0 +1,72 @@
+// === subscribe.test.ts ===============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// Verifies the friendly `subscribe` shape on `declareInterest`. The codec unit tests
+// (test/subscribe_codec.test.ts) cover the translation; these tests exercise the wire
+// round-trip so the server actually accepts the produced shape.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { firstMatch, openClient } from "./helpers.js";
+import type { Client } from "../../src/index.js";
+
+describe("declareInterest({ subscribe }) against my_package.MyClass", () => {
+  let client: Client;
+  beforeAll(async () => {
+    client = await openClient();
+  });
+  afterAll(() => {
+    client.close();
+  });
+
+  it("accepts a wildcard property pre-subscription and serves get() from cache", async () => {
+    const interest = await client.declareInterest({
+      name: "presub_wildcard",
+      query: "SELECT my_package.MyClass FROM test.primary",
+      subscribe: { properties: "*" },
+    });
+    try {
+      const obj = await firstMatch(interest);
+      // With `properties: "*"`, the server seeds `currentValues` for every property in the
+      // initial interestUpdate; `get` should resolve from the local cache without a wire trip.
+      const prop1 = await obj.get("prop1");
+      expect(typeof prop1).toBe("string");
+    } finally {
+      await interest.release();
+    }
+  });
+
+  it("accepts a named property pre-subscription", async () => {
+    const interest = await client.declareInterest({
+      name: "presub_named",
+      query: "SELECT my_package.MyClass FROM test.primary",
+      subscribe: { properties: ["prop1"] },
+    });
+    try {
+      const obj = await firstMatch(interest);
+      const prop1 = await obj.get("prop1");
+      expect(typeof prop1).toBe("string");
+    } finally {
+      await interest.release();
+    }
+  });
+
+  it("accepts a named event pre-subscription with maxRateHz", async () => {
+    const interest = await client.declareInterest({
+      name: "presub_events",
+      query: "SELECT inheritance.MySubClass FROM test.secondary",
+      subscribe: { events: ["somethingElseHappened"], maxRateHz: 5 },
+    });
+    try {
+      const obj = await firstMatch(interest);
+      // Smoke: the object handle should still be usable for an invoke.
+      const reply = await obj.invoke("addNumbers", { a: 1, b: 4 });
+      expect(reply).toBe(5);
+    } finally {
+      await interest.release();
+    }
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/integration/subscriptions.test.ts
+++ b/components/jsonrpc/clients/typescript/test/integration/subscriptions.test.ts
@@ -1,0 +1,42 @@
+// === subscriptions.test.ts ===========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { firstMatch, openClient } from "./helpers.js";
+import type { Client, Var } from "../../src/index.js";
+
+describe("property subscriptions against inheritance.yaml", () => {
+  let client: Client;
+  beforeAll(async () => {
+    client = await openClient();
+  });
+  afterAll(() => {
+    client.close();
+  });
+
+  it("delivers updates of prop5 (i32) when subscribing to MyClass", async () => {
+    const interest = await client.declareInterest({
+      name: "myclass_props",
+      query: "SELECT my_package.MyClass FROM test.primary",
+    });
+    try {
+      const obj = await firstMatch(interest);
+      const seen: Var[] = [];
+      const cancel = obj.onPropertyChanged("prop5", (value) => {
+        seen.push(value);
+      });
+      // prop5 is incremented every tick by MyClassImpl::update, so notifications stream in
+      // at the component's freqHz (30). One delivery within the default waitFor window is
+      // enough to prove the property-change wire path is alive.
+      await vi.waitFor(() => expect(seen.length).toBeGreaterThanOrEqual(1));
+      expect(typeof seen[0]).toBe("number");
+      cancel();
+    } finally {
+      await interest.release();
+    }
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/interest_handle.test.ts
+++ b/components/jsonrpc/clients/typescript/test/interest_handle.test.ts
@@ -1,0 +1,824 @@
+// === interest_handle.test.ts =========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, vi } from "vitest";
+import { connect } from "../src/connect.js";
+import { InterestReleasedError } from "../src/errors.js";
+import type { WebSocketFactory } from "../src/internal/transport.js";
+import { MockWebSocket, tick } from "./test_helpers/mock_websocket.js";
+import type { InterestUpdateNotification } from "../src/index.js";
+
+async function makeConnectedClient() {
+  const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+  const pending = connect({
+    url: "ws://test",
+    reconnect: { enabled: false },
+      onError: () => undefined,
+    webSocketFactory: factory,
+  });
+  await tick();
+  MockWebSocket.lastInstance!.simulateOpen();
+  const client = await pending;
+  return { client, socket: MockWebSocket.lastInstance! };
+}
+
+/** Push a createInterest success response for the most recent request. */
+function respondToCreateInterest(socket: MockWebSocket, expectedMethod = "createInterest"): void {
+  const lastFrame = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+  expect(lastFrame.method).toBe(expectedMethod);
+  socket.simulateMessage({ jsonrpc: "2.0", id: lastFrame.id, result: null });
+}
+
+describe("Client.declareInterest", () => {
+  it("sends createInterest with wire-faithful params and returns a handle", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "SELECT * FROM x" });
+    await tick();
+    const req = JSON.parse(socket.sentFrames[0]!);
+    expect(req.method).toBe("createInterest");
+    expect(req.params).toEqual({
+      interestName: "i1",
+      query: "SELECT * FROM x",
+      subscribe: null,
+      withSchemas: null,
+    });
+    respondToCreateInterest(socket);
+    const handle = await pending;
+    expect(handle.name).toBe("i1");
+    expect(handle.objects()).toEqual([]);
+    client.close();
+  });
+
+  it("rejects when the server returns an error and unregisters the handle", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "bad", query: "INVALID" });
+    await tick();
+    const req = JSON.parse(socket.sentFrames[0]!);
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      id: req.id,
+      error: { code: -32602, message: "invalid query" },
+    });
+    await expect(pending).rejects.toThrow(/invalid query/);
+    client.close();
+  });
+
+  it("serializes concurrent declares for the same name behind the prior release", async () => {
+    // Reproduces the React-StrictMode double-mount race: two declareInterest calls for the
+    // same name fire back-to-back. Without serialization both would hit the wire and the
+    // second would get "interest already exists". With it, the second declare's wire
+    // createInterest is deferred until the first declare's release lifecycle completes.
+    const { client, socket } = await makeConnectedClient();
+    const firstPending = client.declareInterest({ name: "X", query: "q1" });
+    const secondPending = client.declareInterest({ name: "X", query: "q2" });
+    await tick();
+    // Only the first declare's createInterest is on the wire. The second is queued behind
+    // the first's settled chain link and has not yet sent anything.
+    expect(socket.sentFrames).toHaveLength(1);
+    const firstReq = JSON.parse(socket.sentFrames[0]!);
+    expect(firstReq.method).toBe("createInterest");
+    expect(firstReq.params.query).toBe("q1");
+    // Complete the first declare, then immediately release the resulting handle — the
+    // StrictMode hook does the equivalent on cleanup when `released` was set before the
+    // declare resolved.
+    socket.simulateMessage({ jsonrpc: "2.0", id: firstReq.id, result: null });
+    const firstHandle = await firstPending;
+    const firstRelease = firstHandle.release();
+    await tick();
+    // The release goes out before the second declare's createInterest — the chain link
+    // is the prior handle's terminal `released` state, which only fires after the wire
+    // releaseInterest completes.
+    expect(socket.sentFrames).toHaveLength(2);
+    const releaseReq = JSON.parse(socket.sentFrames[1]!);
+    expect(releaseReq.method).toBe("releaseInterest");
+    socket.simulateMessage({ jsonrpc: "2.0", id: releaseReq.id, result: null });
+    await firstRelease;
+    await tick();
+    // With the first handle now in `released`, the chain unblocks and the second declare's
+    // createInterest finally hits the wire — never seeing "already exists".
+    expect(socket.sentFrames).toHaveLength(3);
+    const secondReq = JSON.parse(socket.sentFrames[2]!);
+    expect(secondReq.method).toBe("createInterest");
+    expect(secondReq.params.query).toBe("q2");
+    socket.simulateMessage({ jsonrpc: "2.0", id: secondReq.id, result: null });
+    const secondHandle = await secondPending;
+    expect(secondHandle.name).toBe("X");
+    client.close();
+  });
+
+  it("a failed declare unblocks the next declare for the same name immediately", async () => {
+    // If the first declare's wire createInterest rejects, the next declare for the same
+    // name should not stall waiting on a handle that never reached `active`. The cycle
+    // entry resolves on rejection so the next attempt can proceed.
+    const { client, socket } = await makeConnectedClient();
+    const firstPending = client.declareInterest({ name: "X", query: "INVALID" });
+    const secondPending = client.declareInterest({ name: "X", query: "q" });
+    await tick();
+    expect(socket.sentFrames).toHaveLength(1);
+    const firstReq = JSON.parse(socket.sentFrames[0]!);
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      id: firstReq.id,
+      error: { code: -32602, message: "invalid query" },
+    });
+    await expect(firstPending).rejects.toThrow(/invalid query/);
+    await tick();
+    expect(socket.sentFrames).toHaveLength(2);
+    const secondReq = JSON.parse(socket.sentFrames[1]!);
+    expect(secondReq.method).toBe("createInterest");
+    expect(secondReq.params.query).toBe("q");
+    socket.simulateMessage({ jsonrpc: "2.0", id: secondReq.id, result: null });
+    const handle = await secondPending;
+    expect(handle.name).toBe("X");
+    client.close();
+  });
+});
+
+describe("InterestHandle match-set tracking", () => {
+  it("populates objectsMap from interestUpdate.added", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    const update: InterestUpdateNotification = {
+      interestName: "i1",
+      added: [
+        { objectName: "a1", qualifiedClassName: "demo.Aircraft", currentValues: [] },
+        { objectName: "a2", qualifiedClassName: "demo.Aircraft", currentValues: [] },
+      ],
+      removed: [],
+      types: [],
+      typeSchemas: "",
+    };
+    socket.simulateMessage({ jsonrpc: "2.0", method: "interestUpdate", params: update });
+
+    expect(handle.objects()).toHaveLength(2);
+    expect(handle.objectByName("a1")?.className).toBe("demo.Aircraft");
+    expect(handle.objectByName("a2")?.name).toBe("a2");
+    client.close();
+  });
+
+  it("removes objects on interestUpdate.removed", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a1", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+    expect(handle.objects()).toHaveLength(1);
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: { interestName: "i1", added: [], removed: ["a1"], types: [], typeSchemas: "" },
+    });
+    expect(handle.objects()).toHaveLength(0);
+    client.close();
+  });
+
+  it("drops subscriptionsByObject entry on remove when no consumers remain", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a1", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+    const handleA = handle.objectByName("a1")!;
+    expect(handleA).toBeDefined();
+    // No subscribers ever registered — purely a passive object reference.
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: { interestName: "i1", added: [], removed: ["a1"], types: [], typeSchemas: "" },
+    });
+    // Re-add the same name. If subscriptionsByObject had leaked, the new entry would alias
+    // the old sticky-state. We assert the new ObjectHandle is observably fresh: its cache
+    // is empty (next get() round-trips).
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a1", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+    expect(handle.objectByName("a1")).toBeDefined();
+    client.close();
+  });
+
+  it("objects() returns the same array reference between mutations", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    // Initial empty match set: repeated calls share the cached empty array.
+    const empty1 = handle.objects();
+    const empty2 = handle.objects();
+    expect(empty1).toBe(empty2);
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a1", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+
+    // Membership changed: new reference. Subsequent reads share the new cached array.
+    const afterAdd1 = handle.objects();
+    const afterAdd2 = handle.objects();
+    expect(afterAdd1).not.toBe(empty1);
+    expect(afterAdd1).toBe(afterAdd2);
+    expect(afterAdd1).toHaveLength(1);
+
+    // Idempotent update with no real change should still return the same cached reference.
+    // (An interestUpdate with empty added/removed shouldn't invalidate the cache.)
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: { interestName: "i1", added: [], removed: [], types: [], typeSchemas: "" },
+    });
+    expect(handle.objects()).toBe(afterAdd1);
+
+    // Removing flips identity again.
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: { interestName: "i1", added: [], removed: ["a1"], types: [], typeSchemas: "" },
+    });
+    const afterRemove = handle.objects();
+    expect(afterRemove).not.toBe(afterAdd1);
+    expect(afterRemove).toHaveLength(0);
+
+    client.close();
+  });
+
+  it("ignores interestUpdate scoped to a different interestName", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "other",
+        added: [{ objectName: "x", qualifiedClassName: "y", currentValues: [] }],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+    expect(handle.objects()).toHaveLength(0);
+    client.close();
+  });
+
+  it("fires onObjectAdded / onObjectRemoved callbacks", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    const added = vi.fn();
+    const removed = vi.fn();
+    handle.onObjectAdded(added);
+    handle.onObjectRemoved(removed);
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a1", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+    expect(added).toHaveBeenCalledTimes(1);
+    expect(added.mock.calls[0]![0].name).toBe("a1");
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: { interestName: "i1", added: [], removed: ["a1"], types: [], typeSchemas: "" },
+    });
+    expect(removed).toHaveBeenCalledWith("a1");
+    client.close();
+  });
+
+  it("cancel returned by onObjectAdded is idempotent", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    const added = vi.fn();
+    const cancel = handle.onObjectAdded(added);
+    cancel();
+    cancel(); // idempotent
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a1", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+    expect(added).not.toHaveBeenCalled();
+    client.close();
+  });
+});
+
+describe("InterestHandle.release", () => {
+  it("sends releaseInterest, clears the map, and unregisters from routing", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a1", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+    expect(handle.objects()).toHaveLength(1);
+
+    const releasePending = handle.release();
+    // grab + respond to the releaseInterest request
+    const lastFrame = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    expect(lastFrame.method).toBe("releaseInterest");
+    socket.simulateMessage({ jsonrpc: "2.0", id: lastFrame.id, result: null });
+    await releasePending;
+
+    expect(handle.objects()).toEqual([]);
+
+    // post-release: a stray interestUpdate for the same name should not repopulate the handle.
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "ghost", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+    expect(handle.objects()).toEqual([]);
+    client.close();
+  });
+
+  it("is idempotent: a second release() resolves without sending again", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    const releasePending = handle.release();
+    const lastFrame = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    socket.simulateMessage({ jsonrpc: "2.0", id: lastFrame.id, result: null });
+    await releasePending;
+
+    const before = socket.sentFrames.length;
+    await handle.release();
+    expect(socket.sentFrames.length).toBe(before);
+    client.close();
+  });
+});
+
+describe("InterestHandle post-release method guards", () => {
+  it("onObjectAdded / onObjectRemoved / getObjectsBatchState / asyncIterator throw InterestReleasedError after release()", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    const releasePending = handle.release();
+    const releaseReq = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    expect(releaseReq.method).toBe("releaseInterest");
+    socket.simulateMessage({ jsonrpc: "2.0", id: releaseReq.id, result: null });
+    await releasePending;
+
+    expect(() => handle.onObjectAdded(() => undefined)).toThrow(InterestReleasedError);
+    expect(() => handle.onObjectRemoved(() => undefined)).toThrow(InterestReleasedError);
+    await expect(handle.getObjectsBatchState()).rejects.toBeInstanceOf(InterestReleasedError);
+    const iter = handle[Symbol.asyncIterator]();
+    await expect(iter.next()).rejects.toBeInstanceOf(InterestReleasedError);
+
+    client.close();
+  });
+
+  it("post-release synchronous accessors keep working (objects/state are read-only views)", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    const releasePending = handle.release();
+    const releaseReq = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    socket.simulateMessage({ jsonrpc: "2.0", id: releaseReq.id, result: null });
+    await releasePending;
+
+    expect(handle.state).toBe("released");
+    expect(handle.objects()).toEqual([]);
+    expect(handle.objectByName("anything")).toBeUndefined();
+
+    client.close();
+  });
+
+});
+
+describe("InterestHandle state machine", () => {
+  it("starts in 'pending', transitions to 'active' after createInterest succeeds", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    // We can't get the handle yet (declareInterest hasn't resolved), but the wire request has
+    // been sent. Ack it.
+    respondToCreateInterest(socket);
+    const handle = await pending;
+    expect(handle.state).toBe("active");
+    client.close();
+  });
+
+  it("release-during-pending waits for createInterest to settle, then sends releaseInterest", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const declarePending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    // Pop a synchronous handle ref by waiting one tick and then peeking via the registry... we
+    // can't directly, so we simulate the user calling release() concurrently by awaiting
+    // declarePending then immediately release. The "pending" path is exercised by the
+    // release-after-rejection test below.
+    respondToCreateInterest(socket);
+    const handle = await declarePending;
+
+    const before = socket.sentFrames.length;
+    const releasePending = handle.release();
+    await tick();
+    const lastFrame = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    expect(lastFrame.method).toBe("releaseInterest");
+    socket.simulateMessage({ jsonrpc: "2.0", id: lastFrame.id, result: null });
+    await releasePending;
+    expect(handle.state).toBe("released");
+    expect(socket.sentFrames.length).toBeGreaterThan(before);
+    client.close();
+  });
+
+  it("release after createInterest rejection is a no-op (no wire releaseInterest)", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const declarePending = client.declareInterest({ name: "bad", query: "INVALID" });
+    await tick();
+    const createReq = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      id: createReq.id,
+      error: { code: -32602, message: "invalid query" },
+    });
+    let caught: unknown;
+    try {
+      await declarePending;
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+
+    // The handle the user would have gotten is now released. We can't reach it from outside
+    // (declareInterest threw before returning it), but the assertion is at the wire: no
+    // releaseInterest frame is sent.
+    const releaseFrames = socket.sentFrames
+      .map((f) => JSON.parse(f))
+      .filter((req: { method: string }) => req.method === "releaseInterest");
+    expect(releaseFrames).toHaveLength(0);
+    client.close();
+  });
+});
+
+describe("InterestHandle reestablish (via Client.reestablishAll)", () => {
+  it("fires onObjectRemoved for currently-matched objects before re-issuing createInterest", async () => {
+    // Reestablish is idempotent per connection epoch, so the scenario needs a real bounce;
+    // autoReestablish is off so this test drives the (single) pass by hand.
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const connectPending = connect({
+      url: "ws://test",
+      reconnect: { enabled: true, initialDelayMs: 1, maxDelayMs: 1, autoReestablish: false },
+      onError: () => undefined,
+      webSocketFactory: factory,
+    });
+    await tick();
+    MockWebSocket.lastInstance!.simulateOpen();
+    const client = await connectPending;
+    const socket = MockWebSocket.lastInstance!;
+
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    // Seed two matches.
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [
+          { objectName: "a1", qualifiedClassName: "demo.X", currentValues: [] },
+          { objectName: "a2", qualifiedClassName: "demo.X", currentValues: [] },
+        ],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+    expect(handle.objects().map((o) => o.name).sort()).toEqual(["a1", "a2"]);
+
+    const removed = vi.fn();
+    handle.onObjectRemoved(removed);
+
+    // Bounce the connection so the epoch advances and reestablish has work to do.
+    socket.simulateClose(1006);
+    await tick(20);
+    const socket2 = MockWebSocket.lastInstance!;
+    socket2.simulateOpen();
+    await tick();
+
+    // reestablishAll triggers handle.reestablish(); per the contract we want, every previously
+    // matched object should be reported removed BEFORE the new createInterest goes out.
+    const reestablished = client.reestablishAll();
+    expect(removed.mock.calls.map((c) => c[0]).sort()).toEqual(["a1", "a2"]);
+    expect(handle.objects()).toEqual([]);
+
+    // The fresh createInterest is on the wire; ack it and replay the same two objects.
+    const createReq = JSON.parse(socket2.sentFrames[socket2.sentFrames.length - 1]!);
+    expect(createReq.method).toBe("createInterest");
+    socket2.simulateMessage({ jsonrpc: "2.0", id: createReq.id, result: null });
+    await reestablished;
+
+    const added = vi.fn();
+    handle.onObjectAdded(added);
+    socket2.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [
+          { objectName: "a1", qualifiedClassName: "demo.X", currentValues: [] },
+          { objectName: "a2", qualifiedClassName: "demo.X", currentValues: [] },
+        ],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+    expect(added.mock.calls.map((c) => c[0].name).sort()).toEqual(["a1", "a2"]);
+    client.close();
+  });
+});
+
+describe("InterestHandle async iteration", () => {
+  it("yields objects already in the match set, then later arrivals, until released", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    // Seed two objects before iteration starts.
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [
+          { objectName: "a1", qualifiedClassName: "demo.X", currentValues: [] },
+          { objectName: "a2", qualifiedClassName: "demo.X", currentValues: [] },
+        ],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+
+    const seen: string[] = [];
+    const iter = (async () => {
+      for await (const obj of handle) {
+        seen.push(obj.name);
+        if (seen.length === 3) break;
+      }
+    })();
+
+    // Wait one tick for the iterator to drain the initial replay.
+    await tick();
+    expect(seen).toEqual(["a1", "a2"]);
+
+    // Push a late arrival; the iterator should pick it up and then break.
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a3", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+    await iter;
+    expect(seen).toEqual(["a1", "a2", "a3"]);
+    client.close();
+  });
+
+  it("exits cleanly when the interest is released mid-iteration", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    let iteratorDone = false;
+    const iter = (async () => {
+      for await (const _ of handle) {
+        // Will never enter: no objects pushed, then release() wakes us out.
+      }
+      iteratorDone = true;
+    })();
+
+    await tick();
+    expect(iteratorDone).toBe(false);
+
+    // Release the interest. The wire releaseInterest will be answered below.
+    const releasePromise = handle.release();
+    await tick();
+    const lastFrame = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    expect(lastFrame.method).toBe("releaseInterest");
+    socket.simulateMessage({ jsonrpc: "2.0", id: lastFrame.id, result: null });
+    await releasePromise;
+    await iter;
+    expect(iteratorDone).toBe(true);
+    client.close();
+  });
+
+  it("throws InterestReleasedError when iteration is started on a released interest", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const pending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    respondToCreateInterest(socket);
+    const handle = await pending;
+
+    const releasePromise = handle.release();
+    await tick();
+    const lastFrame = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    socket.simulateMessage({ jsonrpc: "2.0", id: lastFrame.id, result: null });
+    await releasePromise;
+
+    let caught: unknown;
+    try {
+      for await (const _ of handle) { /* unreachable */ }
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(InterestReleasedError);
+    client.close();
+  });
+});
+
+describe("InterestHandle pending-state interestUpdate race", () => {
+  it("queues an interestUpdate arriving before createInterest's response and drains on markActive", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const declarePending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    // createInterest is on the wire but unanswered. Server races an interestUpdate in.
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a1", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: [],
+        types: [],
+        typeSchemas: "",
+      },
+    });
+    // Now ack createInterest; the queued update should drain into the handle.
+    respondToCreateInterest(socket);
+    const handle = await declarePending;
+    expect(handle.objects().map((o) => o.name)).toEqual(["a1"]);
+
+    // A handler registered after the drain still sees the replayed object via onObjectAdded's
+    // built-in current-set replay (covered elsewhere), so the queue + replay combine cleanly.
+    client.close();
+  });
+
+  it("drops queued updates when the initial createInterest is rejected", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const declarePending = client.declareInterest({ name: "bad", query: "INVALID" });
+    await tick();
+    const createReq = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    // Update races in ahead of the error response.
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "bad",
+        added: [{ objectName: "ghost", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: [],
+        types: [],
+        typeSchemas: "",
+      },
+    });
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      id: createReq.id,
+      error: { code: -32602, message: "invalid query" },
+    });
+    await expect(declarePending).rejects.toThrow(/invalid query/);
+    // A later stray update for the same name must also be dropped (handle unregistered).
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "bad",
+        added: [{ objectName: "ghost2", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: [],
+        types: [],
+        typeSchemas: "",
+      },
+    });
+    client.close();
+  });
+
+  it("preserves arrival order when multiple updates queue before markActive", async () => {
+    const { client, socket } = await makeConnectedClient();
+    const declarePending = client.declareInterest({ name: "i1", query: "q" });
+    await tick();
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a1", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: [],
+        types: [],
+        typeSchemas: "",
+      },
+    });
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a2", qualifiedClassName: "demo.X", currentValues: [] }],
+        removed: ["a1"],
+        types: [],
+        typeSchemas: "",
+      },
+    });
+    respondToCreateInterest(socket);
+    const handle = await declarePending;
+    // After both updates drain in order, a1 was added then removed, a2 was added.
+    expect(handle.objects().map((o) => o.name)).toEqual(["a2"]);
+    client.close();
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/narrowing.test.ts
+++ b/components/jsonrpc/clients/typescript/test/narrowing.test.ts
@@ -1,0 +1,59 @@
+// === narrowing.test.ts ===============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect } from "vitest";
+import {
+  isPrimitive,
+  isQuantity,
+  isSequence,
+  isStruct,
+  isVariant,
+} from "../src/narrowing.js";
+import { Quantity, Variant } from "../src/index.js";
+
+const meters = { name: "meter", abbreviation: "m", category: "length" as const };
+
+describe("narrowing helpers", () => {
+  it("isQuantity identifies Quantity instances and rejects plain numbers", () => {
+    expect(isQuantity(new Quantity(10, meters))).toBe(true);
+    expect(isQuantity(10)).toBe(false);
+    expect(isQuantity({ value: 10, unit: meters })).toBe(false);
+  });
+
+  it("isVariant identifies Variant instances and rejects plain objects", () => {
+    expect(isVariant(new Variant("X", { a: 1 }))).toBe(true);
+    expect(isVariant({ type: "X", value: { a: 1 } })).toBe(false);
+    expect(isVariant("plain")).toBe(false);
+  });
+
+  it("isStruct identifies plain objects, excluding runtime classes and arrays", () => {
+    expect(isStruct({ a: 1, b: "s" })).toBe(true);
+    expect(isStruct([1, 2, 3])).toBe(false);
+    expect(isStruct(null)).toBe(false);
+    expect(isStruct(new Quantity(10, meters))).toBe(false);
+    expect(isStruct(new Variant("X", null))).toBe(false);
+    expect(isStruct("scalar")).toBe(false);
+  });
+
+  it("isSequence identifies arrays", () => {
+    expect(isSequence([1, 2, 3])).toBe(true);
+    expect(isSequence([])).toBe(true);
+    expect(isSequence("not-array")).toBe(false);
+    expect(isSequence({ length: 3 })).toBe(false);
+  });
+
+  it("isPrimitive identifies string / number / boolean / null", () => {
+    expect(isPrimitive("hello")).toBe(true);
+    expect(isPrimitive(42)).toBe(true);
+    expect(isPrimitive(false)).toBe(true);
+    expect(isPrimitive(null)).toBe(true);
+    expect(isPrimitive([])).toBe(false);
+    expect(isPrimitive({})).toBe(false);
+    expect(isPrimitive(new Quantity(10, meters))).toBe(false);
+    expect(isPrimitive(new Variant("X", null))).toBe(false);
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/notification_validators.test.ts
+++ b/components/jsonrpc/clients/typescript/test/notification_validators.test.ts
@@ -1,0 +1,140 @@
+// === notification_validators.test.ts =================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect } from "vitest";
+import {
+  isEventTriggeredNotification,
+  isInterestUpdateNotification,
+  isPropertyChangedNotification,
+  isTopologyChangedNotification,
+} from "../src/internal/notification_validators.js";
+
+describe("isPropertyChangedNotification", () => {
+  it("accepts a well-formed payload", () => {
+    expect(
+      isPropertyChangedNotification({
+        interestName: "i1",
+        objectName: "a1",
+        values: [{ propertyName: "x", value: "1" }],
+        timestamp: "2026-05-25",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects missing fields", () => {
+    expect(isPropertyChangedNotification({})).toBe(false);
+    expect(
+      isPropertyChangedNotification({
+        interestName: "i1",
+        objectName: "a1",
+        timestamp: "2026-05-25",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects wrong field types", () => {
+    expect(
+      isPropertyChangedNotification({
+        interestName: 42,
+        objectName: "a1",
+        values: [],
+        timestamp: "2026-05-25",
+      }),
+    ).toBe(false);
+    expect(
+      isPropertyChangedNotification({
+        interestName: "i1",
+        objectName: "a1",
+        values: "not-an-array",
+        timestamp: "2026-05-25",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects null / non-object roots", () => {
+    expect(isPropertyChangedNotification(null)).toBe(false);
+    expect(isPropertyChangedNotification("string")).toBe(false);
+    expect(isPropertyChangedNotification([])).toBe(false);
+  });
+});
+
+describe("isEventTriggeredNotification", () => {
+  it("accepts a well-formed payload", () => {
+    expect(
+      isEventTriggeredNotification({
+        interestName: "i1",
+        objectName: "a1",
+        eventName: "tick",
+        args: "[]",
+        timestamp: "2026-05-25",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects when args is not a string (would have been a wire-shape bug)", () => {
+    expect(
+      isEventTriggeredNotification({
+        interestName: "i1",
+        objectName: "a1",
+        eventName: "tick",
+        args: [],
+        timestamp: "2026-05-25",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isInterestUpdateNotification", () => {
+  it("accepts a well-formed payload", () => {
+    expect(
+      isInterestUpdateNotification({
+        interestName: "i1",
+        added: [],
+        removed: [],
+        types: [], typeSchemas: "",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects when arrays are missing or replaced with other shapes", () => {
+    expect(
+      isInterestUpdateNotification({
+        interestName: "i1",
+        added: {},
+        removed: [],
+        types: [], typeSchemas: "",
+      }),
+    ).toBe(false);
+    expect(
+      isInterestUpdateNotification({
+        interestName: "i1",
+        added: [],
+        removed: [],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isTopologyChangedNotification", () => {
+  it("accepts an empty sessions array", () => {
+    expect(isTopologyChangedNotification({ sessions: [] })).toBe(true);
+  });
+
+  it("accepts a populated sessions array", () => {
+    expect(
+      isTopologyChangedNotification({
+        sessions: [{ name: "local", buses: ["jsonrpc"] }],
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects when sessions is missing or not an array", () => {
+    expect(isTopologyChangedNotification({})).toBe(false);
+    expect(isTopologyChangedNotification({ sessions: "no" })).toBe(false);
+    expect(isTopologyChangedNotification(null)).toBe(false);
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/object_handle.test.ts
+++ b/components/jsonrpc/clients/typescript/test/object_handle.test.ts
@@ -1,0 +1,197 @@
+// === object_handle.test.ts ===========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, vi } from "vitest";
+import { ObjectHandle } from "../src/handles.js";
+import { JsonRpcClient, type TransportLike } from "../src/internal/protocol_client.js";
+import { ObjectSubscriptions } from "../src/internal/subscription_registry.js";
+import { TypeCache } from "../src/internal/type_cache.js";
+import { TransportError } from "../src/index.js";
+import type { CancelFn, CustomTypeSpec } from "../src/index.js";
+
+const aircraftClassSpec: CustomTypeSpec = {
+  name: "Aircraft",
+  qualifiedName: "demo.Aircraft",
+  description: "",
+  data: {
+    type: "sen.kernel.ClassTypeSpec",
+    value: {
+      properties: [
+        {
+          name: "altitude",
+          description: "",
+          category: "dynamicRO",
+          type: "f64",
+          transportMode: "unicast",
+          tags: [],
+          checkedSet: false,
+        },
+        {
+          name: "label",
+          description: "",
+          category: "dynamicRW",
+          type: "string",
+          transportMode: "unicast",
+          tags: [],
+          checkedSet: false,
+        },
+      ],
+      methods: [
+        {
+          name: "land",
+          description: "",
+          args: [{ name: "speed", description: "", type: "f64" }],
+          transportMode: "unicast",
+          constness: "nonConstant",
+          deferred: false,
+          returnType: "bool",
+          propertyRelation: "nonPropertyRelated",
+          localOnly: false,
+        },
+        {
+          name: "noop",
+          description: "",
+          args: [],
+          transportMode: "unicast",
+          constness: "nonConstant",
+          deferred: false,
+          returnType: "",
+          propertyRelation: "nonPropertyRelated",
+          localOnly: false,
+        },
+      ],
+      events: [],
+      constructor: {
+        name: "Aircraft",
+        description: "",
+        args: [],
+        transportMode: "unicast",
+        constness: "nonConstant",
+        deferred: false,
+        returnType: "",
+        propertyRelation: "nonPropertyRelated",
+        localOnly: false,
+      },
+      parents: [],
+      isInterface: false,
+    },
+  },
+};
+
+function makeRecordingTransport(responses: Map<string, unknown> = new Map()): {
+  transport: TransportLike;
+  call: ReturnType<typeof vi.fn>;
+} {
+  const call = vi.fn(async (req: { method: string }) => {
+    return responses.get(req.method);
+  });
+  const onNotification = vi.fn((): CancelFn => () => undefined);
+  return { transport: { call, onNotification }, call };
+}
+
+function makeHandle(transport: TransportLike, cache?: TypeCache): ObjectHandle {
+  const typeCache = cache ?? new TypeCache();
+  if (!typeCache.has("demo.Aircraft")) typeCache.set(aircraftClassSpec);
+  const reportError = (): void => undefined;
+  const protocol = new JsonRpcClient(transport, reportError);
+  const subs = new ObjectSubscriptions(
+    protocol,
+    typeCache,
+    "i1",
+    "a1",
+    "demo.Aircraft",
+    reportError,
+  );
+  return new ObjectHandle("a1", "demo.Aircraft", "i1", protocol, typeCache, subs);
+}
+
+describe("ObjectHandle.get", () => {
+  it("looks up the property type via the class spec and parses the response", async () => {
+    const { transport, call } = makeRecordingTransport(new Map([["getProperty", "1234.5"]]));
+    const handle = makeHandle(transport);
+    await expect(handle.get("altitude")).resolves.toBe(1234.5);
+    expect(call).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "getProperty",
+        params: { interestName: "i1", objectName: "a1", propertyName: "altitude" },
+      }),
+    );
+  });
+
+  it("throws TransportError for an unknown property name", async () => {
+    const { transport } = makeRecordingTransport();
+    const handle = makeHandle(transport);
+    await expect(handle.get("unknown")).rejects.toThrow(/property "unknown" not found/);
+  });
+});
+
+describe("ObjectHandle.set", () => {
+  it("encodes the value against the property type and sends it as a string", async () => {
+    const { transport, call } = makeRecordingTransport();
+    const handle = makeHandle(transport);
+    await handle.set("label", "hello");
+    expect(call).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "setProperty",
+        params: { interestName: "i1", objectName: "a1", propertyName: "label", value: '"hello"' },
+      }),
+    );
+  });
+
+  it("rejects a value whose shape doesn't match the property type", async () => {
+    const { transport } = makeRecordingTransport();
+    const handle = makeHandle(transport);
+    await expect(handle.set("altitude", "not-a-number")).rejects.toThrow(TransportError);
+  });
+});
+
+describe("ObjectHandle.invoke", () => {
+  it("encodes named args by spec order, sends argsJson, and parses the return", async () => {
+    const { transport, call } = makeRecordingTransport(new Map([["invoke", "true"]]));
+    const handle = makeHandle(transport);
+    await expect(handle.invoke("land", { speed: 120 })).resolves.toBe(true);
+    expect(call).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "invoke",
+        params: {
+          interestName: "i1",
+          objectName: "a1",
+          methodName: "land",
+          argsJson: "[120]",
+        },
+      }),
+    );
+  });
+
+  it("returns null for void methods regardless of the wire payload", async () => {
+    const { transport } = makeRecordingTransport(new Map([["invoke", "null"]]));
+    const handle = makeHandle(transport);
+    await expect(handle.invoke("noop")).resolves.toBeNull();
+  });
+
+  it("rejects when a required arg is omitted", async () => {
+    const { transport } = makeRecordingTransport();
+    const handle = makeHandle(transport);
+    await expect(handle.invoke("land", {})).rejects.toThrow(
+      /method "land" requires parameter "speed"/,
+    );
+  });
+
+  it("rejects when an unknown arg name is passed", async () => {
+    const { transport } = makeRecordingTransport();
+    const handle = makeHandle(transport);
+    await expect(handle.invoke("land", { speedd: 120 })).rejects.toThrow(
+      /method "land" has no parameter "speedd"; expected: \[speed\]/,
+    );
+  });
+
+  it("throws TransportError for an unknown method name", async () => {
+    const { transport } = makeRecordingTransport();
+    const handle = makeHandle(transport);
+    await expect(handle.invoke("teleport")).rejects.toThrow(/method "teleport" not found/);
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/parse_sen_timestamp.test.ts
+++ b/components/jsonrpc/clients/typescript/test/parse_sen_timestamp.test.ts
@@ -1,0 +1,48 @@
+// === parse_sen_timestamp.test.ts =====================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, expect, it } from "vitest";
+import { parseSenTimestamp } from "../src/handles.js";
+
+// Fixture mirrors the wire shape emitted by the C++ side's
+// libs/core/src/base/timestamp.cpp::toUtcStringNs (RFC-3339, UTC, 9-digit nanoseconds).
+// The cross-component contract is the "Wire types" table in components/jsonrpc/architecture.md.
+describe("parseSenTimestamp", () => {
+  it("parses the canonical RFC-3339 ns wire format", () => {
+    const parsed = parseSenTimestamp("2026-06-19T07:40:12.345678901Z");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.date.toISOString()).toBe("2026-06-19T07:40:12.345Z");
+    expect(parsed!.nanoseconds).toBe(678901);
+  });
+
+  it("preserves zero-padded sub-millisecond fractions", () => {
+    const parsed = parseSenTimestamp("2026-01-01T00:00:00.000000042Z");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.date.getTime()).toBe(Date.UTC(2026, 0, 1, 0, 0, 0, 0));
+    expect(parsed!.nanoseconds).toBe(42);
+  });
+
+  it("rejects the legacy space-separated microsecond format", () => {
+    expect(parseSenTimestamp("2026-06-19 07:40:12 345678")).toBeNull();
+  });
+
+  it("rejects fractional widths other than 9 digits", () => {
+    expect(parseSenTimestamp("2026-06-19T07:40:12.345Z")).toBeNull();
+    expect(parseSenTimestamp("2026-06-19T07:40:12.3456789012Z")).toBeNull();
+  });
+
+  it("rejects missing or wrong suffix", () => {
+    expect(parseSenTimestamp("2026-06-19T07:40:12.345678901")).toBeNull();
+    expect(parseSenTimestamp("2026-06-19T07:40:12.345678901+00:00")).toBeNull();
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    const parsed = parseSenTimestamp("  2026-06-19T07:40:12.000000000Z  ");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.nanoseconds).toBe(0);
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/parse_var.test.ts
+++ b/components/jsonrpc/clients/typescript/test/parse_var.test.ts
@@ -1,0 +1,347 @@
+// === parse_var.test.ts ===============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect } from "vitest";
+import { parseVar } from "../src/internal/var_codec.js";
+import { TypeCache } from "../src/internal/type_cache.js";
+import { Quantity, Variant, TransportError } from "../src/index.js";
+import type { CustomTypeSpec } from "../src/index.js";
+
+/** Seed a cache with the given specs and return it. */
+function cacheOf(...specs: CustomTypeSpec[]): TypeCache {
+  const cache = new TypeCache();
+  for (const s of specs) cache.set(s);
+  return cache;
+}
+
+const meters = { name: "meter", abbreviation: "m", category: "length" as const };
+
+describe("parseVar -- built-in primitives", () => {
+  it("string passes through verbatim", () => {
+    expect(parseVar("string", "hello", new TypeCache())).toBe("hello");
+  });
+  it("bool passes through verbatim", () => {
+    expect(parseVar("bool", true, new TypeCache())).toBe(true);
+  });
+  it("small integers + floats pass through verbatim as number", () => {
+    expect(parseVar("i32", 42, new TypeCache())).toBe(42);
+    expect(parseVar("u32", 999, new TypeCache())).toBe(999);
+    expect(parseVar("f64", 3.14, new TypeCache())).toBe(3.14);
+  });
+  it("i64/u64 arrive as decimal strings and decode to bigint", () => {
+    expect(parseVar("i64", "-9007199254740993", new TypeCache())).toBe(-9007199254740993n);
+    expect(parseVar("u64", "18446744073709551615", new TypeCache())).toBe(18446744073709551615n);
+  });
+  it("i64/u64 reject a JSON number (would silently truncate past 2^53)", () => {
+    expect(() => parseVar("u64", 42, new TypeCache())).toThrow(TransportError);
+    expect(() => parseVar("u64", 42, new TypeCache())).toThrow(/decimal string/);
+  });
+  it("i64/u64 reject malformed decimal strings", () => {
+    expect(() => parseVar("i64", "not-a-number", new TypeCache())).toThrow(TransportError);
+    expect(() => parseVar("u64", "1.5", new TypeCache())).toThrow(TransportError);
+  });
+  it("TimeStamp + Duration are strings on the wire", () => {
+    expect(parseVar("TimeStamp", "2026-05-24T12:00:00Z", new TypeCache())).toBe(
+      "2026-05-24T12:00:00Z",
+    );
+    expect(parseVar("Duration", "PT1.5S", new TypeCache())).toBe("PT1.5S");
+  });
+});
+
+describe("parseVar -- missing spec invariant", () => {
+  it("throws TransportError when a referenced custom type has no cached spec", () => {
+    expect(() => parseVar("pkg.Missing", {}, new TypeCache())).toThrow(TransportError);
+    expect(() => parseVar("pkg.Missing", {}, new TypeCache())).toThrow(/no type spec/);
+  });
+});
+
+describe("parseVar -- enum", () => {
+  const colorSpec: CustomTypeSpec = {
+    name: "Color",
+    qualifiedName: "demo.Color",
+    description: "",
+    data: {
+      type: "sen.kernel.EnumTypeSpec",
+      value: {
+        storageType: "uint8Type",
+        enums: [
+          { name: "red", key: 0, description: "" },
+          { name: "green", key: 1, description: "" },
+          { name: "blue", key: 2, description: "" },
+        ],
+      },
+    },
+  };
+
+  it("returns enum values as bare strings (decision B)", () => {
+    expect(parseVar("demo.Color", "red", cacheOf(colorSpec))).toBe("red");
+  });
+
+  it("throws if the wire value is not a string", () => {
+    expect(() => parseVar("demo.Color", 0, cacheOf(colorSpec))).toThrow(TransportError);
+  });
+
+  it("throws if the wire value isn't one of the spec's enumerators", () => {
+    expect(() => parseVar("demo.Color", "crimson", cacheOf(colorSpec))).toThrow(
+      /enum "demo\.Color" has no enumerator "crimson"/,
+    );
+  });
+});
+
+describe("parseVar -- Quantity", () => {
+  const altSpec: CustomTypeSpec = {
+    name: "Altitude",
+    qualifiedName: "demo.Altitude",
+    description: "",
+    data: {
+      type: "sen.kernel.QuantityTypeSpec",
+      value: {
+        elementType: { type: "sen.kernel.RealType", value: "float64Type" },
+        unit: meters,
+        minValue: 0,
+        maxValue: 50000,
+      },
+    },
+  };
+
+  it("constructs a Quantity carrying unit and bounds from the spec", () => {
+    const v = parseVar("demo.Altitude", 12345.6, cacheOf(altSpec));
+    expect(v).toBeInstanceOf(Quantity);
+    const q = v as Quantity;
+    expect(q.value).toBe(12345.6);
+    expect(q.unit.abbreviation).toBe("m");
+    expect(q.minValue).toBe(0);
+    expect(q.maxValue).toBe(50000);
+  });
+
+  it("throws if the wire value is not a number", () => {
+    expect(() => parseVar("demo.Altitude", "12345", cacheOf(altSpec))).toThrow(TransportError);
+  });
+});
+
+describe("parseVar -- sequence", () => {
+  const u32List: CustomTypeSpec = {
+    name: "U32List",
+    qualifiedName: "demo.U32List",
+    description: "",
+    data: {
+      type: "sen.kernel.SequenceTypeSpec",
+      value: { elementType: "u32", maxSize: null, fixedSize: false },
+    },
+  };
+
+  it("recursively parses each element against elementType", () => {
+    const v = parseVar("demo.U32List", [1, 2, 3], cacheOf(u32List));
+    expect(v).toEqual([1, 2, 3]);
+  });
+
+  it("throws if the wire value is not an array", () => {
+    expect(() => parseVar("demo.U32List", "not-an-array", cacheOf(u32List))).toThrow(
+      TransportError,
+    );
+  });
+});
+
+describe("parseVar -- struct", () => {
+  const pointSpec: CustomTypeSpec = {
+    name: "Point",
+    qualifiedName: "demo.Point",
+    description: "",
+    data: {
+      type: "sen.kernel.StructTypeSpec",
+      value: {
+        parent: "",
+        fields: [
+          { name: "x", description: "", type: "f64" },
+          { name: "y", description: "", type: "f64" },
+        ],
+      },
+    },
+  };
+
+  it("parses each declared field by name", () => {
+    const v = parseVar("demo.Point", { x: 1.5, y: -2.5 }, cacheOf(pointSpec));
+    expect(v).toEqual({ x: 1.5, y: -2.5 });
+  });
+
+  it("throws if the wire value is not an object", () => {
+    expect(() => parseVar("demo.Point", [1, 2], cacheOf(pointSpec))).toThrow(TransportError);
+  });
+});
+
+describe("parseVar -- struct with parent chain", () => {
+  const baseSpec: CustomTypeSpec = {
+    name: "Base",
+    qualifiedName: "demo.Base",
+    description: "",
+    data: {
+      type: "sen.kernel.StructTypeSpec",
+      value: {
+        parent: "",
+        fields: [{ name: "id", description: "", type: "string" }],
+      },
+    },
+  };
+  const childSpec: CustomTypeSpec = {
+    name: "Child",
+    qualifiedName: "demo.Child",
+    description: "",
+    data: {
+      type: "sen.kernel.StructTypeSpec",
+      value: {
+        parent: "demo.Base",
+        fields: [{ name: "value", description: "", type: "i32" }],
+      },
+    },
+  };
+
+  it("includes parent fields in the parsed result", () => {
+    const v = parseVar("demo.Child", { id: "x", value: 7 }, cacheOf(baseSpec, childSpec));
+    expect(v).toEqual({ id: "x", value: 7 });
+  });
+
+  it("throws if a parent struct isn't cached", () => {
+    expect(() => parseVar("demo.Child", { id: "x", value: 7 }, cacheOf(childSpec))).toThrow(
+      /parent struct "demo\.Base" not cached/,
+    );
+  });
+});
+
+describe("parseVar -- variant", () => {
+  const sleepingSpec: CustomTypeSpec = {
+    name: "Sleeping",
+    qualifiedName: "school.Sleeping",
+    description: "",
+    data: {
+      type: "sen.kernel.StructTypeSpec",
+      value: {
+        parent: "",
+        fields: [{ name: "since", description: "", type: "TimeStamp" }],
+      },
+    },
+  };
+  const doingNothingSpec: CustomTypeSpec = {
+    name: "DoingNothing",
+    qualifiedName: "school.DoingNothing",
+    description: "",
+    data: {
+      type: "sen.kernel.StructTypeSpec",
+      value: {
+        parent: "",
+        fields: [{ name: "since", description: "", type: "TimeStamp" }],
+      },
+    },
+  };
+  const statusSpec: CustomTypeSpec = {
+    name: "StudentStatus",
+    qualifiedName: "school.StudentStatus",
+    description: "",
+    data: {
+      type: "sen.kernel.VariantTypeSpec",
+      value: {
+        fields: [
+          { key: 0, description: "", type: "school.DoingNothing" },
+          { key: 1, description: "", type: "school.Sleeping" },
+        ],
+      },
+    },
+  };
+
+  it("matches the arm by qualified name", () => {
+    const v = parseVar(
+      "school.StudentStatus",
+      { type: "school.Sleeping", value: { since: "2026-05-24T12:00:00Z" } },
+      cacheOf(sleepingSpec, doingNothingSpec, statusSpec),
+    );
+    expect(v).toBeInstanceOf(Variant);
+    const sv = v as Variant;
+    expect(sv.type).toBe("school.Sleeping");
+    expect(sv.value).toEqual({ since: "2026-05-24T12:00:00Z" });
+  });
+
+  it("throws if the tag doesn't match any arm", () => {
+    expect(() =>
+      parseVar(
+        "school.StudentStatus",
+        { type: "school.Walking", value: {} },
+        cacheOf(sleepingSpec, doingNothingSpec, statusSpec),
+      ),
+    ).toThrow(/no arm matching tag "school\.Walking"/);
+  });
+
+  it("throws if the 'type' tag is not a string", () => {
+    expect(() =>
+      parseVar(
+        "school.StudentStatus",
+        { type: 0, value: {} },
+        cacheOf(sleepingSpec, doingNothingSpec, statusSpec),
+      ),
+    ).toThrow(/requires string "type" tag/);
+  });
+});
+
+describe("parseVar -- alias + optional", () => {
+  const aliasSpec: CustomTypeSpec = {
+    name: "Speed",
+    qualifiedName: "demo.Speed",
+    description: "",
+    data: { type: "sen.kernel.AliasTypeSpec", value: { aliasedType: "f64" } },
+  };
+  const maybeIdSpec: CustomTypeSpec = {
+    name: "MaybeId",
+    qualifiedName: "demo.MaybeId",
+    description: "",
+    data: { type: "sen.kernel.OptionalTypeSpec", value: { type: "string" } },
+  };
+
+  it("alias delegates to its aliased type", () => {
+    expect(parseVar("demo.Speed", 250.5, cacheOf(aliasSpec))).toBe(250.5);
+  });
+
+  it("optional returns null when the wire value is null", () => {
+    expect(parseVar("demo.MaybeId", null, cacheOf(maybeIdSpec))).toBeNull();
+  });
+
+  it("optional delegates to the inner type when non-null", () => {
+    expect(parseVar("demo.MaybeId", "abc", cacheOf(maybeIdSpec))).toBe("abc");
+  });
+});
+
+describe("parseVar -- ClassTypeSpec is not a value type", () => {
+  const classSpec: CustomTypeSpec = {
+    name: "Person",
+    qualifiedName: "school.Person",
+    description: "",
+    data: {
+      type: "sen.kernel.ClassTypeSpec",
+      value: {
+        properties: [],
+        methods: [],
+        events: [],
+        constructor: {
+          name: "Person",
+          description: "",
+          args: [],
+          transportMode: "unicast",
+          constness: "nonConstant",
+          deferred: false,
+          returnType: "",
+          propertyRelation: "nonPropertyRelated",
+          localOnly: false,
+        },
+        parents: [],
+        isInterface: false,
+      },
+    },
+  };
+
+  it("throws TransportError if asked to parse a class spec as a value", () => {
+    expect(() => parseVar("school.Person", {}, cacheOf(classSpec))).toThrow(
+      /not a value type/,
+    );
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/protocol_client.test.ts
+++ b/components/jsonrpc/clients/typescript/test/protocol_client.test.ts
@@ -1,0 +1,432 @@
+// === protocol_client.test.ts =========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, vi } from "vitest";
+import { JsonRpcClient, type TransportLike } from "../src/internal/protocol_client.js";
+import type {
+  CancelFn,
+  CustomTypeSpec,
+  EventTriggeredNotification,
+  InterestUpdateNotification,
+  ObjectInfos,
+  PropertyChangedNotification,
+} from "../src/index.js";
+import type { SubscribeBlock } from "../src/generated/index.js";
+
+/** Minimal recording transport for unit-testing the Layer 2 wrappers. */
+function makeRecordingTransport(): {
+  transport: TransportLike;
+  call: ReturnType<typeof vi.fn>;
+  onNotification: ReturnType<typeof vi.fn>;
+  setResponse(value: unknown): void;
+} {
+  let nextResponse: unknown;
+  const call = vi.fn(async (_req: { method: string; params?: unknown }) => nextResponse);
+  const onNotification = vi.fn(
+    (_args: { method: string; handler: (params: unknown) => void }): CancelFn => () => undefined,
+  );
+  return {
+    transport: { call, onNotification },
+    call,
+    onNotification,
+    setResponse(value) {
+      nextResponse = value;
+    },
+  };
+}
+
+describe("JsonRpcClient -- health + introspection", () => {
+  it("ping sends the right method and surfaces the result", async () => {
+    const t = makeRecordingTransport();
+    t.setResponse("pong");
+    const client = new JsonRpcClient(t.transport);
+    await expect(client.ping()).resolves.toBe("pong");
+    expect(t.call).toHaveBeenCalledWith({ method: "ping" });
+  });
+
+  it("listTopology returns the SessionInfoList result", async () => {
+    const t = makeRecordingTransport();
+    t.setResponse([{ name: "s1", buses: ["b1"] }]);
+    const client = new JsonRpcClient(t.transport);
+    await expect(client.listTopology()).resolves.toEqual([{ name: "s1", buses: ["b1"] }]);
+    expect(t.call).toHaveBeenCalledWith({ method: "listTopology" });
+  });
+
+  it("subscribeTopology sends the bare method", async () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    await client.subscribeTopology();
+    expect(t.call).toHaveBeenCalledWith({ method: "subscribeTopology" });
+  });
+
+  it("unsubscribeTopology sends the bare method", async () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    await client.unsubscribeTopology();
+    expect(t.call).toHaveBeenCalledWith({ method: "unsubscribeTopology" });
+  });
+
+  it("getTypes returns the StringList result", async () => {
+    const t = makeRecordingTransport();
+    t.setResponse(["A", "B"]);
+    const client = new JsonRpcClient(t.transport);
+    await expect(client.getTypes()).resolves.toEqual(["A", "B"]);
+    expect(t.call).toHaveBeenCalledWith({ method: "getTypes" });
+  });
+
+  it("getType sends qualifiedName + withSchema:null by default and returns TypeLookupResult", async () => {
+    const t = makeRecordingTransport();
+    const spec: CustomTypeSpec = {
+      name: "X",
+      qualifiedName: "pkg.X",
+      description: "",
+      data: { type: "sen.kernel.AliasTypeSpec", value: { aliasedType: "string" } },
+    };
+    const result = { spec, schema: "" };
+    t.setResponse(result);
+    const client = new JsonRpcClient(t.transport);
+    await expect(client.getType({ qualifiedName: "pkg.X" })).resolves.toEqual(result);
+    expect(t.call).toHaveBeenCalledWith({
+      method: "getType",
+      params: { qualifiedName: "pkg.X", withSchema: null },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+
+  it("getType forwards withSchema:true so the wire ships the schema fragment", async () => {
+    const t = makeRecordingTransport();
+    const result = {
+      spec: {
+        name: "X",
+        qualifiedName: "pkg.X",
+        description: "",
+        data: { type: "sen.kernel.AliasTypeSpec", value: { aliasedType: "string" } },
+      },
+      schema: '{"$id":"pkg.X","type":"string"}',
+    };
+    t.setResponse(result);
+    const client = new JsonRpcClient(t.transport);
+    await expect(client.getType({ qualifiedName: "pkg.X", withSchema: true })).resolves.toEqual(result);
+    expect(t.call).toHaveBeenCalledWith({
+      method: "getType",
+      params: { qualifiedName: "pkg.X", withSchema: true },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+});
+
+describe("JsonRpcClient -- interests", () => {
+  it("createInterest sends wire-faithful params and defaults subscribe + withSchemas to null", async () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    await client.createInterest({ interestName: "i1", query: "SELECT * FROM x" });
+    expect(t.call).toHaveBeenCalledWith({
+      method: "createInterest",
+      params: { interestName: "i1", query: "SELECT * FROM x", subscribe: null, withSchemas: null },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+
+  it("createInterest forwards a provided subscribe block", async () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    const sub: SubscribeBlock = {
+      properties: { type: "sen.components.jsonrpc.WildcardSelection", value: {} },
+      events: null,
+      maxRateHz: 30,
+    };
+    await client.createInterest({ interestName: "i1", query: "q", subscribe: sub });
+    expect(t.call).toHaveBeenCalledWith({
+      method: "createInterest",
+      params: { interestName: "i1", query: "q", subscribe: sub, withSchemas: null },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+
+  it("createInterest forwards withSchemas:true so the wire opts into schema shipping", async () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    await client.createInterest({ interestName: "i1", query: "q", withSchemas: true });
+    expect(t.call).toHaveBeenCalledWith({
+      method: "createInterest",
+      params: { interestName: "i1", query: "q", subscribe: null, withSchemas: true },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+
+  it("releaseInterest sends interestName", async () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    await client.releaseInterest({ interestName: "i1" });
+    expect(t.call).toHaveBeenCalledWith({
+      method: "releaseInterest",
+      params: { interestName: "i1" },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+
+  it("listObjects returns the ObjectInfos result", async () => {
+    const t = makeRecordingTransport();
+    const list: ObjectInfos = [
+      { objectName: "a", qualifiedClassName: "pkg.A" },
+      { objectName: "b", qualifiedClassName: "pkg.B" },
+    ];
+    t.setResponse(list);
+    const client = new JsonRpcClient(t.transport);
+    await expect(client.listObjects({ interestName: "i1" })).resolves.toEqual(list);
+    expect(t.call).toHaveBeenCalledWith({
+      method: "listObjects",
+      params: { interestName: "i1" },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+});
+
+describe("JsonRpcClient -- read/write", () => {
+  it("getProperty returns the string result verbatim (string-contract)", async () => {
+    const t = makeRecordingTransport();
+    t.setResponse("12345.6");
+    const client = new JsonRpcClient(t.transport);
+    await expect(
+      client.getProperty({ interestName: "i", objectName: "o", propertyName: "p" }),
+    ).resolves.toBe("12345.6");
+    expect(t.call).toHaveBeenCalledWith({
+      method: "getProperty",
+      params: { interestName: "i", objectName: "o", propertyName: "p" },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+
+  it("setProperty sends value as a string verbatim", async () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    await client.setProperty({
+      interestName: "i",
+      objectName: "o",
+      propertyName: "p",
+      value: '"hello"',
+    });
+    expect(t.call).toHaveBeenCalledWith({
+      method: "setProperty",
+      params: { interestName: "i", objectName: "o", propertyName: "p", value: '"hello"' },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+});
+
+describe("JsonRpcClient -- sticky subscriptions", () => {
+  it("subscribeProperty defaults maxRateHz to null when omitted", async () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    await client.subscribeProperty({ interestName: "i", objectName: "o", propertyName: "p" });
+    expect(t.call).toHaveBeenCalledWith({
+      method: "subscribeProperty",
+      params: { interestName: "i", objectName: "o", propertyName: "p", maxRateHz: null },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+
+  it("subscribeProperty forwards a provided maxRateHz", async () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    await client.subscribeProperty({
+      interestName: "i",
+      objectName: "o",
+      propertyName: "p",
+      maxRateHz: 60,
+    });
+    expect(t.call).toHaveBeenCalledWith({
+      method: "subscribeProperty",
+      params: { interestName: "i", objectName: "o", propertyName: "p", maxRateHz: 60 },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+
+  it("unsubscribeProperty sends the wire-faithful params", async () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    await client.unsubscribeProperty({ interestName: "i", objectName: "o", propertyName: "p" });
+    expect(t.call).toHaveBeenCalledWith({
+      method: "unsubscribeProperty",
+      params: { interestName: "i", objectName: "o", propertyName: "p" },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+
+  it("subscribeEvent + unsubscribeEvent send wire-faithful params", async () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    await client.subscribeEvent({ interestName: "i", objectName: "o", eventName: "e" });
+    expect(t.call).toHaveBeenLastCalledWith({
+      method: "subscribeEvent",
+      params: { interestName: "i", objectName: "o", eventName: "e" },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+    await client.unsubscribeEvent({ interestName: "i", objectName: "o", eventName: "e" });
+    expect(t.call).toHaveBeenLastCalledWith({
+      method: "unsubscribeEvent",
+      params: { interestName: "i", objectName: "o", eventName: "e" },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+
+  it("subscribeAll + unsubscribeAll send wire-faithful params", async () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    await client.subscribeAll({ interestName: "i", objectName: "o" });
+    expect(t.call).toHaveBeenLastCalledWith({
+      method: "subscribeAll",
+      params: { interestName: "i", objectName: "o", maxRateHz: null },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+    await client.subscribeAll({ interestName: "i", objectName: "o", maxRateHz: 10 });
+    expect(t.call).toHaveBeenLastCalledWith({
+      method: "subscribeAll",
+      params: { interestName: "i", objectName: "o", maxRateHz: 10 },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+    await client.unsubscribeAll({ interestName: "i", objectName: "o" });
+    expect(t.call).toHaveBeenLastCalledWith({
+      method: "unsubscribeAll",
+      params: { interestName: "i", objectName: "o" },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+});
+
+describe("JsonRpcClient -- invoke", () => {
+  it("invoke sends argsJson verbatim and returns the string result", async () => {
+    const t = makeRecordingTransport();
+    t.setResponse('"result-as-encoded-string"');
+    const client = new JsonRpcClient(t.transport);
+    const result = await client.invoke({
+      interestName: "i",
+      objectName: "o",
+      methodName: "doSomething",
+      argsJson: "[1, 2, 3]",
+    });
+    expect(result).toBe('"result-as-encoded-string"');
+    expect(t.call).toHaveBeenCalledWith({
+      method: "invoke",
+      params: {
+        interestName: "i",
+        objectName: "o",
+        methodName: "doSomething",
+        argsJson: "[1, 2, 3]",
+      },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+});
+
+describe("JsonRpcClient -- per-call options pass-through", () => {
+  it("timeoutMs and signal flow into transport.call", async () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    const ctrl = new AbortController();
+    await client.releaseInterest({ interestName: "i", timeoutMs: 5000, signal: ctrl.signal });
+    expect(t.call).toHaveBeenCalledWith({
+      method: "releaseInterest",
+      params: { interestName: "i" },
+      timeoutMs: 5000,
+      signal: ctrl.signal,
+    });
+  });
+});
+
+describe("JsonRpcClient -- notification dispatch", () => {
+  it("onPropertyChanged registers a handler under 'propertyChanged' and casts the payload", () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    const userHandler = vi.fn();
+    const cancel = client.onPropertyChanged(userHandler);
+    expect(t.onNotification).toHaveBeenCalledWith({
+      method: "propertyChanged",
+      handler: expect.any(Function),
+    });
+
+    const internalHandler = t.onNotification.mock.calls[0]![0].handler as (
+      params: unknown,
+    ) => void;
+    const payload: PropertyChangedNotification = {
+      interestName: "i",
+      objectName: "o",
+      values: [{ propertyName: "p", value: "1" }],
+      timestamp: "2026-05-24T12:00:00Z",
+    };
+    internalHandler(payload);
+    expect(userHandler).toHaveBeenCalledWith(payload);
+
+    expect(typeof cancel).toBe("function");
+  });
+
+  it("onEventTriggered routes through 'eventTriggered'", () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    const userHandler = vi.fn();
+    client.onEventTriggered(userHandler);
+    expect(t.onNotification).toHaveBeenCalledWith({
+      method: "eventTriggered",
+      handler: expect.any(Function),
+    });
+
+    const internalHandler = t.onNotification.mock.calls[0]![0].handler as (
+      params: unknown,
+    ) => void;
+    const payload: EventTriggeredNotification = {
+      interestName: "i",
+      objectName: "o",
+      eventName: "e",
+      args: "[]",
+      timestamp: "2026-05-24T12:00:00Z",
+    };
+    internalHandler(payload);
+    expect(userHandler).toHaveBeenCalledWith(payload);
+  });
+
+  it("onInterestUpdate routes through 'interestUpdate'", () => {
+    const t = makeRecordingTransport();
+    const client = new JsonRpcClient(t.transport);
+    const userHandler = vi.fn();
+    client.onInterestUpdate(userHandler);
+    expect(t.onNotification).toHaveBeenCalledWith({
+      method: "interestUpdate",
+      handler: expect.any(Function),
+    });
+
+    const internalHandler = t.onNotification.mock.calls[0]![0].handler as (
+      params: unknown,
+    ) => void;
+    const payload: InterestUpdateNotification = {
+      interestName: "i",
+      added: [{ objectName: "a", qualifiedClassName: "pkg.A", currentValues: [] }],
+      removed: [],
+      types: [],
+      typeSchemas: "",
+    };
+    internalHandler(payload);
+    expect(userHandler).toHaveBeenCalledWith(payload);
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/scaffold.test.ts
+++ b/components/jsonrpc/clients/typescript/test/scaffold.test.ts
@@ -1,0 +1,114 @@
+// === scaffold.test.ts ================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect } from "vitest";
+import {
+  Quantity,
+  Variant,
+  numberFromExact,
+  type CustomTypeSpec,
+  type PropertyValueList,
+  type UnitInfo,
+} from "../src/index.js";
+import type { MemberSelector, SubscribeBlock } from "../src/generated/index.js";
+
+describe("Stage 1 scaffold", () => {
+  it("Quantity carries value + unit and formats sensibly", () => {
+    const meters: UnitInfo = { name: "meter", abbreviation: "m", category: "length" };
+    const q = new Quantity(42, meters, 0, 1000);
+    expect(q.value).toBe(42);
+    expect(q.unit.abbreviation).toBe("m");
+    expect(q.minValue).toBe(0);
+    expect(q.maxValue).toBe(1000);
+    expect(q.toString()).toBe("42 m");
+  });
+
+  it("Quantity equality respects value, unit, and bounds", () => {
+    const meters: UnitInfo = { name: "meter", abbreviation: "m", category: "length" };
+    const a = new Quantity(10, meters, 0, 100);
+    const b = new Quantity(10, meters, 0, 100);
+    const c = new Quantity(10, meters, 0, 200);
+    expect(a.equals(b)).toBe(true);
+    expect(a.equals(c)).toBe(false);
+  });
+
+  it("Variant preserves discriminant and payload", () => {
+    const v = new Variant("Sleeping", { since: "2026-05-24T12:00:00Z", snortingVolume: 0.3 });
+    expect(v.type).toBe("Sleeping");
+    expect(v.value).toEqual({ since: "2026-05-24T12:00:00Z", snortingVolume: 0.3 });
+  });
+
+  it("MemberSelector discriminated union narrows on `type`", () => {
+    const wildcard: MemberSelector = { type: "sen.components.jsonrpc.WildcardSelection", value: {} };
+    const named: MemberSelector = {
+      type: "sen.components.jsonrpc.NamedSelection",
+      value: { memberNames: ["altitude", "heading"] },
+    };
+
+    function describe(sel: MemberSelector): string {
+      switch (sel.type) {
+        case "sen.components.jsonrpc.WildcardSelection":
+          return "all";
+        case "sen.components.jsonrpc.NamedSelection":
+          return sel.value.memberNames.join(",");
+      }
+    }
+
+    expect(describe(wildcard)).toBe("all");
+    expect(describe(named)).toBe("altitude,heading");
+  });
+
+  it("SubscribeBlock optionals accept null", () => {
+    const block: SubscribeBlock = {
+      properties: { type: "sen.components.jsonrpc.WildcardSelection", value: {} },
+      events: null,
+      maxRateHz: 30,
+    };
+    expect(block.events).toBeNull();
+    expect(block.maxRateHz).toBe(30);
+  });
+
+  it("PropertyValueList is a sequence of string-encoded values", () => {
+    const values: PropertyValueList = [
+      { propertyName: "altitude", value: "12345.6" },
+      { propertyName: "label", value: "\"hello\"" },
+    ];
+    expect(values).toHaveLength(2);
+    expect(values[0]?.value).toBe("12345.6");
+  });
+
+  it("CustomTypeSpec discriminated `data` narrows by arm", () => {
+    const spec: CustomTypeSpec = {
+      name: "Altitude",
+      qualifiedName: "demo.Altitude",
+      description: "Altitude in meters",
+      data: {
+        type: "sen.kernel.QuantityTypeSpec",
+        value: {
+          elementType: { type: "sen.kernel.RealType", value: "float64Type" },
+          unit: { name: "meter", abbreviation: "m", category: "length" },
+          minValue: 0,
+          maxValue: 50000,
+        },
+      },
+    };
+    if (spec.data.type === "sen.kernel.QuantityTypeSpec") {
+      expect(spec.data.value.unit.abbreviation).toBe("m");
+    } else {
+      throw new Error("expected QuantityTypeSpec arm");
+    }
+  });
+
+  it("numberFromExact narrows a safe bigint and throws past MAX_SAFE_INTEGER", () => {
+    expect(numberFromExact(42n)).toBe(42);
+    expect(numberFromExact(BigInt(Number.MAX_SAFE_INTEGER))).toBe(Number.MAX_SAFE_INTEGER);
+    expect(() => numberFromExact(BigInt(Number.MAX_SAFE_INTEGER) + 1n)).toThrow(RangeError);
+    expect(() => numberFromExact(BigInt(Number.MIN_SAFE_INTEGER) - 1n, "tickCount")).toThrow(
+      /tickCount/,
+    );
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/store/make_buffer_cell.test.ts
+++ b/components/jsonrpc/clients/typescript/test/store/make_buffer_cell.test.ts
@@ -1,0 +1,96 @@
+// === make_buffer_cell.test.ts ========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, vi } from "vitest";
+
+import { makeBufferCell } from "../../src/react/store/make_buffer_cell.js";
+
+describe("makeBufferCell", () => {
+  it("seeds via the producer on first read and caches the result", () => {
+    let calls = 0;
+    const cell = makeBufferCell<number>({
+      produce: () => ++calls,
+      rafBatch: false,
+    });
+    const a = cell.getView();
+    const b = cell.getView();
+    expect(a).toBe(b);
+    expect(calls).toBe(1);
+  });
+
+  it("invalidate clears the cache and fires subscribers (synchronous flush)", () => {
+    let calls = 0;
+    const cell = makeBufferCell<number>({
+      produce: () => ++calls,
+      rafBatch: false,
+    });
+    const listener = vi.fn();
+    cell.subscribe(listener);
+
+    cell.getView();
+    cell.invalidate();
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(cell.getView()).toBe(2);
+  });
+
+  it("subscribe cancel removes only that listener", () => {
+    const cell = makeBufferCell<number>({
+      produce: () => 0,
+      rafBatch: false,
+    });
+    const kept = vi.fn();
+    const dropped = vi.fn();
+    cell.subscribe(kept);
+    const cancel = cell.subscribe(dropped);
+    cancel();
+    cell.invalidate();
+    expect(kept).toHaveBeenCalledTimes(1);
+    expect(dropped).not.toHaveBeenCalled();
+  });
+
+  it("dispose silences subsequent invalidates", () => {
+    const cell = makeBufferCell<number>({
+      produce: () => 0,
+      rafBatch: false,
+    });
+    const listener = vi.fn();
+    cell.subscribe(listener);
+
+    cell.dispose();
+    cell.invalidate();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("the wrapper-around-mutable-backing convention works for zero-copy reads", () => {
+    // Pattern from the RFC: producer wraps a live mutable array. The wrapper identity
+    // flips per invalidate; the array reference inside is shared (no .slice).
+    const backing: number[] = [];
+    const cell = makeBufferCell<{ items: readonly number[] }>({
+      produce: () => ({ items: backing }),
+      rafBatch: false,
+    });
+
+    const v1 = cell.getView();
+    backing.push(1, 2, 3);
+    // Until invalidate fires, the cell returns the cached wrapper. The wrapper's items ref
+    // points at the live backing, so the consumer sees the appended values via the same
+    // wrapper. This matches event_store's intended consumption pattern.
+    expect(v1.items).toEqual([1, 2, 3]);
+
+    cell.invalidate();
+    const v2 = cell.getView();
+    expect(v2).not.toBe(v1); // fresh wrapper after invalidate
+    expect(v2.items).toBe(backing); // same backing
+    expect(v2.items).toEqual([1, 2, 3]);
+
+    // Append more, invalidate, observe.
+    backing.push(4);
+    cell.invalidate();
+    const v3 = cell.getView();
+    expect(v3.items).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/store/make_buffer_store.test.ts
+++ b/components/jsonrpc/clients/typescript/test/store/make_buffer_store.test.ts
@@ -1,0 +1,258 @@
+// === make_buffer_store.test.ts =======================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, vi } from "vitest";
+
+import { makeBufferStore } from "../../src/react/store/make_buffer_store.js";
+
+/**
+ * Tests use `rafBatch: false` for deterministic synchronous flush. The rAF path is verified
+ * separately in its own test using vitest fake timers — we don't want every test to depend on
+ * timer mocking.
+ */
+function makeStore<K, V>(produce: (key: K) => V) {
+  return makeBufferStore<K, V>({ produce, rafBatch: false });
+}
+
+describe("makeBufferStore", () => {
+  describe("view caching", () => {
+    it("caches the producer's return on first getView, returns same ref on repeat", () => {
+      let produceCalls = 0;
+      const store = makeStore<string, { items: number[] }>(() => {
+        produceCalls++;
+        return { items: [1, 2, 3] };
+      });
+
+      const a = store.getView("k");
+      const b = store.getView("k");
+      expect(a).toBe(b);
+      expect(produceCalls).toBe(1);
+    });
+
+    it("produces a fresh view after invalidate(key)", () => {
+      let produceCalls = 0;
+      const store = makeStore<string, number>(() => ++produceCalls);
+
+      const a = store.getView("k");
+      store.invalidate("k");
+      const b = store.getView("k");
+      expect(a).not.toBe(b);
+      expect(produceCalls).toBe(2);
+    });
+
+    it("dropKey clears the cache without firing listeners", () => {
+      let produceCalls = 0;
+      const store = makeStore<string, number>(() => ++produceCalls);
+      const listener = vi.fn();
+      store.subscribeKey("k", listener);
+
+      store.getView("k");
+      store.dropKey("k");
+      expect(listener).not.toHaveBeenCalled();
+
+      store.getView("k");
+      expect(produceCalls).toBe(2);
+    });
+
+    it("per-key cache is independent across keys", () => {
+      let calls = 0;
+      const store = makeStore<string, number>(() => ++calls);
+      store.getView("a");
+      store.getView("b");
+      store.getView("a");
+      store.getView("b");
+      expect(calls).toBe(2);
+    });
+  });
+
+  describe("listeners", () => {
+    it("invalidate(key) fires only that key's listeners + subscribeAll", () => {
+      const store = makeStore<string, number>(() => 0);
+      const onA = vi.fn();
+      const onB = vi.fn();
+      const onAll = vi.fn();
+      store.subscribeKey("a", onA);
+      store.subscribeKey("b", onB);
+      store.subscribeAll(onAll);
+
+      store.invalidate("a");
+      expect(onA).toHaveBeenCalledTimes(1);
+      expect(onB).not.toHaveBeenCalled();
+      expect(onAll).toHaveBeenCalledTimes(1);
+    });
+
+    it("subscribeKey cancel removes only that listener", () => {
+      const store = makeStore<string, number>(() => 0);
+      const kept = vi.fn();
+      const dropped = vi.fn();
+      store.subscribeKey("k", kept);
+      const cancel = store.subscribeKey("k", dropped);
+
+      cancel();
+      store.invalidate("k");
+      expect(kept).toHaveBeenCalledTimes(1);
+      expect(dropped).not.toHaveBeenCalled();
+    });
+
+    it("subscribeAll fires once per flush, not once per dirtied key", () => {
+      const store = makeStore<string, number>(() => 0);
+      const onAll = vi.fn();
+      store.subscribeAll(onAll);
+
+      // rafBatch is false, so each invalidate flushes synchronously.
+      store.invalidate("a");
+      store.invalidate("b");
+      store.invalidate("c");
+      // Each synchronous flush emits one global notification.
+      expect(onAll).toHaveBeenCalledTimes(3);
+    });
+
+    it("version bumps once per flush (rAF-batched), not once per dirtied key", () => {
+      const store = makeStore<string, number>(() => 0);
+      expect(store.getVersion()).toBe(0);
+      // rafBatch=false → each invalidate is its own synchronous flush.
+      store.invalidate("a");
+      store.invalidate("b");
+      expect(store.getVersion()).toBe(2);
+    });
+
+    it("subscribeAll cancel removes only that listener", () => {
+      const store = makeStore<string, number>(() => 0);
+      const kept = vi.fn();
+      const dropped = vi.fn();
+      store.subscribeAll(kept);
+      const cancel = store.subscribeAll(dropped);
+      cancel();
+      store.invalidate("anything");
+      expect(kept).toHaveBeenCalledTimes(1);
+      expect(dropped).not.toHaveBeenCalled();
+    });
+
+    it("throwing listener does not abort sibling per-key or subscribeAll fan-out", () => {
+      const store = makeStore<string, number>(() => 0);
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const throwingA = vi.fn(() => {
+        throw new Error("boom");
+      });
+      const siblingA = vi.fn();
+      const onB = vi.fn();
+      const onAll = vi.fn();
+      store.subscribeKey("a", throwingA);
+      store.subscribeKey("a", siblingA);
+      store.subscribeKey("b", onB);
+      store.subscribeAll(onAll);
+
+      store.invalidate("a");
+      store.invalidate("b");
+
+      expect(throwingA).toHaveBeenCalledTimes(1);
+      expect(siblingA).toHaveBeenCalledTimes(1);
+      expect(onB).toHaveBeenCalledTimes(1);
+      expect(onAll).toHaveBeenCalledTimes(2);
+      expect(errSpy).toHaveBeenCalled();
+      errSpy.mockRestore();
+    });
+  });
+
+  describe("rAF batching", () => {
+    it("coalesces multiple invalidates within one frame into a single flush", () => {
+      // The node test env has no global rAF; install a controllable one so we can observe
+      // batching. We define + delete on globalThis (rather than spyOn) because spyOn
+      // requires the property to already exist.
+      let pending: (() => void) | null = null;
+      const raf = vi.fn((cb: FrameRequestCallback) => {
+        pending = () => cb(0);
+        return 1;
+      });
+      const cancelRaf = vi.fn(() => {
+        pending = null;
+      });
+      (globalThis as unknown as { requestAnimationFrame: typeof raf }).requestAnimationFrame = raf;
+      (globalThis as unknown as { cancelAnimationFrame: typeof cancelRaf }).cancelAnimationFrame = cancelRaf;
+
+      const store = makeBufferStore<string, number>({
+        produce: () => 0,
+        rafBatch: true,
+      });
+      const onA = vi.fn();
+      const onB = vi.fn();
+      const onAll = vi.fn();
+      store.subscribeKey("a", onA);
+      store.subscribeKey("b", onB);
+      store.subscribeAll(onAll);
+
+      // Three invalidates in the same frame: one rAF scheduled.
+      store.invalidate("a");
+      store.invalidate("b");
+      store.invalidate("a"); // dup
+      expect(raf).toHaveBeenCalledTimes(1);
+      expect(onA).not.toHaveBeenCalled();
+      expect(onB).not.toHaveBeenCalled();
+      expect(onAll).not.toHaveBeenCalled();
+
+      // Drain the pending rAF: per-key listeners fire once each, global fires once.
+      pending!();
+      expect(onA).toHaveBeenCalledTimes(1);
+      expect(onB).toHaveBeenCalledTimes(1);
+      expect(onAll).toHaveBeenCalledTimes(1);
+
+      delete (globalThis as { requestAnimationFrame?: unknown }).requestAnimationFrame;
+      delete (globalThis as { cancelAnimationFrame?: unknown }).cancelAnimationFrame;
+    });
+
+    it("falls back to setTimeout when requestAnimationFrame is unavailable", () => {
+      // Vitest's node env has no global rAF; setTimeout is the documented fallback.
+      vi.useFakeTimers();
+      const store = makeBufferStore<string, number>({
+        produce: () => 0,
+        rafBatch: true,
+      });
+      const onAll = vi.fn();
+      store.subscribeAll(onAll);
+
+      store.invalidate("k");
+      expect(onAll).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(20);
+      expect(onAll).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    it("dispose cancels any pending rAF and silences subsequent invalidates", () => {
+      let pending: (() => void) | null = null;
+      const raf = vi.fn((cb: FrameRequestCallback) => {
+        pending = () => cb(0);
+        return 42;
+      });
+      const cancelRaf = vi.fn(() => {
+        pending = null;
+      });
+      (globalThis as unknown as { requestAnimationFrame: typeof raf }).requestAnimationFrame = raf;
+      (globalThis as unknown as { cancelAnimationFrame: typeof cancelRaf }).cancelAnimationFrame = cancelRaf;
+
+      const store = makeBufferStore<string, number>({
+        produce: () => 0,
+        rafBatch: true,
+      });
+      const onAll = vi.fn();
+      store.subscribeAll(onAll);
+
+      store.invalidate("k");
+      expect(pending).not.toBeNull();
+      store.dispose();
+      expect(cancelRaf).toHaveBeenCalledWith(42);
+
+      // Post-dispose invalidate is a no-op: it schedules nothing and fires no listeners.
+      store.invalidate("k");
+      expect(onAll).not.toHaveBeenCalled();
+      expect(raf).toHaveBeenCalledTimes(1);
+
+      delete (globalThis as { requestAnimationFrame?: unknown }).requestAnimationFrame;
+      delete (globalThis as { cancelAnimationFrame?: unknown }).cancelAnimationFrame;
+    });
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/store/make_store.test.ts
+++ b/components/jsonrpc/clients/typescript/test/store/make_store.test.ts
@@ -1,0 +1,101 @@
+// === make_store.test.ts ==============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, vi } from "vitest";
+
+import { makeStore } from "../../src/react/store/make_store.js";
+
+describe("makeStore", () => {
+  it("seeds with the initial value and returns it from getState", () => {
+    const store = makeStore({ count: 7 });
+    expect(store.getState()).toEqual({ count: 7 });
+  });
+
+  it("setState with a value swaps state and notifies subscribers", () => {
+    const store = makeStore({ count: 0 });
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.setState({ count: 1 });
+    expect(store.getState()).toEqual({ count: 1 });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("setState with an updater function receives prev and applies its return", () => {
+    const store = makeStore({ count: 5 });
+    store.setState((prev) => ({ count: prev.count + 1 }));
+    expect(store.getState()).toEqual({ count: 6 });
+  });
+
+  it("no-ops when the updater returns an Object.is-equal value", () => {
+    const initial = { count: 0 };
+    const store = makeStore(initial);
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.setState(initial);
+    expect(listener).not.toHaveBeenCalled();
+
+    store.setState((prev) => prev);
+    expect(listener).not.toHaveBeenCalled();
+
+    expect(store.getState()).toBe(initial);
+  });
+
+  it("fires every subscribed listener on each non-no-op setState", () => {
+    const store = makeStore(0);
+    const a = vi.fn();
+    const b = vi.fn();
+    store.subscribe(a);
+    store.subscribe(b);
+
+    store.setState(1);
+    store.setState(2);
+    expect(a).toHaveBeenCalledTimes(2);
+    expect(b).toHaveBeenCalledTimes(2);
+  });
+
+  it("subscribe returns a cancel that removes only that listener", () => {
+    const store = makeStore(0);
+    const kept = vi.fn();
+    const dropped = vi.fn();
+    store.subscribe(kept);
+    const cancel = store.subscribe(dropped);
+
+    cancel();
+    store.setState(1);
+    expect(kept).toHaveBeenCalledTimes(1);
+    expect(dropped).not.toHaveBeenCalled();
+  });
+
+  it("dispose clears all listeners and silences subsequent setState", () => {
+    const store = makeStore(0);
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.dispose();
+    store.setState(99);
+    expect(listener).not.toHaveBeenCalled();
+    // State stays at the last value pre-dispose; setState is a no-op after.
+    expect(store.getState()).toBe(0);
+  });
+
+  it("handles primitive state values (numbers, strings)", () => {
+    const numStore = makeStore(0);
+    numStore.setState((n) => n + 10);
+    expect(numStore.getState()).toBe(10);
+
+    const strStore = makeStore("hello");
+    const listener = vi.fn();
+    strStore.subscribe(listener);
+    strStore.setState("world");
+    expect(strStore.getState()).toBe("world");
+    expect(listener).toHaveBeenCalledTimes(1);
+    strStore.setState("world"); // Object.is-equal string, no-op
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/store/use_store.test.ts
+++ b/components/jsonrpc/clients/typescript/test/store/use_store.test.ts
@@ -1,0 +1,91 @@
+// === use_store.test.ts ===============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect } from "vitest";
+
+import { __selectorMemoStep } from "../../src/react/store/use_store.js";
+
+/**
+ * Tests for the snapshot-stability logic at the heart of `useSelector`. The hook itself
+ * runs in React; we extract the memoization step into a pure function so the contract is
+ * directly testable without jsdom + RTL.
+ *
+ * The properties under test correspond to the three branches of `__selectorMemoStep`:
+ *  1. Same state ref → return cached pair (StrictMode double-invoke safety).
+ *  2. Different state, same selector output by Object.is → refresh state ref, keep
+ *     cached `selected` (selector-identity stability across consumer-irrelevant state
+ *     mutations).
+ *  3. Different state AND different selector output → install fresh pair.
+ */
+describe("__selectorMemoStep", () => {
+  it("returns the cached memo when state ref is unchanged (StrictMode double-invoke safety)", () => {
+    const state = { a: 1, b: 2 };
+    const selector = (s: typeof state) => s.a;
+    const first = __selectorMemoStep(state, selector, null);
+    // Second call with the SAME state ref — StrictMode simulates this by calling
+    // getSnapshot twice per render.
+    const second = __selectorMemoStep(state, selector, first);
+    expect(second).toBe(first);
+    expect(second.selected).toBe(1);
+  });
+
+  it("returns a fresh memo when called for the first time", () => {
+    const state = { a: 42 };
+    const result = __selectorMemoStep(state, (s) => s.a, null);
+    expect(result.state).toBe(state);
+    expect(result.selected).toBe(42);
+  });
+
+  it("keeps the cached `selected` ref when state changes but selector output is Object.is-equal", () => {
+    const stateA = { a: 1, b: 2 };
+    const stateB = { a: 1, b: 99 }; // `a` unchanged; selector sees same value
+    const selector = (s: typeof stateA) => s.a;
+    const first = __selectorMemoStep(stateA, selector, null);
+    const second = __selectorMemoStep(stateB, selector, first);
+    // State ref updated.
+    expect(second.state).toBe(stateB);
+    // Selected ref preserved — this is what gates React's `Object.is` bailout downstream.
+    expect(second.selected).toBe(first.selected);
+  });
+
+  it("installs the fresh pair when both state and selected change", () => {
+    const stateA = { a: 1 };
+    const stateB = { a: 2 };
+    const selector = (s: typeof stateA) => s.a;
+    const first = __selectorMemoStep(stateA, selector, null);
+    const second = __selectorMemoStep(stateB, selector, first);
+    expect(second.state).toBe(stateB);
+    expect(second.selected).toBe(2);
+    expect(second).not.toBe(first);
+  });
+
+  it("works with selectors returning reference types (keeps cached ref when value-equal)", () => {
+    // A selector returning a derived array would defeat the optimization (fresh ref every
+    // time), but a selector returning a stored Set / Map reference works correctly because
+    // the consumer cached it on state.
+    const setA = new Set([1, 2, 3]);
+    const stateA = { items: setA };
+    const stateB = { items: setA }; // SAME Set ref, different state object
+    const selector = (s: { items: Set<number> }) => s.items;
+    const first = __selectorMemoStep(stateA, selector, null);
+    const second = __selectorMemoStep(stateB, selector, first);
+    expect(second.state).toBe(stateB);
+    expect(second.selected).toBe(setA);
+  });
+
+  it("handles selectors returning primitive false/0/'' correctly (does not treat as null)", () => {
+    // Guard against accidental `!memo.selected` treatment of falsy values.
+    let state = { ready: false };
+    const memo = __selectorMemoStep(state, (s) => s.ready, null);
+    expect(memo.selected).toBe(false);
+    state = { ready: false };
+    const memo2 = __selectorMemoStep(state, (s) => s.ready, memo);
+    // Even though `selected` is `false`, the equality check on Object.is(false, false) holds.
+    expect(memo2.selected).toBe(false);
+    expect(memo2.state).toBe(state);
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/subscribe_codec.test.ts
+++ b/components/jsonrpc/clients/typescript/test/subscribe_codec.test.ts
@@ -1,0 +1,97 @@
+// === subscribe_codec.test.ts =========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect } from "vitest";
+import { toWireSubscribeBlock } from "../src/internal/subscribe_codec.js";
+
+describe("toWireSubscribeBlock", () => {
+  it("returns null when subscribe is undefined", () => {
+    expect(toWireSubscribeBlock(undefined)).toBeNull();
+  });
+
+  it("emits wildcard selector for properties: '*'", () => {
+    expect(toWireSubscribeBlock({ properties: "*" })).toEqual({
+      properties: { type: "sen.components.jsonrpc.WildcardSelection", value: {} },
+      events: null,
+      maxRateHz: null,
+    });
+  });
+
+  it("emits named selector for properties: [...]", () => {
+    expect(toWireSubscribeBlock({ properties: ["altitude", "speed"] })).toEqual({
+      properties: {
+        type: "sen.components.jsonrpc.NamedSelection",
+        value: { memberNames: ["altitude", "speed"] },
+      },
+      events: null,
+      maxRateHz: null,
+    });
+  });
+
+  it("emits wildcard selector for events: '*'", () => {
+    expect(toWireSubscribeBlock({ events: "*" })).toEqual({
+      properties: null,
+      events: { type: "sen.components.jsonrpc.WildcardSelection", value: {} },
+      maxRateHz: null,
+    });
+  });
+
+  it("emits named selector for events: [...]", () => {
+    expect(toWireSubscribeBlock({ events: ["landed", "takenOff"] })).toEqual({
+      properties: null,
+      events: {
+        type: "sen.components.jsonrpc.NamedSelection",
+        value: { memberNames: ["landed", "takenOff"] },
+      },
+      maxRateHz: null,
+    });
+  });
+
+  it("passes maxRateHz through", () => {
+    expect(toWireSubscribeBlock({ properties: "*", maxRateHz: 10 })).toEqual({
+      properties: { type: "sen.components.jsonrpc.WildcardSelection", value: {} },
+      events: null,
+      maxRateHz: 10,
+    });
+  });
+
+  it("combines properties, events, and maxRateHz", () => {
+    expect(
+      toWireSubscribeBlock({
+        properties: ["altitude"],
+        events: "*",
+        maxRateHz: 5,
+      }),
+    ).toEqual({
+      properties: {
+        type: "sen.components.jsonrpc.NamedSelection",
+        value: { memberNames: ["altitude"] },
+      },
+      events: { type: "sen.components.jsonrpc.WildcardSelection", value: {} },
+      maxRateHz: 5,
+    });
+  });
+
+  it("handles an empty object as 'subscribe to nothing' (all fields null)", () => {
+    expect(toWireSubscribeBlock({})).toEqual({
+      properties: null,
+      events: null,
+      maxRateHz: null,
+    });
+  });
+
+  it("handles an empty selector array as 'subscribe to no named members'", () => {
+    expect(toWireSubscribeBlock({ properties: [] })).toEqual({
+      properties: {
+        type: "sen.components.jsonrpc.NamedSelection",
+        value: { memberNames: [] },
+      },
+      events: null,
+      maxRateHz: null,
+    });
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/subscriptions.test.ts
+++ b/components/jsonrpc/clients/typescript/test/subscriptions.test.ts
@@ -1,0 +1,825 @@
+// === subscriptions.test.ts ===========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, vi } from "vitest";
+import { connect } from "../src/connect.js";
+import type { WebSocketFactory } from "../src/internal/transport.js";
+import { MockWebSocket, tick } from "./test_helpers/mock_websocket.js";
+import type { CustomTypeSpec, InterestUpdateNotification } from "../src/index.js";
+
+const aircraftClassSpec: CustomTypeSpec = {
+  name: "Aircraft",
+  qualifiedName: "demo.Aircraft",
+  description: "",
+  data: {
+    type: "sen.kernel.ClassTypeSpec",
+    value: {
+      properties: [
+        {
+          name: "altitude",
+          description: "",
+          category: "dynamicRO",
+          type: "f64",
+          transportMode: "unicast",
+          tags: [],
+          checkedSet: false,
+        },
+        {
+          name: "label",
+          description: "",
+          category: "dynamicRW",
+          type: "string",
+          transportMode: "unicast",
+          tags: [],
+          checkedSet: false,
+        },
+      ],
+      methods: [],
+      events: [
+        {
+          name: "landed",
+          description: "",
+          args: [{ name: "speed", description: "", type: "f64" }],
+          transportMode: "unicast",
+        },
+      ],
+      constructor: {
+        name: "Aircraft",
+        description: "",
+        args: [],
+        transportMode: "unicast",
+        constness: "nonConstant",
+        deferred: false,
+        returnType: "",
+        propertyRelation: "nonPropertyRelated",
+        localOnly: false,
+      },
+      parents: [],
+      isInterface: false,
+    },
+  },
+};
+
+async function setup() {
+  const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+  const pending = connect({
+    url: "ws://test",
+    reconnect: { enabled: true, initialDelayMs: 1, maxDelayMs: 1 },
+      onError: () => undefined,
+    webSocketFactory: factory,
+  });
+  await tick();
+  MockWebSocket.lastInstance!.simulateOpen();
+  const client = await pending;
+  const socket = MockWebSocket.lastInstance!;
+
+  // Declare an interest and ack it.
+  const declarePending = client.declareInterest({ name: "i1", query: "q" });
+  await tick();
+  const createReq = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+  expect(createReq.method).toBe("createInterest");
+  socket.simulateMessage({ jsonrpc: "2.0", id: createReq.id, result: null });
+  const interest = await declarePending;
+
+  // Push interestUpdate.added with the class spec bundled, mimicking the server.
+  const update: InterestUpdateNotification = {
+    interestName: "i1",
+    added: [{ objectName: "a1", qualifiedClassName: "demo.Aircraft", currentValues: [] }],
+    removed: [],
+    types: [aircraftClassSpec],
+    typeSchemas: "",
+  };
+  socket.simulateMessage({ jsonrpc: "2.0", method: "interestUpdate", params: update });
+  await tick();
+
+  const obj = interest.objectByName("a1")!;
+  return { client, socket, interest, obj };
+}
+
+function findRequest(socket: MockWebSocket, method: string): { id: number; params?: unknown } | undefined {
+  for (let i = socket.sentFrames.length - 1; i >= 0; i--) {
+    const frame = JSON.parse(socket.sentFrames[i]!);
+    if (frame.method === method) return frame;
+  }
+  return undefined;
+}
+
+describe("ObjectHandle.onPropertyChanged -- wire-side coordination", () => {
+  it("issues subscribeProperty on first consumer, unsubscribeProperty when last cancels", async () => {
+    const { client, socket, obj } = await setup();
+
+    const cancel = obj.onPropertyChanged("altitude", vi.fn());
+    await tick();
+    const sub = findRequest(socket, "subscribeProperty")!;
+    expect(sub.params).toEqual({
+      interestName: "i1",
+      objectName: "a1",
+      propertyName: "altitude",
+      maxRateHz: null,
+    });
+    socket.simulateMessage({ jsonrpc: "2.0", id: sub.id, result: null });
+
+    cancel();
+    await tick();
+    const unsub = findRequest(socket, "unsubscribeProperty")!;
+    expect(unsub.params).toEqual({ interestName: "i1", objectName: "a1", propertyName: "altitude" });
+    socket.simulateMessage({ jsonrpc: "2.0", id: unsub.id, result: null });
+    client.close();
+  });
+
+  it("multi-consumer fan-out: one wire subscribe; both handlers fire on propertyChanged", async () => {
+    const { client, socket, obj } = await setup();
+
+    const a = vi.fn();
+    const b = vi.fn();
+    obj.onPropertyChanged("altitude", a);
+    obj.onPropertyChanged("altitude", b);
+    await tick();
+
+    // exactly one subscribeProperty across both consumers
+    const subscribes = socket.sentFrames
+      .map((f) => JSON.parse(f))
+      .filter((req: { method: string }) => req.method === "subscribeProperty");
+    expect(subscribes).toHaveLength(1);
+
+    // simulate propertyChanged bundle
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "propertyChanged",
+      params: {
+        interestName: "i1",
+        objectName: "a1",
+        values: [{ propertyName: "altitude", value: "1234.5" }],
+        timestamp: "2026-05-24T00:00:00Z",
+      },
+    });
+    expect(a).toHaveBeenCalledWith(1234.5, expect.objectContaining({ timestamp: expect.any(String) }));
+    expect(b).toHaveBeenCalledWith(1234.5, expect.objectContaining({ timestamp: expect.any(String) }));
+    client.close();
+  });
+
+  it("idempotent cancel: same cancel called twice doesn't unsubscribe twice", async () => {
+    const { client, socket, obj } = await setup();
+    const cancel = obj.onPropertyChanged("altitude", vi.fn());
+    await tick();
+    const before = socket.sentFrames.length;
+    cancel();
+    cancel(); // idempotent
+    await tick();
+    const unsubs = socket.sentFrames
+      .slice(before)
+      .map((f) => JSON.parse(f))
+      .filter((req: { method: string }) => req.method === "unsubscribeProperty");
+    expect(unsubs).toHaveLength(1);
+    client.close();
+  });
+
+  it("AbortSignal abort cancels the subscription (idempotent with explicit cancel)", async () => {
+    const { client, socket, obj } = await setup();
+    const ctrl = new AbortController();
+    const handler = vi.fn();
+    const cancel = obj.onPropertyChanged("altitude", handler, { signal: ctrl.signal });
+    await tick();
+    ctrl.abort();
+    await tick();
+    // a propertyChanged after abort doesn't fire the handler
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "propertyChanged",
+      params: {
+        interestName: "i1",
+        objectName: "a1",
+        values: [{ propertyName: "altitude", value: "1" }],
+        timestamp: "2026-05-24T00:00:00Z",
+      },
+    });
+    expect(handler).not.toHaveBeenCalled();
+    // explicit cancel after abort is a no-op
+    cancel();
+    client.close();
+  });
+
+  it("only one wire unsubscribe when the last of many consumers cancels", async () => {
+    const { client, socket, obj } = await setup();
+    const c1 = obj.onPropertyChanged("altitude", vi.fn());
+    const c2 = obj.onPropertyChanged("altitude", vi.fn());
+    await tick();
+
+    c1();
+    await tick();
+    // refcount still > 0; no unsubscribe yet
+    expect(findRequest(socket, "unsubscribeProperty")).toBeUndefined();
+
+    c2();
+    await tick();
+    expect(findRequest(socket, "unsubscribeProperty")).toBeDefined();
+    client.close();
+  });
+
+  it("multiple properties: each gets its own wire subscribe and dispatch", async () => {
+    const { client, socket, obj } = await setup();
+    const altHandler = vi.fn();
+    const labelHandler = vi.fn();
+    obj.onPropertyChanged("altitude", altHandler);
+    obj.onPropertyChanged("label", labelHandler);
+    await tick();
+
+    const subs = socket.sentFrames
+      .map((f) => JSON.parse(f))
+      .filter((req: { method: string }) => req.method === "subscribeProperty");
+    expect(subs).toHaveLength(2);
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "propertyChanged",
+      params: {
+        interestName: "i1",
+        objectName: "a1",
+        values: [
+          { propertyName: "altitude", value: "100" },
+          { propertyName: "label", value: '"hello"' },
+        ],
+        timestamp: "2026-05-24",
+      },
+    });
+    expect(altHandler).toHaveBeenCalledWith(100, expect.objectContaining({ timestamp: expect.any(String) }));
+    expect(labelHandler).toHaveBeenCalledWith("hello", expect.objectContaining({ timestamp: expect.any(String) }));
+    client.close();
+  });
+});
+
+describe("ObjectHandle.onPropertyChanged -- value cache freshness", () => {
+  it("after last consumer cancels, a fresh subscribe does not replay the stale cached value", async () => {
+    const { client, socket, obj } = await setup();
+
+    // First subscriber: install, receive a value, cancel.
+    const first = vi.fn();
+    const cancelFirst = obj.onPropertyChanged("altitude", first);
+    await tick();
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "propertyChanged",
+      params: {
+        interestName: "i1",
+        objectName: "a1",
+        values: [{ propertyName: "altitude", value: "100" }],
+        timestamp: "2026-05-24T00:00:00Z",
+      },
+    });
+    expect(first).toHaveBeenCalledWith(100, expect.anything());
+    cancelFirst();
+    await tick();
+
+    // Second subscriber: must NOT receive the stale 100 via replay; the wire will deliver
+    // a fresh value next.
+    const second = vi.fn();
+    obj.onPropertyChanged("altitude", second);
+    await tick();
+    expect(second).not.toHaveBeenCalled();
+
+    // Simulate the fresh wire-pushed value after the re-subscribe.
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "propertyChanged",
+      params: {
+        interestName: "i1",
+        objectName: "a1",
+        values: [{ propertyName: "altitude", value: "200" }],
+        timestamp: "2026-05-24T00:00:01Z",
+      },
+    });
+    expect(second).toHaveBeenCalledWith(200, expect.anything());
+    client.close();
+  });
+
+  it("subscribeAll keeps the per-property cache alive across per-property unsub+resub", async () => {
+    const { client, socket, obj } = await setup();
+
+    // onAnyChange keeps a wire subscribeAll active, which keeps valueCache fresh even while
+    // per-property has no consumer.
+    obj.onAnyChange(vi.fn());
+    await tick();
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "propertyChanged",
+      params: {
+        interestName: "i1",
+        objectName: "a1",
+        values: [{ propertyName: "altitude", value: "55" }],
+        timestamp: "2026-05-24T00:00:00Z",
+      },
+    });
+
+    // No per-property sub has run yet; install + cancel.
+    const probe = vi.fn();
+    const cancelProbe = obj.onPropertyChanged("altitude", probe);
+    await tick();
+    expect(probe).toHaveBeenCalledWith(55, expect.anything()); // replay from cache
+    cancelProbe();
+    await tick();
+
+    // Resubscribe; the cached value should still replay because subscribeAll has been
+    // keeping it fresh.
+    const after = vi.fn();
+    obj.onPropertyChanged("altitude", after);
+    await tick();
+    expect(after).toHaveBeenCalledWith(55, expect.anything());
+    client.close();
+  });
+});
+
+describe("ObjectHandle.onEventTriggered -- wire-side coordination", () => {
+  it("issues subscribeEvent + unsubscribeEvent with idempotent cancel", async () => {
+    const { client, socket, obj } = await setup();
+    const cancel = obj.onEventTriggered("landed", vi.fn());
+    await tick();
+    const sub = findRequest(socket, "subscribeEvent")!;
+    expect(sub.params).toEqual({ interestName: "i1", objectName: "a1", eventName: "landed" });
+    cancel();
+    cancel();
+    await tick();
+    const unsub = findRequest(socket, "unsubscribeEvent")!;
+    expect(unsub).toBeDefined();
+    client.close();
+  });
+
+  it("fan-out: dispatch parses argsJson against the event's arg types", async () => {
+    const { client, socket, obj } = await setup();
+    const a = vi.fn();
+    const b = vi.fn();
+    obj.onEventTriggered("landed", a);
+    obj.onEventTriggered("landed", b);
+    await tick();
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "eventTriggered",
+      params: {
+        interestName: "i1",
+        objectName: "a1",
+        eventName: "landed",
+        args: "[120.5]",
+        timestamp: "2026-05-24",
+      },
+    });
+
+    expect(a).toHaveBeenCalledWith([120.5], expect.objectContaining({ timestamp: expect.any(String) }));
+    expect(b).toHaveBeenCalledWith([120.5], expect.objectContaining({ timestamp: expect.any(String) }));
+    client.close();
+  });
+
+  it("awaitEventSubscribed resolves only after the server acks the subscribe", async () => {
+    const { client, socket, obj } = await setup();
+    obj.onEventTriggered("landed", vi.fn());
+    await tick();
+    const sub = findRequest(socket, "subscribeEvent")!;
+
+    let resolved = false;
+    const waiter = obj.awaitEventSubscribed("landed").then(() => {
+      resolved = true;
+    });
+    await tick();
+    expect(resolved).toBe(false);
+
+    socket.simulateMessage({ jsonrpc: "2.0", id: sub.id, result: null });
+    await waiter;
+    expect(resolved).toBe(true);
+    client.close();
+  });
+
+  it("awaitEventSubscribed is a noop when no one is subscribed", async () => {
+    const { client, obj } = await setup();
+    await expect(obj.awaitEventSubscribed("landed")).resolves.toBeUndefined();
+    client.close();
+  });
+
+  it("awaitEventSubscribed propagates the wire rejection", async () => {
+    const { client, socket, obj } = await setup();
+    obj.onEventTriggered("landed", vi.fn());
+    await tick();
+    const sub = findRequest(socket, "subscribeEvent")!;
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      id: sub.id,
+      error: { code: -32000, message: "no such event" },
+    });
+    await expect(obj.awaitEventSubscribed("landed")).rejects.toThrow();
+    client.close();
+  });
+
+  it("awaitPropertySubscribed resolves only after the server acks subscribeProperty", async () => {
+    const { client, socket, obj } = await setup();
+    obj.onPropertyChanged("altitude", vi.fn());
+    await tick();
+    const sub = findRequest(socket, "subscribeProperty")!;
+
+    let resolved = false;
+    const waiter = obj.awaitPropertySubscribed("altitude").then(() => {
+      resolved = true;
+    });
+    await tick();
+    expect(resolved).toBe(false);
+
+    socket.simulateMessage({ jsonrpc: "2.0", id: sub.id, result: null });
+    await waiter;
+    expect(resolved).toBe(true);
+    client.close();
+  });
+
+  it("awaitPropertySubscribed is a noop when no one is subscribed", async () => {
+    const { client, obj } = await setup();
+    await expect(obj.awaitPropertySubscribed("altitude")).resolves.toBeUndefined();
+    client.close();
+  });
+
+  it("awaitPropertySubscribed propagates the wire rejection", async () => {
+    const { client, socket, obj } = await setup();
+    obj.onPropertyChanged("altitude", vi.fn());
+    await tick();
+    const sub = findRequest(socket, "subscribeProperty")!;
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      id: sub.id,
+      error: { code: -32000, message: "no such property" },
+    });
+    await expect(obj.awaitPropertySubscribed("altitude")).rejects.toThrow();
+    client.close();
+  });
+});
+
+describe("Subscription stickiness across object remove/add", () => {
+  it("a returning object replays the wire subscribe; the handler still fires", async () => {
+    const { client, socket, interest, obj } = await setup();
+
+    const handler = vi.fn();
+    obj.onPropertyChanged("altitude", handler);
+    await tick();
+    const subsBefore = socket.sentFrames
+      .map((f) => JSON.parse(f))
+      .filter((req: { method: string }) => req.method === "subscribeProperty").length;
+    expect(subsBefore).toBe(1);
+
+    // Remove the object
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: { interestName: "i1", added: [], removed: ["a1"], types: [], typeSchemas: "" },
+    });
+    expect(interest.objectByName("a1")).toBeUndefined();
+
+    // Re-add with the same name; same class
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a1", qualifiedClassName: "demo.Aircraft", currentValues: [] }],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+    await tick();
+
+    // a second subscribeProperty should have fired (replayed)
+    const subsAfter = socket.sentFrames
+      .map((f) => JSON.parse(f))
+      .filter((req: { method: string }) => req.method === "subscribeProperty").length;
+    expect(subsAfter).toBe(2);
+
+    // a propertyChanged for the new object delivers to the original handler
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "propertyChanged",
+      params: {
+        interestName: "i1",
+        objectName: "a1",
+        values: [{ propertyName: "altitude", value: "999" }],
+        timestamp: "2026-05-24",
+      },
+    });
+    expect(handler).toHaveBeenCalledWith(999, expect.objectContaining({ timestamp: expect.any(String) }));
+    client.close();
+  });
+});
+
+describe("ObjectHandle.onAnyChange", () => {
+  it("first consumer triggers wire subscribeAll; last cancel triggers unsubscribeAll", async () => {
+    const { client, socket, obj } = await setup();
+    const cancel = obj.onAnyChange(vi.fn());
+    await tick();
+    const subAll = findRequest(socket, "subscribeAll")!;
+    // Layer 2 always sends maxRateHz (null when no per-object rate is set).
+    expect(subAll.params).toEqual({ interestName: "i1", objectName: "a1", maxRateHz: null });
+
+    cancel();
+    await tick();
+    const unsubAll = findRequest(socket, "unsubscribeAll")!;
+    expect(unsubAll.params).toEqual({ interestName: "i1", objectName: "a1" });
+    client.close();
+  });
+
+  it("multi-consumer fan-out: one wire subscribeAll; both handlers receive the bundle map", async () => {
+    const { client, socket, obj } = await setup();
+    const a = vi.fn();
+    const b = vi.fn();
+    obj.onAnyChange(a);
+    obj.onAnyChange(b);
+    await tick();
+
+    const subAlls = socket.sentFrames
+      .map((f) => JSON.parse(f))
+      .filter((r: { method: string }) => r.method === "subscribeAll");
+    expect(subAlls).toHaveLength(1);
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "propertyChanged",
+      params: {
+        interestName: "i1",
+        objectName: "a1",
+        values: [
+          { propertyName: "altitude", value: "1234" },
+          { propertyName: "label", value: '"tower"' },
+        ],
+        timestamp: "2026-05-25",
+      },
+    });
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    const aMap = a.mock.calls[0]![0] as Map<string, unknown>;
+    expect(aMap.get("altitude")).toBe(1234);
+    expect(aMap.get("label")).toBe("tower");
+    client.close();
+  });
+
+  it("idempotent cancel; AbortSignal cancels too", async () => {
+    const { client, socket, obj } = await setup();
+    const ctrl = new AbortController();
+    const handler = vi.fn();
+    const cancel = obj.onAnyChange(handler, { signal: ctrl.signal });
+    await tick();
+    ctrl.abort();
+    cancel(); // no-op after abort
+    await tick();
+    // Next propertyChanged should not fire the handler.
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "propertyChanged",
+      params: {
+        interestName: "i1",
+        objectName: "a1",
+        values: [{ propertyName: "altitude", value: "1" }],
+        timestamp: "2026-05-25",
+      },
+    });
+    expect(handler).not.toHaveBeenCalled();
+    client.close();
+  });
+});
+
+describe("ObjectHandle.setMaxRateHz", () => {
+  it("re-issues subscribeProperty for one active property with the new rate", async () => {
+    const { client, socket, obj } = await setup();
+    obj.onPropertyChanged("altitude", vi.fn());
+    await tick();
+    // Ack the first (rate-less) subscribeProperty so its promise settles.
+    const initialSub = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    socket.simulateMessage({ jsonrpc: "2.0", id: initialSub.id, result: null });
+    const before = socket.sentFrames.length;
+
+    const pendingRate = obj.setMaxRateHz(30);
+    await tick();
+    // Ack the re-issued subscribeProperty so the awaited setMaxRateHz settles within the test
+    // timeout instead of hitting the default 2s wire timeout.
+    const reissue = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    socket.simulateMessage({ jsonrpc: "2.0", id: reissue.id, result: null });
+    await pendingRate;
+
+    const ratedSubscribes = socket.sentFrames
+      .slice(before)
+      .map((f) => JSON.parse(f))
+      .filter(
+        (r: { method: string; params: { maxRateHz: unknown } }) =>
+          r.method === "subscribeProperty" && r.params.maxRateHz === 30,
+      );
+    expect(ratedSubscribes.length).toBeGreaterThanOrEqual(1);
+    client.close();
+  });
+
+  it("applies the per-object rate to subsequent property subscribes", async () => {
+    const { client, socket, obj } = await setup();
+    await obj.setMaxRateHz(60);
+    await tick();
+    const before = socket.sentFrames.length;
+    obj.onPropertyChanged("altitude", vi.fn());
+    await tick();
+    const subscribe = socket.sentFrames
+      .slice(before)
+      .map((f) => JSON.parse(f))
+      .find((r: { method: string }) => r.method === "subscribeProperty") as
+      | { params: { maxRateHz: unknown } }
+      | undefined;
+    expect(subscribe?.params.maxRateHz).toBe(60);
+    client.close();
+  });
+
+  it("setMaxRateHz with no active property subs is a no-op on the wire", async () => {
+    const { client, socket, obj } = await setup();
+    // Only an event subscription, no property subs.
+    obj.onEventTriggered("landed", vi.fn());
+    await tick();
+    const before = socket.sentFrames.length;
+    await obj.setMaxRateHz(45);
+    await tick();
+    // No new wire frames - the rate sits dormant until a property subscribe lands.
+    expect(socket.sentFrames.length).toBe(before);
+    client.close();
+  });
+
+  it("re-issues subscribeProperty for EVERY active property with the new rate", async () => {
+    const { client, socket, obj } = await setup();
+    obj.onPropertyChanged("altitude", vi.fn());
+    obj.onPropertyChanged("speed", vi.fn());
+    await tick();
+    // Ack both initial (rate-less) subscribeProperty calls so their promises settle.
+    for (const f of socket.sentFrames.slice(-2)) {
+      const req = JSON.parse(f);
+      if (req.method === "subscribeProperty") {
+        socket.simulateMessage({ jsonrpc: "2.0", id: req.id, result: null });
+      }
+    }
+    const before = socket.sentFrames.length;
+
+    const pending = obj.setMaxRateHz(20);
+    await tick();
+    // Ack each re-issued subscribe so the awaited setMaxRateHz settles.
+    for (const f of socket.sentFrames.slice(before)) {
+      const req = JSON.parse(f);
+      socket.simulateMessage({ jsonrpc: "2.0", id: req.id, result: null });
+    }
+    await pending;
+
+    const reissues = socket.sentFrames
+      .slice(before)
+      .map((f) => JSON.parse(f))
+      .filter((r: { method: string }) => r.method === "subscribeProperty");
+    const names = reissues.map((r: { params: { propertyName: string } }) => r.params.propertyName).sort();
+    expect(names).toEqual(["altitude", "speed"]);
+    for (const r of reissues) {
+      expect(r.params.maxRateHz).toBe(20);
+    }
+    client.close();
+  });
+
+  it("re-issues subscribeAll for an active onAnyChange with the new rate", async () => {
+    const { client, socket, obj } = await setup();
+    obj.onAnyChange(vi.fn());
+    await tick();
+    // Ack the initial subscribeAll.
+    const initial = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    expect(initial.method).toBe("subscribeAll");
+    socket.simulateMessage({ jsonrpc: "2.0", id: initial.id, result: null });
+    const before = socket.sentFrames.length;
+
+    const pending = obj.setMaxRateHz(15);
+    await tick();
+    const reissue = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    expect(reissue.method).toBe("subscribeAll");
+    expect(reissue.params.maxRateHz).toBe(15);
+    socket.simulateMessage({ jsonrpc: "2.0", id: reissue.id, result: null });
+    await pending;
+    client.close();
+  });
+});
+
+describe("Client.reestablishAll", () => {
+  // Reestablish is idempotent per connection epoch: these scenarios bounce the transport
+  // first (the recovery situation the API exists for) and then drive/observe the pass.
+  async function bounce() {
+    MockWebSocket.lastInstance!.simulateClose(1006);
+    await tick(20);
+    const next = MockWebSocket.lastInstance!;
+    next.simulateOpen();
+    await tick();
+    return next;
+  }
+
+  it("re-issues createInterest for every registered interest with the original args", async () => {
+    const { client } = await setup();
+
+    const socket2 = await bounce(); // autoReestablish (default) fires the pass
+    const pending = client.reestablishAll(); // coalesces with the in-flight auto pass
+
+    const recreates = socket2.sentFrames
+      .map((f) => JSON.parse(f))
+      .filter((r: { method: string }) => r.method === "createInterest");
+    expect(recreates).toHaveLength(1);
+    expect(recreates[0].params).toEqual({ interestName: "i1", query: "q", subscribe: null, withSchemas: null });
+
+    // ack
+    socket2.simulateMessage({ jsonrpc: "2.0", id: recreates[0].id, result: null });
+    await pending;
+    client.close();
+  });
+
+  it("subscriptions replay automatically when the post-reestablish interestUpdate arrives", async () => {
+    const { client, obj } = await setup();
+    obj.onPropertyChanged("altitude", vi.fn());
+    await tick();
+
+    const socket2 = await bounce(); // auto pass fires
+    const recreate = socket2.sentFrames
+      .map((f) => JSON.parse(f))
+      .find((r: { method: string }) => r.method === "createInterest")!;
+    socket2.simulateMessage({ jsonrpc: "2.0", id: recreate.id, result: null });
+    await client.reestablishAll(); // coalesces; resolves with the auto pass
+
+    // New interestUpdate.added for the same object name
+    socket2.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: {
+        interestName: "i1",
+        added: [{ objectName: "a1", qualifiedClassName: "demo.Aircraft", currentValues: [] }],
+        removed: [],
+        types: [], typeSchemas: "",
+      },
+    });
+    await tick();
+
+    const replayedSub = socket2.sentFrames
+      .map((f) => JSON.parse(f))
+      .filter((r: { method: string }) => r.method === "subscribeProperty");
+    expect(replayedSub.length).toBeGreaterThanOrEqual(1);
+    client.close();
+  });
+
+  it("uses allSettled: a single failing interest doesn't block the rest, errors flow to onError", async () => {
+    // Set up two interests; one will fail on reestablish, the other will succeed.
+    const errors: Error[] = [];
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const pending = connect({
+      url: "ws://test",
+      reconnect: { enabled: true, initialDelayMs: 1, maxDelayMs: 1, autoReestablish: false },
+      onError: (err) => errors.push(err),
+      webSocketFactory: factory,
+    });
+    await tick();
+    MockWebSocket.lastInstance!.simulateOpen();
+    const client = await pending;
+    const socket = MockWebSocket.lastInstance!;
+
+    // Declare both interests, ack both.
+    const declareA = client.declareInterest({ name: "good", query: "q1" });
+    await tick();
+    const reqA = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    socket.simulateMessage({ jsonrpc: "2.0", id: reqA.id, result: null });
+    await declareA;
+    const declareB = client.declareInterest({ name: "bad", query: "q2" });
+    await tick();
+    const reqB = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    socket.simulateMessage({ jsonrpc: "2.0", id: reqB.id, result: null });
+    await declareB;
+
+    const socket2 = await bounce(); // autoReestablish off: nothing fires on its own
+
+    // Reestablish both: ack the first, error the second.
+    const reestablish = client.reestablishAll();
+    await tick();
+    const recent = socket2.sentFrames
+      .map((f) => JSON.parse(f))
+      .filter((r: { method: string }) => r.method === "createInterest")
+      .slice(-2);
+    expect(recent).toHaveLength(2);
+    socket2.simulateMessage({ jsonrpc: "2.0", id: recent[0]!.id, result: null });
+    socket2.simulateMessage({
+      jsonrpc: "2.0",
+      id: recent[1]!.id,
+      error: { code: -32602, message: "server rejected" },
+    });
+    // The failed re-declare probes listObjects before giving up; report the interest gone.
+    await tick();
+    const probe = socket2.sentFrames
+      .map((f) => JSON.parse(f))
+      .find((r: { method: string }) => r.method === "listObjects")!;
+    expect(probe).toBeDefined();
+    socket2.simulateMessage({
+      jsonrpc: "2.0",
+      id: probe.id,
+      error: { code: -32011, message: "listObjects: unknown interest: bad" },
+    });
+    // reestablishAll resolves regardless of the per-interest failure.
+    await expect(reestablish).resolves.toBeUndefined();
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors.some((e) => /server rejected/.test(e.message))).toBe(true);
+    client.close();
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/test_helpers/mock_websocket.ts
+++ b/components/jsonrpc/clients/typescript/test/test_helpers/mock_websocket.ts
@@ -1,0 +1,125 @@
+// === mock_websocket.ts ===============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import type { WebSocketLike } from "../../src/internal/transport.js";
+
+// Mirror native WebSocket.readyState values so consumers that depend on numeric ranges work.
+const CONNECTING = 0;
+const OPEN = 1;
+const CLOSING = 2;
+const CLOSED = 3;
+
+type OpenListener = () => void;
+type MessageListener = (event: { data: unknown }) => void;
+type CloseListener = (event: { code: number; reason: string }) => void;
+type ErrorListener = (event: unknown) => void;
+
+/**
+ * Test-controllable WebSocket double. Construction does NOT auto-open -- tests drive the
+ * lifecycle by calling `simulateOpen()` etc. Capturing happens via `sentFrames`.
+ *
+ * `lastInstance` lets the test capture whichever mock the Transport's factory produced without
+ * having to thread it through manually.
+ */
+export class MockWebSocket implements WebSocketLike {
+  static lastInstance: MockWebSocket | null = null;
+
+  readonly url: string;
+  readyState: number = CONNECTING;
+
+  readonly sentFrames: string[] = [];
+  readonly closeCalls: { code: number | undefined; reason: string | undefined }[] = [];
+
+  private readonly openListeners = new Set<OpenListener>();
+  private readonly messageListeners = new Set<MessageListener>();
+  private readonly closeListeners = new Set<CloseListener>();
+  private readonly errorListeners = new Set<ErrorListener>();
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.lastInstance = this;
+  }
+
+  send(data: string): void {
+    if (this.readyState !== OPEN) {
+      throw new Error(`MockWebSocket: send while readyState=${this.readyState}`);
+    }
+    this.sentFrames.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+    if (this.readyState === CLOSED) return;
+    this.readyState = CLOSED;
+    // Native WebSocket fires 'close' asynchronously even when close() is initiated locally; we
+    // mirror that so the Transport's state machine sees a real handler invocation.
+    queueMicrotask(() => this.fireClose(code ?? 1000, reason ?? ""));
+  }
+
+  addEventListener(type: "open", listener: OpenListener): void;
+  addEventListener(type: "message", listener: MessageListener): void;
+  addEventListener(type: "close", listener: CloseListener): void;
+  addEventListener(type: "error", listener: ErrorListener): void;
+  addEventListener(type: string, listener: unknown): void {
+    switch (type) {
+      case "open":
+        this.openListeners.add(listener as OpenListener);
+        break;
+      case "message":
+        this.messageListeners.add(listener as MessageListener);
+        break;
+      case "close":
+        this.closeListeners.add(listener as CloseListener);
+        break;
+      case "error":
+        this.errorListeners.add(listener as ErrorListener);
+        break;
+    }
+  }
+
+  // --- driver methods used by tests ----------------------------------------------------------
+
+  simulateOpen(): void {
+    this.readyState = OPEN;
+    for (const listener of this.openListeners) listener();
+  }
+
+  simulateMessage(frame: string | object): void {
+    const data = typeof frame === "string" ? frame : JSON.stringify(frame);
+    for (const listener of this.messageListeners) listener({ data });
+  }
+
+  simulateBinaryMessage(): void {
+    for (const listener of this.messageListeners) listener({ data: new Uint8Array([1, 2, 3]) });
+  }
+
+  simulateClose(code = 1006, reason = "abnormal"): void {
+    if (this.readyState === CLOSED) return;
+    this.readyState = CLOSED;
+    this.fireClose(code, reason);
+  }
+
+  simulateError(): void {
+    for (const listener of this.errorListeners) listener(new Error("simulated error"));
+  }
+
+  clearFrames(): void {
+    this.sentFrames.length = 0;
+  }
+
+  private fireClose(code: number, reason: string): void {
+    for (const listener of this.closeListeners) listener({ code, reason });
+  }
+}
+
+/**
+ * Helper: wait one macrotask. Lets queued microtasks settle before the test asserts. Useful
+ * after `socket.send(...)` or `close()` which schedule via `queueMicrotask`.
+ */
+export function tick(ms = 0): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/components/jsonrpc/clients/typescript/test/transport.test.ts
+++ b/components/jsonrpc/clients/typescript/test/transport.test.ts
@@ -1,0 +1,461 @@
+// === transport.test.ts ===============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Transport, type WebSocketFactory } from "../src/internal/transport.js";
+import { JsonRpcError, TimeoutError, TransportError } from "../src/errors.js";
+import { MockWebSocket, tick } from "./test_helpers/mock_websocket.js";
+
+/** Construct a Transport wired to the mock factory and let it open. */
+async function makeOpenTransport(overrides?: { defaultTimeoutMs?: number }): Promise<{
+  transport: Transport;
+  socket: MockWebSocket;
+}> {
+  const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+  const transport = new Transport({
+    url: "ws://test",
+    defaultTimeoutMs: overrides?.defaultTimeoutMs ?? 1000,
+    reconnect: { enabled: false },
+    reportError: () => undefined,
+    webSocketFactory: factory,
+  });
+  const socket = MockWebSocket.lastInstance!;
+  socket.simulateOpen();
+  await tick();
+  return { transport, socket };
+}
+
+beforeEach(() => {
+  MockWebSocket.lastInstance = null;
+});
+
+describe("Transport lifecycle", () => {
+  it("starts in 'connecting' and moves to 'open' on socket open", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const transport = new Transport({
+      url: "ws://test",
+      reconnect: { enabled: false },
+      reportError: () => undefined,
+      webSocketFactory: factory,
+    });
+    expect(transport.connectionState).toBe("connecting");
+    MockWebSocket.lastInstance!.simulateOpen();
+    expect(transport.connectionState).toBe("open");
+    transport.close();
+  });
+
+  it("close() transitions to 'closed' and stops accepting calls", async () => {
+    const { transport } = await makeOpenTransport();
+    transport.close();
+    expect(transport.connectionState).toBe("closed");
+    await expect(transport.call({ method: "ping" })).rejects.toBeInstanceOf(TransportError);
+  });
+
+  it("call() rejects with TransportError when the transport is not open", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const transport = new Transport({
+      url: "ws://test",
+      reconnect: { enabled: false },
+      reportError: () => undefined,
+      webSocketFactory: factory,
+    });
+    // still 'connecting'
+    await expect(transport.call({ method: "ping" })).rejects.toBeInstanceOf(TransportError);
+    transport.close();
+  });
+});
+
+describe("Transport whenOpen()", () => {
+  it("resolves on first open", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const transport = new Transport({
+      url: "ws://test",
+      reconnect: { enabled: false },
+      reportError: () => undefined,
+      webSocketFactory: factory,
+    });
+    const ready = transport.whenOpen();
+    MockWebSocket.lastInstance!.simulateOpen();
+    await expect(ready).resolves.toBeUndefined();
+    transport.close();
+  });
+
+  it("rejects with TransportError when close arrives before first open", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const transport = new Transport({
+      url: "ws://test",
+      reconnect: { enabled: false },
+      reportError: () => undefined,
+      webSocketFactory: factory,
+    });
+    const ready = transport.whenOpen();
+    MockWebSocket.lastInstance!.simulateClose(1006, "no server");
+    await expect(ready).rejects.toBeInstanceOf(TransportError);
+  });
+
+  it("rejects with TransportError when close() is called before first open", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const transport = new Transport({
+      url: "ws://test",
+      reconnect: { enabled: false },
+      reportError: () => undefined,
+      webSocketFactory: factory,
+    });
+    const ready = transport.whenOpen();
+    transport.close();
+    await expect(ready).rejects.toBeInstanceOf(TransportError);
+  });
+
+  it("subsequent disconnects do not re-fulfill the promise", async () => {
+    const { transport, socket } = await makeOpenTransport();
+    // whenOpen already resolved; calling it again returns the same resolved promise
+    await expect(transport.whenOpen()).resolves.toBeUndefined();
+    socket.simulateClose(1006);
+    // still resolved, doesn't reject
+    await expect(transport.whenOpen()).resolves.toBeUndefined();
+    transport.close();
+  });
+});
+
+describe("Transport request/response correlation", () => {
+  it("sends a well-formed JSON-RPC request and resolves with the result", async () => {
+    const { transport, socket } = await makeOpenTransport();
+    const pending = transport.call({ method: "ping", params: { x: 1 } });
+    expect(socket.sentFrames).toHaveLength(1);
+    const sent = JSON.parse(socket.sentFrames[0]!);
+    expect(sent.jsonrpc).toBe("2.0");
+    expect(sent.method).toBe("ping");
+    expect(sent.params).toEqual({ x: 1 });
+    expect(typeof sent.id).toBe("number");
+
+    socket.simulateMessage({ jsonrpc: "2.0", id: sent.id, result: "pong" });
+    await expect(pending).resolves.toBe("pong");
+    transport.close();
+  });
+
+  it("omits 'params' from the envelope when not provided", async () => {
+    const { transport, socket } = await makeOpenTransport();
+    // absorb the rejection that close() will trigger; only the wire frame matters here
+    transport.call({ method: "ping" }).catch(() => undefined);
+    const sent = JSON.parse(socket.sentFrames[0]!);
+    expect(sent).not.toHaveProperty("params");
+    transport.close();
+  });
+
+  it("routes multiple in-flight responses to the right promises", async () => {
+    const { transport, socket } = await makeOpenTransport();
+    const a = transport.call({ method: "first" });
+    const b = transport.call({ method: "second" });
+    const c = transport.call({ method: "third" });
+    const ids = socket.sentFrames.map((f) => JSON.parse(f).id);
+
+    // respond out of order
+    socket.simulateMessage({ jsonrpc: "2.0", id: ids[1], result: "B" });
+    socket.simulateMessage({ jsonrpc: "2.0", id: ids[2], result: "C" });
+    socket.simulateMessage({ jsonrpc: "2.0", id: ids[0], result: "A" });
+
+    await expect(a).resolves.toBe("A");
+    await expect(b).resolves.toBe("B");
+    await expect(c).resolves.toBe("C");
+    transport.close();
+  });
+
+  it("rejects with JsonRpcError when the response carries an error", async () => {
+    const { transport, socket } = await makeOpenTransport();
+    const pending = transport.call({ method: "boom" });
+    const id = JSON.parse(socket.sentFrames[0]!).id;
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32600, message: "Invalid Request", data: { detail: "oops" } },
+    });
+    await expect(pending).rejects.toMatchObject({
+      code: -32600,
+      message: "Invalid Request",
+      data: { detail: "oops" },
+    });
+    await expect(pending).rejects.toBeInstanceOf(JsonRpcError);
+    transport.close();
+  });
+
+  it("ignores a late response whose id is no longer pending", async () => {
+    const { transport, socket } = await makeOpenTransport({ defaultTimeoutMs: 25 });
+    const pending = transport.call({ method: "slow" });
+    const id = JSON.parse(socket.sentFrames[0]!).id;
+    await expect(pending).rejects.toBeInstanceOf(TimeoutError);
+    // late response -- must not throw or crash
+    socket.simulateMessage({ jsonrpc: "2.0", id, result: "too-late" });
+    transport.close();
+  });
+});
+
+describe("Transport notification dispatch", () => {
+  it("fans out a matching notification to every registered handler", async () => {
+    const { transport, socket } = await makeOpenTransport();
+    const a = vi.fn();
+    const b = vi.fn();
+    transport.onNotification({ method: "tick", handler: a });
+    transport.onNotification({ method: "tick", handler: b });
+    socket.simulateMessage({ jsonrpc: "2.0", method: "tick", params: { n: 7 } });
+    expect(a).toHaveBeenCalledWith({ n: 7 });
+    expect(b).toHaveBeenCalledWith({ n: 7 });
+    transport.close();
+  });
+
+  it("does not dispatch when no handlers are registered for the method", async () => {
+    const { transport, socket } = await makeOpenTransport();
+    const handler = vi.fn();
+    transport.onNotification({ method: "other", handler });
+    socket.simulateMessage({ jsonrpc: "2.0", method: "tick", params: {} });
+    expect(handler).not.toHaveBeenCalled();
+    transport.close();
+  });
+
+  it("CancelFn for a notification is idempotent and removes only that handler", async () => {
+    const { transport, socket } = await makeOpenTransport();
+    const a = vi.fn();
+    const b = vi.fn();
+    const cancelA = transport.onNotification({ method: "tick", handler: a });
+    transport.onNotification({ method: "tick", handler: b });
+    cancelA();
+    cancelA(); // idempotent, no-op
+    socket.simulateMessage({ jsonrpc: "2.0", method: "tick", params: {} });
+    expect(a).not.toHaveBeenCalled();
+    expect(b).toHaveBeenCalled();
+    transport.close();
+  });
+
+  it("a throwing handler does not break the dispatch loop for siblings", async () => {
+    const { transport, socket } = await makeOpenTransport();
+    const thrower = vi.fn(() => {
+      throw new Error("kaboom");
+    });
+    const survivor = vi.fn();
+    transport.onNotification({ method: "tick", handler: thrower });
+    transport.onNotification({ method: "tick", handler: survivor });
+    socket.simulateMessage({ jsonrpc: "2.0", method: "tick", params: {} });
+    expect(thrower).toHaveBeenCalled();
+    expect(survivor).toHaveBeenCalled();
+    transport.close();
+  });
+});
+
+describe("Transport timeout + abort", () => {
+  it("rejects with TimeoutError after the per-call timeout", async () => {
+    const { transport } = await makeOpenTransport();
+    const pending = transport.call({ method: "slow", timeoutMs: 20 });
+    await expect(pending).rejects.toBeInstanceOf(TimeoutError);
+    await expect(pending).rejects.toMatchObject({ timeoutMs: 20 });
+    transport.close();
+  });
+
+  it("uses defaultTimeoutMs when no per-call timeout is given", async () => {
+    const { transport } = await makeOpenTransport({ defaultTimeoutMs: 15 });
+    await expect(transport.call({ method: "slow" })).rejects.toBeInstanceOf(TimeoutError);
+    transport.close();
+  });
+
+  it("AbortSignal abort rejects the call with TransportError", async () => {
+    const { transport } = await makeOpenTransport();
+    const ctrl = new AbortController();
+    const pending = transport.call({ method: "slow", signal: ctrl.signal });
+    ctrl.abort();
+    await expect(pending).rejects.toBeInstanceOf(TransportError);
+    transport.close();
+  });
+
+  it("an already-aborted signal rejects synchronously without sending a frame", async () => {
+    const { transport, socket } = await makeOpenTransport();
+    const ctrl = new AbortController();
+    ctrl.abort();
+    await expect(
+      transport.call({ method: "noop", signal: ctrl.signal }),
+    ).rejects.toBeInstanceOf(TransportError);
+    expect(socket.sentFrames).toHaveLength(0);
+    transport.close();
+  });
+});
+
+describe("Transport malformed input", () => {
+  it("ignores binary frames and keeps the wire alive", async () => {
+    const { transport, socket } = await makeOpenTransport();
+    socket.simulateBinaryMessage();
+    // still alive -- can still call/get a response
+    const p = transport.call({ method: "ping" });
+    const id = JSON.parse(socket.sentFrames[0]!).id;
+    socket.simulateMessage({ jsonrpc: "2.0", id, result: "ok" });
+    await expect(p).resolves.toBe("ok");
+    transport.close();
+  });
+
+  it("ignores invalid JSON and keeps the wire alive", async () => {
+    const { transport, socket } = await makeOpenTransport();
+    socket.simulateMessage("{not valid json");
+    const p = transport.call({ method: "ping" });
+    const id = JSON.parse(socket.sentFrames[0]!).id;
+    socket.simulateMessage({ jsonrpc: "2.0", id, result: "ok" });
+    await expect(p).resolves.toBe("ok");
+    transport.close();
+  });
+
+  it("rejects with TransportError when a response has neither result nor error", async () => {
+    const { transport, socket } = await makeOpenTransport();
+    const p = transport.call({ method: "ping" });
+    const id = JSON.parse(socket.sentFrames[0]!).id;
+    socket.simulateMessage({ jsonrpc: "2.0", id });
+    await expect(p).rejects.toBeInstanceOf(TransportError);
+    transport.close();
+  });
+});
+
+describe("Transport reconnection", () => {
+  it("disconnect fires onDisconnect and triggers reconnect; onReconnect fires after success", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const transport = new Transport({
+      url: "ws://test",
+      reconnect: { enabled: true, initialDelayMs: 1, maxDelayMs: 1 },
+      reportError: () => undefined,
+      webSocketFactory: factory,
+    });
+    const firstSocket = MockWebSocket.lastInstance!;
+    firstSocket.simulateOpen();
+
+    const disconnected = vi.fn();
+    const reconnected = vi.fn();
+    transport.onDisconnect(disconnected);
+    transport.onReconnect(reconnected);
+
+    firstSocket.simulateClose(1006, "gone");
+    expect(transport.connectionState).toBe("reconnecting");
+    expect(disconnected).toHaveBeenCalledTimes(1);
+
+    // wait past the reconnect delay
+    await tick(20);
+    const secondSocket = MockWebSocket.lastInstance!;
+    expect(secondSocket).not.toBe(firstSocket);
+    secondSocket.simulateOpen();
+
+    expect(transport.connectionState).toBe("open");
+    expect(reconnected).toHaveBeenCalledTimes(1);
+    transport.close();
+  });
+
+  it("disconnect rejects all in-flight calls with TransportError", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const transport = new Transport({
+      url: "ws://test",
+      reconnect: { enabled: false },
+      reportError: () => undefined,
+      webSocketFactory: factory,
+    });
+    const socket = MockWebSocket.lastInstance!;
+    socket.simulateOpen();
+
+    const a = transport.call({ method: "first" });
+    const b = transport.call({ method: "second" });
+    socket.simulateClose(1006);
+    await expect(a).rejects.toBeInstanceOf(TransportError);
+    await expect(b).rejects.toBeInstanceOf(TransportError);
+    transport.close();
+  });
+
+  it("close() cancels a pending reconnect", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const transport = new Transport({
+      url: "ws://test",
+      reconnect: { enabled: true, initialDelayMs: 50 },
+      reportError: () => undefined,
+      webSocketFactory: factory,
+    });
+    const firstSocket = MockWebSocket.lastInstance!;
+    firstSocket.simulateOpen();
+    firstSocket.simulateClose(1006);
+    expect(transport.connectionState).toBe("reconnecting");
+    transport.close();
+    expect(transport.connectionState).toBe("closed");
+    // wait past where the reconnect would have fired; no new socket
+    await tick(80);
+    expect(MockWebSocket.lastInstance).toBe(firstSocket);
+  });
+
+  it("onReconnect does NOT fire on the initial connect", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const transport = new Transport({
+      url: "ws://test",
+      reconnect: { enabled: false },
+      reportError: () => undefined,
+      webSocketFactory: factory,
+    });
+    const reconnected = vi.fn();
+    transport.onReconnect(reconnected);
+    MockWebSocket.lastInstance!.simulateOpen();
+    expect(reconnected).not.toHaveBeenCalled();
+    transport.close();
+  });
+
+  it("onDisconnect does NOT fire on explicit close()", async () => {
+    const { transport } = await makeOpenTransport();
+    const disconnected = vi.fn();
+    transport.onDisconnect(disconnected);
+    transport.close();
+    await tick();
+    expect(disconnected).not.toHaveBeenCalled();
+  });
+});
+
+describe("Transport.onConnectionStateChange", () => {
+  it("fires on every transition with the new state", async () => {
+    const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+    const transport = new Transport({
+      url: "ws://test",
+      reconnect: { enabled: true, initialDelayMs: 1, maxDelayMs: 1 },
+      reportError: () => undefined,
+      webSocketFactory: factory,
+    });
+
+    const states: string[] = [];
+    transport.onConnectionStateChange((s) => states.push(s));
+
+    // connecting -> open
+    MockWebSocket.lastInstance!.simulateOpen();
+    expect(states).toEqual(["open"]);
+
+    // open -> reconnecting
+    MockWebSocket.lastInstance!.simulateClose(1006, "gone");
+    expect(states).toEqual(["open", "reconnecting"]);
+
+    // reconnecting -> open
+    await tick(20);
+    MockWebSocket.lastInstance!.simulateOpen();
+    expect(states).toEqual(["open", "reconnecting", "open"]);
+
+    // -> closed (explicit)
+    transport.close();
+    expect(states).toEqual(["open", "reconnecting", "open", "closed"]);
+  });
+
+  it("does not fire on register and does not re-fire when the state stays the same", async () => {
+    const { transport } = await makeOpenTransport();
+    const fn = vi.fn();
+    transport.onConnectionStateChange(fn);
+    await tick();
+    expect(fn).not.toHaveBeenCalled();
+    transport.close();
+    expect(fn).toHaveBeenCalledTimes(1);
+    transport.close();  // idempotent
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel function removes the handler", async () => {
+    const { transport } = await makeOpenTransport();
+    const fn = vi.fn();
+    const cancel = transport.onConnectionStateChange(fn);
+    cancel();
+    transport.close();
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/type_cache.test.ts
+++ b/components/jsonrpc/clients/typescript/test/type_cache.test.ts
@@ -1,0 +1,79 @@
+// === type_cache.test.ts ==============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, vi } from "vitest";
+import { TypeCache } from "../src/internal/type_cache.js";
+import { TransportError } from "../src/errors.js";
+import type { CustomTypeSpec } from "../src/index.js";
+
+function makeSpec(qualifiedName: string, description = ""): CustomTypeSpec {
+  return {
+    name: qualifiedName.split(".").pop() ?? qualifiedName,
+    qualifiedName,
+    description,
+    data: { type: "sen.kernel.AliasTypeSpec", value: { aliasedType: "string" } },
+  };
+}
+
+describe("TypeCache", () => {
+  it("get returns undefined for unknown names", () => {
+    const cache = new TypeCache();
+    expect(cache.get("pkg.X")).toBeUndefined();
+    expect(cache.has("pkg.X")).toBe(false);
+    expect(cache.size()).toBe(0);
+  });
+
+  it("set then get returns the same spec", () => {
+    const cache = new TypeCache();
+    const spec = makeSpec("pkg.X", "first");
+    cache.set(spec);
+    expect(cache.get("pkg.X")).toBe(spec);
+    expect(cache.has("pkg.X")).toBe(true);
+    expect(cache.size()).toBe(1);
+  });
+
+  it("set overwrites an existing entry with the same qualifiedName", () => {
+    const cache = new TypeCache();
+    cache.set(makeSpec("pkg.X", "first"));
+    cache.set(makeSpec("pkg.X", "second"));
+    expect(cache.get("pkg.X")?.description).toBe("second");
+    expect(cache.size()).toBe(1);
+  });
+
+  it("setMany inserts every spec in the input", () => {
+    const cache = new TypeCache();
+    cache.setMany([makeSpec("pkg.A"), makeSpec("pkg.B"), makeSpec("pkg.C")]);
+    expect(cache.size()).toBe(3);
+    expect(cache.has("pkg.A")).toBe(true);
+    expect(cache.has("pkg.B")).toBe(true);
+    expect(cache.has("pkg.C")).toBe(true);
+  });
+
+  it("clear empties the cache", () => {
+    const cache = new TypeCache();
+    cache.set(makeSpec("pkg.X"));
+    cache.clear();
+    expect(cache.size()).toBe(0);
+  });
+
+  it("setSchemasFromBlob routes parse errors through reportError", () => {
+    const reportError = vi.fn();
+    const cache = new TypeCache(reportError);
+    cache.setSchemasFromBlob("{not-json");
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const err = reportError.mock.calls[0]![0];
+    expect(err).toBeInstanceOf(TransportError);
+    expect((err as Error).message).toMatch(/typeSchemas blob failed to parse/);
+  });
+
+  it("setSchemasFromBlob is a no-op for empty strings without reporting", () => {
+    const reportError = vi.fn();
+    const cache = new TypeCache(reportError);
+    cache.setSchemasFromBlob("");
+    expect(reportError).not.toHaveBeenCalled();
+  });
+});

--- a/components/jsonrpc/clients/typescript/test/value_cache.test.ts
+++ b/components/jsonrpc/clients/typescript/test/value_cache.test.ts
@@ -1,0 +1,240 @@
+// === value_cache.test.ts =============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { describe, it, expect, vi } from "vitest";
+import { connect } from "../src/connect.js";
+import type { WebSocketFactory } from "../src/internal/transport.js";
+import { MockWebSocket, tick } from "./test_helpers/mock_websocket.js";
+import type { CustomTypeSpec, InterestUpdateNotification } from "../src/index.js";
+
+const aircraftClassSpec: CustomTypeSpec = {
+  name: "Aircraft",
+  qualifiedName: "demo.Aircraft",
+  description: "",
+  data: {
+    type: "sen.kernel.ClassTypeSpec",
+    value: {
+      properties: [
+        {
+          name: "altitude",
+          description: "",
+          category: "dynamicRO",
+          type: "f64",
+          transportMode: "unicast",
+          tags: [],
+          checkedSet: false,
+        },
+        {
+          name: "label",
+          description: "",
+          category: "dynamicRW",
+          type: "string",
+          transportMode: "unicast",
+          tags: [],
+          checkedSet: false,
+        },
+      ],
+      methods: [],
+      events: [],
+      constructor: {
+        name: "Aircraft",
+        description: "",
+        args: [],
+        transportMode: "unicast",
+        constness: "nonConstant",
+        deferred: false,
+        returnType: "",
+        propertyRelation: "nonPropertyRelated",
+        localOnly: false,
+      },
+      parents: [],
+      isInterface: false,
+    },
+  },
+};
+
+async function setup() {
+  const factory: WebSocketFactory = (url) => new MockWebSocket(url);
+  const pending = connect({
+    url: "ws://test",
+    reconnect: { enabled: false },
+      onError: () => undefined,
+    webSocketFactory: factory,
+  });
+  await tick();
+  MockWebSocket.lastInstance!.simulateOpen();
+  const client = await pending;
+  const socket = MockWebSocket.lastInstance!;
+
+  const declarePending = client.declareInterest({ name: "i1", query: "q" });
+  await tick();
+  const createReq = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+  socket.simulateMessage({ jsonrpc: "2.0", id: createReq.id, result: null });
+  const interest = await declarePending;
+  return { client, socket, interest };
+}
+
+function addObject(socket: MockWebSocket, withCurrentValues = false): void {
+  const update: InterestUpdateNotification = {
+    interestName: "i1",
+    added: [
+      {
+        objectName: "a1",
+        qualifiedClassName: "demo.Aircraft",
+        currentValues: withCurrentValues
+          ? [
+              { propertyName: "altitude", value: "9999" },
+              { propertyName: "label", value: '"initial"' },
+            ]
+          : [],
+      },
+    ],
+    removed: [],
+    types: [aircraftClassSpec],
+    typeSchemas: "",
+  };
+  socket.simulateMessage({ jsonrpc: "2.0", method: "interestUpdate", params: update });
+}
+
+function countCalls(socket: MockWebSocket, method: string, sinceIndex: number): number {
+  return socket.sentFrames
+    .slice(sinceIndex)
+    .map((f) => JSON.parse(f))
+    .filter((req: { method: string }) => req.method === method).length;
+}
+
+describe("ObjectHandle.get -- value cache", () => {
+  it("first get hits the wire, second hits the cache", async () => {
+    const { client, socket, interest } = await setup();
+    addObject(socket);
+    const obj = interest.objectByName("a1")!;
+    const before = socket.sentFrames.length;
+
+    const firstPending = obj.get("altitude");
+    await tick();
+    const getReq = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    socket.simulateMessage({ jsonrpc: "2.0", id: getReq.id, result: "1234" });
+    await expect(firstPending).resolves.toBe(1234);
+    expect(countCalls(socket, "getProperty", before)).toBe(1);
+
+    // Second get should hit cache; no new wire calls.
+    await expect(obj.get("altitude")).resolves.toBe(1234);
+    expect(countCalls(socket, "getProperty", before)).toBe(1);
+    client.close();
+  });
+
+  it("propertyChanged delivery updates the cache (no wire fetch needed)", async () => {
+    const { client, socket, interest } = await setup();
+    addObject(socket);
+    const obj = interest.objectByName("a1")!;
+    obj.onPropertyChanged("altitude", vi.fn());
+    await tick();
+    const before = socket.sentFrames.length;
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "propertyChanged",
+      params: {
+        interestName: "i1",
+        objectName: "a1",
+        values: [{ propertyName: "altitude", value: "777" }],
+        timestamp: "2026-05-24",
+      },
+    });
+
+    await expect(obj.get("altitude")).resolves.toBe(777);
+    expect(countCalls(socket, "getProperty", before)).toBe(0);
+    client.close();
+  });
+
+  it("interestUpdate.added.currentValues seeds the cache for immediate reads", async () => {
+    const { client, socket, interest } = await setup();
+    addObject(socket, /* withCurrentValues */ true);
+    const obj = interest.objectByName("a1")!;
+    const before = socket.sentFrames.length;
+
+    await expect(obj.get("altitude")).resolves.toBe(9999);
+    await expect(obj.get("label")).resolves.toBe("initial");
+    expect(countCalls(socket, "getProperty", before)).toBe(0);
+    client.close();
+  });
+
+  it("{ fresh: true } forces a wire round-trip even when cached", async () => {
+    const { client, socket, interest } = await setup();
+    addObject(socket, /* withCurrentValues */ true);
+    const obj = interest.objectByName("a1")!;
+    const before = socket.sentFrames.length;
+
+    const pending = obj.get("altitude", { fresh: true });
+    await tick();
+    const req = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    expect(req.method).toBe("getProperty");
+    socket.simulateMessage({ jsonrpc: "2.0", id: req.id, result: "42" });
+    await expect(pending).resolves.toBe(42);
+    expect(countCalls(socket, "getProperty", before)).toBe(1);
+
+    // Subsequent get without fresh hits the updated cache.
+    await expect(obj.get("altitude")).resolves.toBe(42);
+    expect(countCalls(socket, "getProperty", before)).toBe(1);
+    client.close();
+  });
+
+  it("set() invalidates the cache; subsequent get() falls through to wire", async () => {
+    const { client, socket, interest } = await setup();
+    addObject(socket, /* withCurrentValues */ true);
+    const obj = interest.objectByName("a1")!;
+    // Pre-set: cache holds the seeded value; get() doesn't hit the wire.
+    const before = socket.sentFrames.length;
+    await expect(obj.get("label")).resolves.toBe("initial");
+    expect(countCalls(socket, "getProperty", before)).toBe(0);
+
+    const setPending = obj.set("label", "new-label");
+    await tick();
+    const setReq = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    socket.simulateMessage({ jsonrpc: "2.0", id: setReq.id, result: null });
+    await setPending;
+
+    // Cache invalidated by set(); next get() must wire-fetch.
+    const afterSet = socket.sentFrames.length;
+    const pendingGet = obj.get("label");
+    await tick();
+    const getReq = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    expect(getReq.method).toBe("getProperty");
+    socket.simulateMessage({ jsonrpc: "2.0", id: getReq.id, result: '"new-label"' });
+    await expect(pendingGet).resolves.toBe("new-label");
+    expect(countCalls(socket, "getProperty", afterSet)).toBe(1);
+    client.close();
+  });
+
+  it("cache is cleared when the object leaves the match set", async () => {
+    const { client, socket, interest } = await setup();
+    addObject(socket, /* withCurrentValues */ true);
+    const objBefore = interest.objectByName("a1")!;
+    // Cache is seeded; verify via cache-hit (no wire trip).
+    const baseline = socket.sentFrames.length;
+    await expect(objBefore.get("altitude")).resolves.toBe(9999);
+    expect(countCalls(socket, "getProperty", baseline)).toBe(0);
+
+    socket.simulateMessage({
+      jsonrpc: "2.0",
+      method: "interestUpdate",
+      params: { interestName: "i1", added: [], removed: ["a1"], types: [], typeSchemas: "" },
+    });
+    // Cache cleared on removal: next get() on the stale handle wire-fetches.
+    const afterRemove = socket.sentFrames.length;
+    const pendingGet = objBefore.get("altitude");
+    await tick();
+    const req = JSON.parse(socket.sentFrames[socket.sentFrames.length - 1]!);
+    expect(req.method).toBe("getProperty");
+    // The handle is stale (object removed); server would normally reject. For this unit-level
+    // test we just confirm the cache was invalidated by sending a synthetic response.
+    socket.simulateMessage({ jsonrpc: "2.0", id: req.id, result: "0" });
+    await expect(pendingGet).resolves.toBe(0);
+    expect(countCalls(socket, "getProperty", afterRemove)).toBe(1);
+    client.close();
+  });
+});

--- a/components/jsonrpc/clients/typescript/tsconfig.json
+++ b/components/jsonrpc/clients/typescript/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "useDefineForClassFields": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/components/jsonrpc/clients/typescript/tsconfig.test.json
+++ b/components/jsonrpc/clients/typescript/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/components/jsonrpc/clients/typescript/vite.config.ts
+++ b/components/jsonrpc/clients/typescript/vite.config.ts
@@ -1,0 +1,36 @@
+// === vite.config.ts ==================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  build: {
+    lib: {
+      // Two entry points: the core (`@sen/client`) and the React adapter
+      // (`@sen/client/react`). The core has no React dependency at runtime.
+      entry: {
+        index: resolve(__dirname, "src/index.ts"),
+        "react/index": resolve(__dirname, "src/react/index.ts"),
+      },
+      formats: ["es"],
+    },
+    sourcemap: true,
+    rollupOptions: {
+      // React is a peer dep of the `/react` sub-import; never bundle it.
+      external: ["ws", "react"],
+    },
+  },
+  plugins: [
+    dts({
+      entryRoot: "src",
+      include: ["src/**/*.ts"],
+      tsconfigPath: "./tsconfig.json",
+    }),
+  ],
+});

--- a/components/jsonrpc/clients/typescript/vitest.config.ts
+++ b/components/jsonrpc/clients/typescript/vitest.config.ts
@@ -1,0 +1,20 @@
+// === vitest.config.ts ================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    // Integration tests live alongside the unit tests but need a running Sen subprocess. They
+    // ship under their own vitest config (vitest.integration.config.ts) with a globalSetup; the
+    // default unit-test loop excludes them so `npm test` stays fast and self-contained.
+    exclude: ["test/integration/**", "node_modules/**", "dist/**"],
+    globals: false,
+  },
+});

--- a/components/jsonrpc/clients/typescript/vitest.integration.config.ts
+++ b/components/jsonrpc/clients/typescript/vitest.integration.config.ts
@@ -1,0 +1,30 @@
+// === vitest.integration.config.ts ====================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// Integration suite: spawns a Sen subprocess against the SEN_CONFIG YAML, runs the per-feature
+// tests under test/integration/, then tears the subprocess down. Driven by `npm run
+// test:integration`; separate from the unit-test loop (vitest.config.ts) so the fast path stays
+// mock-only.
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/integration/**/*.test.ts"],
+    globalSetup: ["test/integration/globalSetup.ts"],
+    globals: false,
+    // Subprocess spawn + first connect can take a second; the per-test timeout default is
+    // generous to absorb that.
+    testTimeout: 10_000,
+    // Tests share one Sen subprocess (single fork). Sequential execution avoids interleaved
+    // notifications and shared-port races.
+    sequence: { concurrent: false },
+    pool: "forks",
+    poolOptions: { forks: { singleFork: true } },
+  },
+});

--- a/docs/components/jsonrpc_ts_client.md
+++ b/docs/components/jsonrpc_ts_client.md
@@ -1,0 +1,97 @@
+# The TypeScript Client (`@sen/client`)
+
+A TypeScript library that lets a browser or Node.js program talk to a running Sen process
+over the [`jsonrpc`](jsonrpc.md) component's wire (JSON-RPC 2.0 + WebSocket). Connect, walk
+the live object graph, subscribe to property changes and events, invoke methods, and (in
+React apps) drive a UI off the same data without writing your own subscription bookkeeping.
+
+It ships in-tree at
+[`components/jsonrpc/clients/typescript/`](https://github.com/airbus/sen/tree/main/components/jsonrpc/clients/typescript)
+and is the primary client for the [Sen Web Explorer](web_explorer.md) and for any custom
+operator UI built against Sen.
+
+## When to use it
+
+| Want to ... | Reach for |
+|---|---|
+| Build a browser UI that drives Sen interactively | `@sen/client` + `@sen/client/react` |
+| Write a Node.js script that polls / scripts a running Sen | `@sen/client` (no React) |
+| Build a backend service that bridges Sen to another protocol | `@sen/client` |
+| Talk to Sen from a non-TypeScript language | Write a client against `jsonrpc.stl` directly |
+
+## Hello, animals
+
+In one terminal, start a Sen process exposing the bundled `animals` package:
+
+```bash
+sen run components/jsonrpc/clients/typescript/examples/browser/animals.yaml
+```
+
+That spins up `rufus` (a `Cat`) and `elon` (a `Dog`) on `my.tutorial`. The JSON-RPC server
+listens on `ws://127.0.0.1:8080`.
+
+In a second terminal:
+
+```ts
+import { connect } from "@sen/client";
+
+const client = await connect({ url: "ws://127.0.0.1:8080" });
+
+const cats = await client.declareInterest({
+  name: "cats",
+  query: "SELECT animals.Cat FROM my.tutorial",
+});
+
+cats.onObjectAdded(async (cat) => {
+  console.log(`got ${cat.className} named ${cat.name}`);
+  cat.onPropertyChanged("position", (pos) => console.log("position:", pos));
+  await cat.invoke("jumpToLocation", { x: 42, y: 17 });
+});
+```
+
+You should see the initial position print, then the post-jump position. The
+`onObjectAdded` handler fires uniformly for objects matched at declare-time and for late
+arrivals.
+
+## Concepts
+
+Three layered handles:
+
+- **`Client`** -- the connection. One per Sen process. Owns the WebSocket, hands out
+  interests, surfaces connection-state events.
+- **`InterestHandle`** -- a live query. Keeps a local cache of matching objects in sync
+  with the server. Tells you when objects appear or disappear.
+- **`ObjectHandle`** -- one object in an interest's match set. The unit of work for
+  property reads/writes, event subscriptions, method calls.
+
+You only ever construct a `Client`. Interests and objects come from it.
+
+## Full reference
+
+The package's [README](https://github.com/airbus/sen/blob/main/components/jsonrpc/clients/typescript/README.md)
+is the comprehensive user reference, covering:
+
+- Queries + pre-subscribing properties / events at declare time
+- Property reads, writes, and subscriptions (and `onAnyChange`)
+- Events (`onEventTriggered`)
+- Method invocation (`invoke`)
+- Runtime value types (`Quantity`, `Variant`) + narrowing helpers
+- Error model (`JsonRpcError`, `TransportError`, `TimeoutError`)
+- Reconnection + `reestablishAll`
+- Batch reads (`getObjectsBatchState`) for dashboard-style refresh
+- React bindings (`@sen/client/react`): `useObject`, `useObjects`, `useProperty`,
+  `useEvents`, `useInvoke`, `useSetProperty`, `useTopology`, `useTypeSpec`, and the
+  `makeStore` / `useCell` primitives for fine-grained subscriptions.
+
+## Browser example
+
+[`examples/browser/`](https://github.com/airbus/sen/tree/main/components/jsonrpc/clients/typescript/examples/browser)
+in the package is a static HTML page that loads the built bundle and runs the hello-world
+above in a real browser. Use it as a sanity check after `npm run build`, or as a starting
+point for a custom browser UI.
+
+## Architecture
+
+For contributors: see
+[`components/jsonrpc/clients/typescript/architecture.md`](https://github.com/airbus/sen/blob/main/components/jsonrpc/clients/typescript/architecture.md)
+for the layer diagram, per-module responsibilities, key invariants, and extension points.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,6 +176,7 @@ nav:
       - Log Master: components/logmaster.md
       - REST: components/rest.md
       - JSON-RPC: components/jsonrpc.md
+      - JSON-RPC TypeScript Client: components/jsonrpc_ts_client.md
       - Tracy: components/tracy.md
   - Guides:
       - Working with objects: howto_guides/objects.md


### PR DESCRIPTION
`@sen/client`: programmatic TypeScript / React client for the jsonrpc API — typed handles over interests and objects, React hooks and store primitives, and race-proof reconnect recovery (single-flight, epoch-idempotent re-declaration). Wire types are generated from the same STL grammar as the server at build time, so the two cannot drift.

**Stack — part 4/6 (base: `feat/jsonrpc`).** This PR shows only its own changes; review and merge bottom-up.

---
**The stack**
1. #64 — kernel subscription-path fixes
2. #65 — mode-driven build selection + libs/gen
3. #66 — jsonrpc component
4. #67 — @sen/client TypeScript library
5. #68 — db Python bindings
6. #69 — Web Explorer + getting-started docs

Each PR is based on its predecessor's branch and shows only its own changes. Review in any order; merge strictly bottom-up. Note: this repository is squash-merge only, so after each merge the remaining branches must be rebased onto the updated `main` and force-pushed before the next PR's diff reads correctly again.
