### PR TITLE
ci: move to hosted runners and streamline the pull-request pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @EnriqueParodi @vulder
+* @EnriqueParodi

--- a/.github/actions/build_documentation/action.yaml
+++ b/.github/actions/build_documentation/action.yaml
@@ -1,0 +1,69 @@
+name: "Build the documentation."
+description: "Build the API reference and the handbook; the caller decides whether to publish the result."
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-python@v6
+      with:
+        python-version: 3.x
+
+    - name: Generate daily cache id
+      shell: bash
+      run: echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_ENV"
+
+    - uses: actions/cache@v5
+      with:
+        path: ~/.conan2/p
+        key: conanp-docs-${{ env.cache_date }}
+        restore-keys: conanp-docs-
+
+    - uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: docs
+        max-size: 1G
+        verbose: 1
+
+    - name: Install system dependencies
+      shell: bash
+      # graphviz draws the doxygen diagrams; libxext-dev is needed for clang
+      # compat with sdl2 2.24.0.
+      run: |
+        sudo apt update
+        sudo apt install -y g++ graphviz libxext-dev
+
+    - name: Install python dependencies
+      shell: bash
+      run: |
+        pip install conan==2.28.1
+        pip install -r docs/requirements.txt
+
+    - name: Setup conan profile
+      shell: bash
+      run: |
+        rm -f ~/.conan2/profiles/default
+        conan profile detect --force -vquiet
+        cp .conan/profiles/sen_gcc ~/.conan2/profiles/sen_gcc
+        cp .conan/profiles/sen_build_docs ~/.conan2/profiles/default
+        {
+          echo "[conf]"
+          echo "tools.system.package_manager:mode=install"
+          echo "tools.system.package_manager:sudo=True"
+        } >> ~/.conan2/profiles/default
+        conan profile show -pr default
+
+    # The handbook runs the built sen binary to capture its command-line help,
+    # so the documentation needs a full build first.
+    - name: Build the documentation
+      shell: bash
+      run: |
+        export PATH="/usr/lib/ccache:$PATH"
+        conan install . --build=missing
+        cmake --preset=conan-gcc-release
+        cmake --build build/gcc/Release/
+        cmake --build build/gcc/Release/ --target doxydocs
+        cmake --build build/gcc/Release/ --target mkdocs
+
+    - name: Remove unwanted parts from conan cache before backup
+      shell: bash
+      run: conan cache clean "*" -s -b -d

--- a/.github/actions/setup_build_context/action.yaml
+++ b/.github/actions/setup_build_context/action.yaml
@@ -17,7 +17,7 @@ runs:
 
     - name: Install python dependencies
       shell: bash
-      run: pip install -U conan pytest
+      run: pip install conan==2.28.1 pytest==9.1.1 junitparser==5.0.1
 
     - name: Install gcc-${{ inputs.compiler-version }}
       if: ${{ inputs.compiler-name == 'gcc' }}
@@ -31,7 +31,11 @@ runs:
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh ${{ inputs.compiler-version }}
-        sudo apt install -y clang-tools-${{ inputs.compiler-version }}
+        sudo apt install -y \
+          clang-tools-${{ inputs.compiler-version }} \
+          clang-tidy-${{ inputs.compiler-version }} \
+          llvm-${{ inputs.compiler-version }} \
+          libclang-rt-${{ inputs.compiler-version }}-dev
 
     - name: Install system dependencies
       if: ${{ inputs.compiler-name != 'msvc' }}
@@ -46,8 +50,12 @@ runs:
         conan profile detect --force -vquiet
         conan config install .conan/profiles/ --target-folder ~/.conan2/profiles/
         cp .conan/profiles/sen_${COMPILER}_${ARCH} ~/.conan2/profiles/default
-        echo tools.system.package_manager:mode=install >> ~/.conan2/profiles/default
-        echo tools.system.package_manager:sudo=True >> ~/.conan2/profiles/default
+        # In global.conf, not appended to the profile: a bare append lands in
+        # whichever section the profile ends with, and a profile ending in
+        # [settings] turns these into settings, where they do nothing. That is
+        # how the arm leg ended up refusing to install libgl.
+        printf 'tools.system.package_manager:mode=install\ntools.system.package_manager:sudo=True\n' \
+            >> ~/.conan2/global.conf
         conan profile show -pr default
       env:
         COMPILER: ${{ inputs.compiler-name }}

--- a/.github/scripts/check_package_archive.py
+++ b/.github/scripts/check_package_archive.py
@@ -1,0 +1,123 @@
+# === check_package_archive.py =========================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Checks that the archive built by CPack is complete.
+
+The release workflow attaches this archive to the GitHub release and the
+installer script unpacks it, so its layout is a contract. Without this check a
+dropped install rule ships a healthy-looking archive, and a changed archive
+name silently leaves the release with no artifacts at all.
+"""
+
+import argparse
+import re
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+# What the archive must hold, as paths under its top-level directory. Keep the
+# lists short: one representative of each thing an install rule ships. Files and
+# directories are separate, so a directory cannot stand in for a missing file.
+REQUIRED_FILES = (
+    "LICENSE.txt",
+    # sen.exe on Windows; either spelling satisfies this entry.
+    "bin/sen",
+    "cmake/sen/sen_targets.cmake",
+    "cmake/sen/SenConfigVersion.cmake",
+    "cmake/sen/util/sen_utils.cmake",
+)
+
+REQUIRED_DIRECTORIES = (
+    "libs/core/include/sen/core",
+    "resources/syntax_highlighting",
+)
+
+# sen-<version>-<processor>-<system>-<compiler>-<version>-<build type>, lower
+# case. The version is a tag or "latest", and a tag may carry an -rc suffix.
+NAME_PATTERN = re.compile(r"^sen-[^-]+(?:-rc\d+)?-[^-]+-[^-]+-[^-]+-[^-]+-(release|debug)$")
+
+
+def list_entries(archive: Path) -> list[str]:
+    """Lists the files in the archive, without their common top-level directory.
+
+    Only directory members are dropped, so an install rule that produces an
+    empty directory cannot satisfy a required file. Symlinks count: the sen
+    executable and the versioned libraries ship as links.
+    """
+    if archive.suffixes[-2:] == [".tar", ".gz"]:
+        with tarfile.open(archive) as tar:
+            names = [member.name for member in tar.getmembers() if not member.isdir()]
+    elif archive.suffix == ".zip":
+        with zipfile.ZipFile(archive) as zip_file:
+            names = [name for name in zip_file.namelist() if not name.endswith("/")]
+    else:
+        raise SystemExit(f"Error: unsupported archive type: {archive.name}")
+
+    if not names:
+        raise SystemExit(f"Error: the archive holds no entries: {archive.name}")
+
+    roots = {name.split("/", 1)[0] for name in names}
+    if len(roots) != 1:
+        raise SystemExit(f"Error: expected one top-level directory, found {sorted(roots)}")
+
+    return [name.split("/", 1)[1] for name in names if "/" in name]
+
+
+def archive_stem(archive: Path) -> str:
+    """Returns the archive name without its extension."""
+    name = archive.name
+    for suffix in (".tar.gz", ".zip"):
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+
+    raise SystemExit(f"Error: unsupported archive type: {name}")
+
+
+def missing_entries(entries: list[str]) -> list[str]:
+    """Returns the required files and directories the archive does not hold."""
+    present = set(entries)
+    missing = [name for name in REQUIRED_FILES if name not in present and f"{name}.exe" not in present]
+    missing += [name for name in REQUIRED_DIRECTORIES if not any(entry.startswith(f"{name}/") for entry in entries)]
+    return missing
+
+
+def check_archive(archive: Path) -> list[str]:
+    """Returns the problems found in the archive, empty when it is complete."""
+    problems = []
+    if not NAME_PATTERN.match(archive_stem(archive)):
+        problems.append(f"name does not match the expected pattern: {archive.name}")
+
+    problems.extend(f"missing entry: {entry}" for entry in missing_entries(list_entries(archive)))
+    return problems
+
+
+def main() -> int:
+    """Checks the archives found in the given build directory."""
+    parser = argparse.ArgumentParser(
+        prog="check_package_archive",
+        description="Checks that the archive built by CPack is complete.",
+    )
+    parser.add_argument("build_dir", help="Build directory holding the archive that CPack wrote.")
+    args = parser.parse_args()
+
+    archives = sorted(Path(args.build_dir).glob("sen-*.tar.gz")) + sorted(Path(args.build_dir).glob("sen-*.zip"))
+    if not archives:
+        raise SystemExit(f"Error: no archive found in {args.build_dir}")
+
+    problems = [problem for archive in archives for problem in check_archive(archive)]
+    for problem in problems:
+        print(problem)
+
+    if problems:
+        return 1
+
+    print(f"checked {', '.join(archive.name for archive in archives)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/generate_matrix_jobs.py
+++ b/.github/scripts/generate_matrix_jobs.py
@@ -10,18 +10,10 @@ import argparse
 import json
 import os
 import typing as tp
-from dataclasses import asdict, dataclass, is_dataclass
+from dataclasses import asdict, dataclass, fields
 
 
-def convert_dataclass_to_json(obj) -> dict:
-    """Converts the given dataclass to json."""
-    if is_dataclass(obj):
-        return {key: convert_dataclass_to_json(value) for key, value in asdict(obj).items()}
-
-    return obj
-
-
-@dataclass(frozen=True, order=True)
+@dataclass(frozen=True, order=True, kw_only=True)
 class Compiler:
     """Compiler specification."""
 
@@ -31,154 +23,172 @@ class Compiler:
     cxx: str
 
 
-@dataclass(frozen=True, order=True)
+@dataclass(frozen=True, order=True, kw_only=True)
 class Container:
     """Container specification."""
 
     image: str
 
 
-@dataclass(frozen=True, order=True)
+@dataclass(frozen=True, order=True, kw_only=True)
 class JobSpecification:
     """Pipeline job specification that defines the configuration options."""
 
     name: str
     os: str
-    runner: tp.Literal["ubuntu-latest", "windows-2022", "self-hosted", "ubuntu-24.04-arm"]
+    runner: tp.Literal["ubuntu-latest", "ubuntu-22.04", "ubuntu-24.04", "windows-2022", "ubuntu-24.04-arm"]
     container: Container | None
     compiler: Compiler
     arch: tp.Literal["x86", "arm"]
     std: tp.Literal[17, 20, 23]
     build_type: tp.Literal["Release", "Debug"]
     enable_coverage: bool = False
+    enable_examples: bool = False
+    # Builds the CPack archive and checks its contents. Set on the shipping
+    # configuration only: the archive is the same everywhere it is built.
+    check_package: bool = False
+
+    def __post_init__(self):
+        """Validates every Literal-typed field against its allowed values."""
+        for field in fields(self):
+            if tp.get_origin(field.type) is tp.Literal:
+                value = getattr(self, field.name)
+                allowed = tp.get_args(field.type)
+                if value not in allowed:
+                    raise ValueError(f"{field.name}={value!r} is not one of {allowed}")
 
     def as_json(self) -> dict:
         """Converts the job spec into json."""
-        return convert_dataclass_to_json(self)
+        return asdict(self)
 
 
-@dataclass(frozen=True, order=True)
+@dataclass(frozen=True, order=True, kw_only=True)
 class JobSelector:
     """Selector specification that defines when to add a job."""
 
     job_spec: JobSpecification
     include_in_release_workflow: bool
     include_in_conan_workflow: bool
+    include_in_conan_workflow_on_pull_requests: bool
     include_in_standard_test_workflow: bool
     include_in_standard_test_workflow_also_main: bool
 
 
-def compute_jobs(release: bool, conan: bool, standard_test: bool, target_main: bool) -> list[JobSpecification]:
+# Every leg the pipeline knows about. A leg no workflow can select advertises
+# coverage that never happens, so test_generate_matrix_jobs.py asserts that
+# every entry here is selected by some workflow.
+SPECIFIED_JOBS = [
+    # Add gcc jobs
+    JobSelector(
+        job_spec=JobSpecification(
+            name="Basic GCC",
+            os="ubuntu-22.04",
+            runner="ubuntu-22.04",
+            container=None,
+            compiler=Compiler(name="gcc", version=12, cc="gcc-12", cxx="g++-12"),
+            arch="x86",
+            std=17,
+            build_type="Debug",
+            enable_examples=True,
+        ),
+        include_in_release_workflow=False,
+        include_in_conan_workflow=True,
+        include_in_conan_workflow_on_pull_requests=False,
+        include_in_standard_test_workflow=True,
+        include_in_standard_test_workflow_also_main=False,
+    ),
+    JobSelector(
+        job_spec=JobSpecification(
+            name="Basic GCC",
+            os="ubuntu-22.04",
+            runner="ubuntu-22.04",
+            container=None,
+            compiler=Compiler(name="gcc", version=12, cc="gcc-12", cxx="g++-12"),
+            arch="x86",
+            std=17,
+            build_type="Release",
+            enable_examples=True,
+            check_package=True,
+        ),
+        include_in_release_workflow=True,
+        include_in_conan_workflow=True,
+        include_in_conan_workflow_on_pull_requests=True,
+        include_in_standard_test_workflow=True,
+        # Also after a merge: this leg carries the package-archive check.
+        include_in_standard_test_workflow_also_main=True,
+    ),
+    # Add clang jobs
+    JobSelector(
+        job_spec=JobSpecification(
+            name="Basic Clang",
+            os="ubuntu-24.04",
+            runner="ubuntu-24.04",
+            container=None,
+            compiler=Compiler(name="clang", version=20, cc="clang-20", cxx="clang++-20"),
+            arch="x86",
+            std=17,
+            build_type="Debug",
+            enable_coverage=True,
+            enable_examples=True,
+        ),
+        include_in_release_workflow=False,
+        include_in_conan_workflow=True,
+        include_in_conan_workflow_on_pull_requests=False,
+        include_in_standard_test_workflow=True,
+        include_in_standard_test_workflow_also_main=True,
+    ),
+    # Add msvc jobs
+    JobSelector(
+        job_spec=JobSpecification(
+            name="Basic Windows",
+            os="windows",
+            runner="windows-2022",
+            container=None,
+            compiler=Compiler(name="msvc", version=194, cc="cl", cxx="cl"),
+            arch="x86",
+            std=17,
+            build_type="Release",
+        ),
+        include_in_release_workflow=True,
+        include_in_conan_workflow=True,
+        include_in_conan_workflow_on_pull_requests=False,
+        # TODO(SEN-1725): fix build failures in test setup
+        include_in_standard_test_workflow=False,
+        include_in_standard_test_workflow_also_main=False,
+    ),
+    # Add arm jobs
+    JobSelector(
+        job_spec=JobSpecification(
+            name="Basic Ubuntu arm",
+            os="ubuntu-24.04",
+            runner="ubuntu-24.04-arm",
+            container=None,
+            compiler=Compiler(name="gcc", version=12, cc="gcc-12", cxx="g++-12"),
+            arch="arm",
+            std=17,
+            build_type="Debug",
+            enable_examples=True,
+        ),
+        include_in_release_workflow=False,
+        include_in_conan_workflow=False,
+        include_in_conan_workflow_on_pull_requests=False,
+        include_in_standard_test_workflow=True,
+        include_in_standard_test_workflow_also_main=False,
+    ),
+]
+
+
+def compute_jobs(
+    release: bool, conan: bool, standard_test: bool, target_main: bool, pull_request: bool = False
+) -> list[JobSpecification]:
     """Computes the list of pipeline jobs that should run."""
-    specified_jobs = [
-        # Add gcc jobs
-        JobSelector(
-            job_spec=JobSpecification(
-                "Basic GCC",
-                "ubuntu-22.04",
-                "self-hosted",
-                None,
-                Compiler("gcc", 12, "gcc-12", "g++-12"),
-                "x86",
-                17,
-                "Debug",
-            ),
-            include_in_release_workflow=False,
-            include_in_conan_workflow=True,
-            include_in_standard_test_workflow=True,
-            include_in_standard_test_workflow_also_main=False,
-        ),
-        JobSelector(
-            job_spec=JobSpecification(
-                "Basic GCC",
-                "ubuntu-22.04",
-                "self-hosted",
-                None,
-                Compiler("gcc", 12, "gcc-12", "g++-12"),
-                "x86",
-                17,
-                "Release",
-            ),
-            include_in_release_workflow=True,
-            include_in_conan_workflow=True,
-            include_in_standard_test_workflow=True,
-            include_in_standard_test_workflow_also_main=False,
-        ),
-        # Add clang jobs
-        JobSelector(
-            job_spec=JobSpecification(
-                "Basic Clang",
-                "ubuntu-24.04",
-                "self-hosted",
-                None,
-                Compiler("clang", 20, "clang-20", "clang++-20"),
-                "x86",
-                17,
-                "Debug",
-                enable_coverage=True,
-            ),
-            include_in_release_workflow=False,
-            include_in_conan_workflow=True,
-            include_in_standard_test_workflow=True,
-            include_in_standard_test_workflow_also_main=True,
-        ),
-        # Add msvc jobs
-        JobSelector(
-            job_spec=JobSpecification(
-                "Basic Windows",
-                "windows",
-                "windows-2022",
-                None,
-                Compiler("msvc", 194, "cl", "cl"),
-                "x86",
-                17,
-                "Release",
-            ),
-            include_in_release_workflow=True,
-            include_in_conan_workflow=True,
-            # TODO(SEN-1725): fix build failures in test setup
-            include_in_standard_test_workflow=False,
-            include_in_standard_test_workflow_also_main=False,
-        ),
-        JobSelector(
-            job_spec=JobSpecification(
-                "Basic Windows",
-                "windows",
-                "windows-2022",
-                None,
-                Compiler("msvc", 194, "cl", "cl"),
-                "x86",
-                17,
-                "Debug",
-            ),
-            include_in_release_workflow=False,
-            include_in_conan_workflow=False,
-            # TODO: fix build failures in test setup
-            include_in_standard_test_workflow=False,
-            include_in_standard_test_workflow_also_main=False,
-        ),
-        # Add amd64 jobs
-        JobSelector(
-            job_spec=JobSpecification(
-                "Basic Ubuntu arm",
-                "ubuntu-24.04",
-                "ubuntu-24.04-arm",
-                None,
-                Compiler("gcc", 14, "gcc-14", "g++-14"),
-                "arm",
-                17,
-                "Debug",
-            ),
-            include_in_release_workflow=False,
-            include_in_conan_workflow=False,
-            include_in_standard_test_workflow=True,
-            include_in_standard_test_workflow_also_main=False,
-        ),
-    ]
 
     def include_job(job_selector: JobSelector) -> bool:
         if release:
             return job_selector.include_in_release_workflow
+
+        if conan and pull_request:
+            return job_selector.include_in_conan_workflow_on_pull_requests
 
         if conan:
             return job_selector.include_in_conan_workflow
@@ -192,21 +202,28 @@ def compute_jobs(release: bool, conan: bool, standard_test: bool, target_main: b
         if standard_test:
             return job_selector.include_in_standard_test_workflow
 
-        print(f"Warning: could not correctly determine selection for job {job_selector}")
-        return False  # by default, we skip jobs
+        raise ValueError(f"could not determine the workflow selection for job {job_selector.job_spec.name}")
 
-    return sorted([job_selector.job_spec for job_selector in specified_jobs if include_job(job_selector)])
+    jobs = [job_selector.job_spec for job_selector in SPECIFIED_JOBS if include_job(job_selector)]
+    if not jobs:
+        raise ValueError("the selection produced no jobs; a matrix job would silently not exist")
+
+    # Explicit key: ordering by the dataclass would compare container against None.
+    return sorted(jobs, key=lambda job: (job.name, job.runner, job.build_type, job.std))
 
 
-def generate_jobs_file(release: bool, conan: bool, standard_test: bool, target_main: bool) -> None:
+def generate_jobs_file(
+    release: bool, conan: bool, standard_test: bool, target_main: bool, pull_request: bool = False
+) -> None:
     """Generates the jobs file at GITHUB_OUTPUT."""
-    jobs = compute_jobs(release, conan, standard_test, target_main)
+    jobs = compute_jobs(release, conan, standard_test, target_main, pull_request)
 
-    if output_file := os.environ.get("GITHUB_OUTPUT"):
-        with open(output_file, "w", encoding="utf-8") as matrix_file:
-            matrix_file.write(f"jobs={json.dumps([j.as_json() for j in jobs])}")
-    else:
-        print("Error: No output file specified to write to.")
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if not output_file:
+        raise SystemExit("Error: No output file specified to write to.")
+
+    with open(output_file, "a", encoding="utf-8") as matrix_file:
+        matrix_file.write(f"jobs={json.dumps([j.as_json() for j in jobs])}\n")
 
 
 def main() -> None:
@@ -235,14 +252,27 @@ def main() -> None:
         action=argparse.BooleanOptionalAction,
         help="Specifies that we are explicitly building for the main branch.",
     )
+    parser.add_argument(
+        "--pull-request",
+        action=argparse.BooleanOptionalAction,
+        help="Generate only the packaging jobs that run on a pull request.",
+    )
 
     args = parser.parse_args()
+
+    if sum(bool(flag) for flag in (args.release, args.conan, args.standard_test)) != 1:
+        parser.error("exactly one of --release, --conan, --standard-test is required")
+    if args.target_main and not args.standard_test:
+        parser.error("--target-main only applies to --standard-test")
+    if args.pull_request and not args.conan:
+        parser.error("--pull-request only applies to --conan")
 
     generate_jobs_file(
         release=args.release,
         conan=args.conan,
         standard_test=args.standard_test,
         target_main=args.target_main,
+        pull_request=args.pull_request,
     )
 
 

--- a/.github/scripts/test_check_package_archive.py
+++ b/.github/scripts/test_check_package_archive.py
@@ -1,0 +1,133 @@
+# === test_check_package_archive.py ====================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Pins what the package check accepts and rejects.
+
+The archive contents here are written out literally rather than derived from
+the checker's own constants: a fixture built from REQUIRED_FILES cannot
+disagree with it, and would pass even if an entry were dropped.
+"""
+
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+from check_package_archive import REQUIRED_DIRECTORIES, REQUIRED_FILES, check_archive
+
+LINUX_NAME = "sen-0.6.0-x86_64-linux-gnu-12.4.0-release"
+WINDOWS_NAME = "sen-0.6.0-amd64-windows-msvc-19.44.35228.0-release"
+
+# The layout of a real archive, as built by CPack (verified against one).
+LINUX_MEMBERS = (
+    "LICENSE.txt",
+    "bin/sen",
+    "bin/libkernel.so.0.0.0",
+    "cmake/sen/sen_targets.cmake",
+    "cmake/sen/SenConfigVersion.cmake",
+    "cmake/sen/util/sen_utils.cmake",
+    "libs/core/include/sen/core/base/hash32.h",
+    "resources/syntax_highlighting/stl.tmLanguage.json",
+)
+
+WINDOWS_MEMBERS = tuple("bin/sen.exe" if member == "bin/sen" else member for member in LINUX_MEMBERS)
+
+
+def write_archive(directory: Path, stem: str, members, suffix: str = ".tar.gz") -> Path:
+    """Writes an archive holding the given files under one top-level directory."""
+    payload = directory / "payload"
+    payload.write_text("x", encoding="utf-8")
+
+    archive = directory / f"{stem}{suffix}"
+    if suffix == ".zip":
+        with zipfile.ZipFile(archive, "w") as zip_file:
+            for member in members:
+                zip_file.write(payload, f"{stem}/{member}")
+    else:
+        with tarfile.open(archive, "w:gz") as tar:
+            for member in members:
+                tar.add(payload, f"{stem}/{member}")
+
+    return archive
+
+
+def test_realistic_linux_archive_passes(tmp_path):
+    """The layout CPack produces on Linux reports nothing."""
+    assert check_archive(write_archive(tmp_path, LINUX_NAME, LINUX_MEMBERS)) == []
+
+
+def test_realistic_windows_archive_passes(tmp_path):
+    """The Windows zip passes, where the executable carries the .exe suffix."""
+    archive = write_archive(tmp_path, WINDOWS_NAME, WINDOWS_MEMBERS, suffix=".zip")
+    assert check_archive(archive) == []
+
+
+@pytest.mark.parametrize("dropped", REQUIRED_FILES)
+def test_each_required_file_is_pinned(tmp_path, dropped):
+    """Dropping any required file is reported, not just one of them."""
+    members = [member for member in LINUX_MEMBERS if member != dropped]
+    assert check_archive(write_archive(tmp_path, LINUX_NAME, members)) == [f"missing entry: {dropped}"]
+
+
+@pytest.mark.parametrize("dropped", REQUIRED_DIRECTORIES)
+def test_each_required_directory_is_pinned(tmp_path, dropped):
+    """Dropping the contents of any required directory is reported."""
+    members = [member for member in LINUX_MEMBERS if not member.startswith(f"{dropped}/")]
+    assert check_archive(write_archive(tmp_path, LINUX_NAME, members)) == [f"missing entry: {dropped}"]
+
+
+def test_an_empty_directory_does_not_ship_a_file(tmp_path):
+    """A directory named like a required file does not satisfy it."""
+    members = [member for member in LINUX_MEMBERS if member != "bin/sen"] + ["bin/sen/placeholder"]
+    assert check_archive(write_archive(tmp_path, LINUX_NAME, members)) == ["missing entry: bin/sen"]
+
+
+def test_unexpected_name_is_reported(tmp_path):
+    """A drifting archive name would leave the release without artifacts."""
+    problems = check_archive(write_archive(tmp_path, "sen-package", LINUX_MEMBERS))
+    assert problems == ["name does not match the expected pattern: sen-package.tar.gz"]
+
+
+@pytest.mark.parametrize(
+    "stem",
+    [
+        "sen-0.6.0-rc1-x86_64-linux-gnu-12.4.0-release",
+        "sen-latest-aarch64-linux-gnu-12.3.0-release",
+        "sen-0.6.0-x86_64-linux-gnu-12.4.0-debug",
+    ],
+)
+def test_names_cpack_really_produces_are_accepted(tmp_path, stem):
+    """Release candidates, untagged builds and Debug archives are all valid names."""
+    assert check_archive(write_archive(tmp_path, stem, LINUX_MEMBERS)) == []
+
+
+def test_empty_archive_is_reported(tmp_path):
+    """An archive with no members fails with a clear message, not a confusing one."""
+    archive = tmp_path / f"{LINUX_NAME}.tar.gz"
+    with tarfile.open(archive, "w:gz"):
+        pass
+
+    with pytest.raises(SystemExit, match="no entries"):
+        check_archive(archive)
+
+
+def test_a_symlinked_executable_ships(tmp_path):
+    """The sen executable and the versioned libraries ship as symlinks."""
+    payload = tmp_path / "payload"
+    payload.write_text("x", encoding="utf-8")
+
+    archive = tmp_path / f"{LINUX_NAME}.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        for member in LINUX_MEMBERS:
+            if member == "bin/sen":
+                link = tarfile.TarInfo(f"{LINUX_NAME}/{member}")
+                link.type = tarfile.SYMTYPE
+                link.linkname = "cli_sen"
+                tar.addfile(link)
+            else:
+                tar.add(payload, f"{LINUX_NAME}/{member}")
+
+    assert check_archive(archive) == []

--- a/.github/scripts/test_generate_matrix_jobs.py
+++ b/.github/scripts/test_generate_matrix_jobs.py
@@ -1,0 +1,185 @@
+# === test_generate_matrix_jobs.py =====================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Pins the exact job matrix emitted for every workflow flag combination.
+
+When the matrix changes, the expectations here change in the same commit.
+"""
+
+import pytest
+from generate_matrix_jobs import SPECIFIED_JOBS, Compiler, JobSpecification, compute_jobs
+
+GCC_DEBUG = ("Basic GCC", "gcc-12", "Debug", "ubuntu-22.04", "x86")
+GCC_RELEASE = ("Basic GCC", "gcc-12", "Release", "ubuntu-22.04", "x86")
+CLANG_COVERAGE = ("Basic Clang", "clang-20", "Debug", "ubuntu-24.04", "x86")
+MSVC_RELEASE = ("Basic Windows", "cl", "Release", "windows-2022", "x86")
+ARM_DEBUG = ("Basic Ubuntu arm", "gcc-12", "Debug", "ubuntu-24.04-arm", "arm")
+
+
+def job_keys(jobs: list[JobSpecification]) -> list[tuple[str, str, str, str, str]]:
+    """Reduces job specs to the fields that identify a matrix leg."""
+    return [(job.name, job.compiler.cc, job.build_type, job.runner, job.arch) for job in jobs]
+
+
+def test_standard_test_job_set():
+    """Standard tests run the three Linux x86 legs plus the arm leg."""
+    jobs = compute_jobs(release=False, conan=False, standard_test=True, target_main=False)
+    assert job_keys(jobs) == [CLANG_COVERAGE, GCC_DEBUG, GCC_RELEASE, ARM_DEBUG]
+
+
+def test_standard_test_main_job_set():
+    """Post-merge main builds run the coverage leg and the shipping leg."""
+    jobs = compute_jobs(release=False, conan=False, standard_test=True, target_main=True)
+    assert job_keys(jobs) == [CLANG_COVERAGE, GCC_RELEASE]
+
+
+def test_conan_job_set():
+    """Packaging runs the Linux legs plus the MSVC Release leg."""
+    jobs = compute_jobs(release=False, conan=True, standard_test=False, target_main=False)
+    assert job_keys(jobs) == [CLANG_COVERAGE, GCC_DEBUG, GCC_RELEASE, MSVC_RELEASE]
+
+
+def test_release_job_set():
+    """Releases build gcc and MSVC, Release only."""
+    jobs = compute_jobs(release=True, conan=False, standard_test=False, target_main=False)
+    assert job_keys(jobs) == [GCC_RELEASE, MSVC_RELEASE]
+
+
+def test_only_coverage_leg_enables_coverage():
+    """Exactly one leg collects coverage."""
+    jobs = compute_jobs(release=False, conan=False, standard_test=True, target_main=False)
+    assert [job.name for job in jobs if job.enable_coverage] == ["Basic Clang"]
+
+
+def test_no_flag_selection_fails_loudly():
+    """compute_jobs raises when no workflow flag is set."""
+    with pytest.raises(ValueError, match="could not determine"):
+        compute_jobs(release=False, conan=False, standard_test=False, target_main=False)
+
+
+def test_positional_construction_is_rejected():
+    """Constructing a spec positionally raises TypeError."""
+    with pytest.raises(TypeError):
+        Compiler("gcc", 12, "gcc-12", "g++-12")
+
+
+def test_invalid_literal_value_is_rejected():
+    """Values outside a Literal field fail at construction time."""
+    with pytest.raises(ValueError, match="runner="):
+        JobSpecification(
+            name="Bad",
+            os="ubuntu-22.04",
+            runner="self-hosted",  # the retired datacenter runner's label
+            container=None,
+            compiler=Compiler(name="gcc", version=12, cc="gcc-12", cxx="g++-12"),
+            arch="x86",
+            std=17,
+            build_type="Debug",
+        )
+
+
+def test_standard_test_legs_build_examples():
+    """Every standard-test leg builds the examples."""
+    jobs = compute_jobs(release=False, conan=False, standard_test=True, target_main=False)
+    assert all(job.enable_examples for job in jobs)
+
+
+def test_windows_legs_keep_the_defaults():
+    """The Windows legs do not build the examples."""
+    jobs = compute_jobs(release=True, conan=False, standard_test=False, target_main=False)
+    windows = [job for job in jobs if job.os == "windows"]
+    assert windows
+    assert all(not job.enable_examples for job in windows)
+
+
+def test_pull_request_packaging_job_set():
+    """A pull request packages the shipping configuration only."""
+    jobs = compute_jobs(release=False, conan=True, standard_test=False, target_main=False, pull_request=True)
+    assert job_keys(jobs) == [GCC_RELEASE]
+
+
+def test_only_the_shipping_leg_checks_the_package():
+    """The CPack archive is built and checked once, on the shipping leg."""
+    jobs = compute_jobs(release=False, conan=False, standard_test=True, target_main=False)
+    checked = [job for job in jobs if job.check_package]
+    assert job_keys(checked) == [GCC_RELEASE]
+
+
+def test_standard_test_specs_in_full():
+    """Pins every field of every standard-test leg, not just the identifying ones.
+
+    The fields left out of job_keys are load-bearing: os feeds the cache keys
+    and cxx is exported as the compiler.
+    """
+    jobs = compute_jobs(release=False, conan=False, standard_test=True, target_main=False)
+    assert [job.as_json() for job in jobs] == [
+        {
+            "name": "Basic Clang",
+            "os": "ubuntu-24.04",
+            "runner": "ubuntu-24.04",
+            "container": None,
+            "compiler": {"name": "clang", "version": 20, "cc": "clang-20", "cxx": "clang++-20"},
+            "arch": "x86",
+            "std": 17,
+            "build_type": "Debug",
+            "enable_coverage": True,
+            "enable_examples": True,
+            "check_package": False,
+        },
+        {
+            "name": "Basic GCC",
+            "os": "ubuntu-22.04",
+            "runner": "ubuntu-22.04",
+            "container": None,
+            "compiler": {"name": "gcc", "version": 12, "cc": "gcc-12", "cxx": "g++-12"},
+            "arch": "x86",
+            "std": 17,
+            "build_type": "Debug",
+            "enable_coverage": False,
+            "enable_examples": True,
+            "check_package": False,
+        },
+        {
+            "name": "Basic GCC",
+            "os": "ubuntu-22.04",
+            "runner": "ubuntu-22.04",
+            "container": None,
+            "compiler": {"name": "gcc", "version": 12, "cc": "gcc-12", "cxx": "g++-12"},
+            "arch": "x86",
+            "std": 17,
+            "build_type": "Release",
+            "enable_coverage": False,
+            "enable_examples": True,
+            "check_package": True,
+        },
+        {
+            "name": "Basic Ubuntu arm",
+            "os": "ubuntu-24.04",
+            "runner": "ubuntu-24.04-arm",
+            "container": None,
+            "compiler": {"name": "gcc", "version": 12, "cc": "gcc-12", "cxx": "g++-12"},
+            "arch": "arm",
+            "std": 17,
+            "build_type": "Debug",
+            "enable_coverage": False,
+            "enable_examples": True,
+            "check_package": False,
+        },
+    ]
+
+
+def test_every_declared_leg_is_reachable():
+    """A leg no workflow can select advertises coverage that never happens."""
+    selections = [
+        compute_jobs(release=True, conan=False, standard_test=False, target_main=False),
+        compute_jobs(release=False, conan=True, standard_test=False, target_main=False),
+        compute_jobs(release=False, conan=True, standard_test=False, target_main=False, pull_request=True),
+        compute_jobs(release=False, conan=False, standard_test=True, target_main=False),
+        compute_jobs(release=False, conan=False, standard_test=True, target_main=True),
+    ]
+    reachable = {job for jobs in selections for job in jobs}
+    declared = {selector.job_spec for selector in SPECIFIED_JOBS}
+    assert declared == reachable

--- a/.github/scripts/test_main_yaml.py
+++ b/.github/scripts/test_main_yaml.py
@@ -1,0 +1,22 @@
+"""Guard the ci-ok aggregator in main.yaml.
+
+ci-ok is the only required status check on main, and it only blocks what it
+`needs`. A job missing from that list can fail without blocking a merge, so
+every job must appear there.
+"""
+
+from pathlib import Path
+
+import yaml
+
+MAIN_YAML = Path(__file__).resolve().parents[1] / "workflows" / "main.yaml"
+
+
+def test_ci_ok_needs_every_job():
+    """Every job in main.yaml must appear in the needs list of ci-ok."""
+    jobs = yaml.safe_load(MAIN_YAML.read_text())["jobs"]
+    needs = set(jobs["ci-ok"]["needs"])
+    others = set(jobs) - {"ci-ok"}
+    missing = sorted(others - needs)
+    stale = sorted(needs - others)
+    assert needs == others, f"ci-ok.needs is out of sync with the job list: missing {missing}, stale {stale}"

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -7,6 +7,12 @@
 
 name: Build documentation
 
+# Queue deploys instead of racing them: a merge and its tag arrive seconds
+# apart and both push to gh-pages, where the loser is rejected.
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
 on:
   push:
     branches:
@@ -18,19 +24,15 @@ on:
 
 permissions:
   contents: write
-  pages: write
 
 jobs:
   deploy_docs:
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: 3.x
 
       - name: Configure git user and gh-pages repo
         run: |
@@ -38,45 +40,21 @@ jobs:
           git config --global user.email github-actions@github.com
           git fetch origin gh-pages --depth=1
 
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y g++ graphviz
+      # docs_check.yaml runs the same build on pull requests; only the
+      # publishing below needs write access.
+      - uses: ./.github/actions/build_documentation
 
-      - name: Install pip dependencies
-        run: |
-          pip install conan pytest mike
-          pip install -r docs/requirements.txt
+      - name: Install mike
+        run: pip install mike==2.1.3
 
-      - name: Setup conan profile
-        shell: bash
-        run: |
-          rm ~/.conan2/profiles/default
-          conan profile detect --force -vquiet
-          cp .conan/profiles/sen_gcc ~/.conan2/profiles/sen_gcc
-          cp .conan/profiles/sen_build_docs ~/.conan2/profiles/default
-          echo [conf] >> ~/.conan2/profiles/default
-          echo tools.system.package_manager:mode=install >> ~/.conan2/profiles/default
-          echo tools.system.package_manager:sudo=True >> ~/.conan2/profiles/default
-          conan profile show -pr default
-
-      - name: Install system dependencies
-        # need for clang compat with sdl2 2.24.0
-        shell: bash
-        run: sudo apt-get install -y libxext-dev
-
-      - name: Auto generate docs
-        run: |
-          conan install . --build=missing
-          cmake --preset=conan-gcc-release
-          cmake --build build/gcc/Release/
-          cmake --build build/gcc/Release/ --target doxydocs
-          cmake --build build/gcc/Release/ --target mkdocs
-
+      # Every release keeps a frozen copy. `stable` follows the newest
+      # release and the site's front page opens it; `latest` follows main.
       - name: Build and deploy release documentation
-        if: github.ref_type == 'tag'
-        run: mike deploy --push --update-aliases ${{ github.ref_name }}
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        run: |
+          mike deploy --push --update-aliases ${{ github.ref_name }} stable
+          mike set-default --push stable
 
       - name: Build and deploy intermediate documentation
-        if: github.ref_type != 'tag'
+        if: github.event_name == 'push' && github.ref_type != 'tag'
         run: mike deploy --push --update-aliases latest

--- a/.github/workflows/conan.yaml
+++ b/.github/workflows/conan.yaml
@@ -14,6 +14,11 @@ on:
         required: false
         default: false
         type: boolean
+      # Pull requests package the shipping configuration only; see main.yaml.
+      pull_request_subset:
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -22,6 +27,7 @@ jobs:
   compute-matrix-jobs:
     name: "Generate build matrix"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       jobs: ${{ steps.compute-jobs.outputs.jobs }}
     steps:
@@ -32,11 +38,12 @@ jobs:
         with:
           python-version: 3.x
       - id: compute-jobs
-        run: python .github/scripts/generate_matrix_jobs.py --conan
+        run: python .github/scripts/generate_matrix_jobs.py --conan ${{ inputs.pull_request_subset && '--pull-request' || '' }}
   build:
     name: "Conan Job: ${{ matrix.compiler.name }}-${{ matrix.arch }}-${{ matrix.compiler.version }} C++${{ matrix.std }} [${{ matrix.build_type }}]"
     needs: compute-matrix-jobs
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
     strategy:
       fail-fast: true
       matrix:
@@ -49,27 +56,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Disable for now on local runner
-      #
-      # - name: Generate daily cache id
-      #   shell: bash
-      #   run: echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_ENV
+      - name: Generate daily cache id
+        shell: bash
+        run: echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_ENV"
 
-      # - name: Cache conan packages
-      #   uses: actions/cache@v5
-      #   if: always()
-      #   env:
-      #     cache-name: cache-conan-packages
-      #   with:
-      #     path: ~/.conan2/p
-      #     key: conanp-${{ matrix.os }}-${{ matrix.compiler.name }}-${{ matrix.build_type }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ env.cache_date }}
-      #     restore-keys: conanp-${{ matrix.os }}-${{ matrix.compiler.name }}-${{ matrix.build_type }}-${{ matrix.compiler.version }}-${{ matrix.std }}-
+      # Same key scheme as standard_test.yaml so both workflows share one
+      # dependency slice per compiler (dependencies are always Release).
+      - name: Cache conan packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2/p
+          key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ env.cache_date }}
+          restore-keys: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-
 
       - uses: hendrikmuhs/ccache-action@v1.2
         if: runner.os == 'Linux'
         with:
-          key: ${{ matrix.os }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ matrix.build_type }}
-          max-size: 250M
+          key: ${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ matrix.build_type }}
+          max-size: 1G
           verbose: 1
 
       - name: Setup build context
@@ -83,9 +87,13 @@ jobs:
         shell: bash
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          # build_type applies to the sen package only; dependencies stay at
+          # the profiles' Release default, shared across build types and
+          # matching what binary remotes serve. Scoped by name rather than &
+          # because the test_package graph has a different consumer.
           conan create . --user airbus --channel dev --lockfile-out=package.lock \
               --test-folder .conan/test_packages/package \
-              --build=missing -s:a build_type=${{ matrix.build_type }}
+              --build=missing -s "sen/*:build_type=${{ matrix.build_type }}"
 
       - name: Push conan packages
         if: ${{ inputs.push_artifacts }}
@@ -93,6 +101,7 @@ jobs:
         run: echo "Pushing package (fake entry)"
 
       - name: Remove unwanted parts from conan cache before backup
+        if: always()
         shell: bash
         run: |
           conan remove sen --confirm

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -1,0 +1,30 @@
+# === docs_check.yaml ==================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+
+name: Check the documentation
+
+# Publishing lives in build_docs.yaml, which needs write access to
+# gh-pages. This workflow stays read-only: it builds unreviewed
+# pull-request content.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build_docs:
+    name: "Build the documentation"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/build_documentation

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,19 +8,161 @@
 name: Orchestrator Workflow
 
 on:
+  # The default types do not fire when a draft is marked ready; converting
+  # back to draft lands in the same concurrency group and cancels the run.
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+  merge_group:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One run per branch and trigger kind; a new push cancels the running one.
+# event_name is in the key so the nightly cannot cancel a push to main.
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    name: "Detect docs-only changes"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        name: Classify changed paths
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # docs/ holds CMakeLists.txt files that every configure parses, so a
+          # build file never counts as documentation. --no-renames keeps a
+          # rename from hiding the path it moved away from. Without diff
+          # information both classifications fail open.
+          code=true
+          docs=true
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            changed=$(git diff --no-renames --name-only "$BASE_SHA"...HEAD)
+            build_files='(^|/)CMakeLists\.txt$|\.cmake$'
+            docs_files='^docs/|\.md$'
+            docs_inputs='^docs/|^examples/|^components/|^\.conan/|\.md$'
+            docs_inputs="$docs_inputs|^mkdocs\.yml$|^conanfile\.py$|^conan\.lock$|^LICENSE\.txt$"
+            docs_inputs="$docs_inputs|^\.github/actions/build_documentation/"
+            docs_inputs="$docs_inputs|^\.github/workflows/docs_check\.yaml$"
+            if [ -n "$changed" ] &&
+               ! echo "$changed" | grep -qvE "$docs_files" &&
+               ! echo "$changed" | grep -qE "$build_files"; then
+              code=false
+            fi
+            if [ -n "$changed" ] && ! echo "$changed" | grep -qE "$docs_inputs"; then
+              docs=false
+            fi
+          fi
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          echo "docs=$docs" >> "$GITHUB_OUTPUT"
+
+  # Not on a push: after the merge the hook range is empty, so every hook
+  # environment would install to check nothing.
   initial-pre-commit-checks:
+    if: github.event_name != 'push'
     uses: ./.github/workflows/pre-commit.yaml
 
+  python-checks:
+    name: "Python checks"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - name: Install pytest
+        shell: bash
+        run: pip install pytest==9.1.1 pyyaml==6.0.3
+      - name: Run repository script tests
+        shell: bash
+        run: python -m pytest .github/scripts/ -v
+
+  # Draft pull requests stop after the pre-commit checks; docs-only pull
+  # requests stop there regardless of draft state.
   standard-tests:
+    needs: detect-changes
+    if: >-
+      needs.detect-changes.outputs.code == 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     uses: ./.github/workflows/standard_test.yaml
     with:
       building-main: ${{ github.ref == 'refs/heads/main' }}
 
+  # Builds the documentation without publishing it. Pushes to main skip it:
+  # build_docs.yaml builds and publishes there anyway.
+  docs-build:
+    needs: detect-changes
+    if: >-
+      github.event_name != 'push' &&
+      needs.detect-changes.outputs.docs == 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    uses: ./.github/workflows/docs_check.yaml
+
+  # Packaging is the only check that builds Sen as a package and consumes it
+  # from outside, so a pull request runs the shipping configuration; running
+  # every configuration on every push flooded the queue. The full set runs
+  # post-merge, in the merge queue, nightly (see nightly.yaml) and on
+  # dispatch.
   conan-packaging:
+    needs: detect-changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+       needs.detect-changes.outputs.code == 'true')
     uses: ./.github/workflows/conan.yaml
-    needs: standard-tests
+    with:
+      pull_request_subset: ${{ github.event_name == 'pull_request' }}
+
+  # The only required check: every other job is skipped in some legitimate
+  # case, and a required check that never reports blocks the merge forever.
+  # test_main_yaml.py keeps the needs list complete.
+  #
+  # It has to decide explicitly, because GitHub reports a skipped job as a
+  # successful check: without the step below, cancelling a run would satisfy
+  # the check with nothing built.
+  #
+  # A draft is a different case and is deliberately not failed. Its run did
+  # what a draft run is meant to do, and GitHub does not allow a draft to be
+  # merged; reporting failure for work that was never meant to start would
+  # make the check mean "unfinished" as well as "broken".
+  ci-ok:
+    name: "CI OK"
+    if: ${{ always() }}
+    needs:
+      - detect-changes
+      - initial-pre-commit-checks
+      - python-checks
+      - standard-tests
+      - docs-build
+      - conan-packaging
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Fail unless the checks that had to run passed
+        if: >-
+          cancelled() ||
+          contains(needs.*.result, 'failure') ||
+          contains(needs.*.result, 'cancelled') ||
+          (github.event.pull_request.draft != true &&
+           needs.detect-changes.outputs.code == 'true' &&
+           needs.standard-tests.result == 'skipped')
+        shell: bash
+        run: |
+          echo 'Job results: ${{ toJSON(needs.*.result) }}'
+          exit 1

--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -21,6 +21,7 @@ jobs:
   compute-matrix-jobs:
     name: "Generate build matrix"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       jobs: ${{ steps.compute-jobs.outputs.jobs }}
     steps:
@@ -36,6 +37,9 @@ jobs:
     name: "Standard Test Job: ${{ matrix.compiler.name }}-${{ matrix.arch }}-${{ matrix.compiler.version }} C++${{ matrix.std }} [${{ matrix.build_type }}]"
     needs: compute-matrix-jobs
     runs-on: ${{ matrix.runner }}
+      # Generous on purpose: a cold cache builds every dependency from
+      # source. The cap ends a hang, it does not police duration.
+    timeout-minutes: 120
     strategy:
       fail-fast: true
       matrix:
@@ -48,27 +52,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Disable for now on local runner
-      #
-      # - name: Generate daily cache id
-      #   shell: bash
-      #   run: echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_ENV
+      - name: Generate daily cache id
+        shell: bash
+        run: echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_ENV"
 
-      # - name: Cache conan packages
-      #   uses: actions/cache@v5
-      #   if: always()
-      #   env:
-      #     cache-name: cache-conan-packages
-      #   with:
-      #     path: ~/.conan2/p
-      #     key: conanp-${{ matrix.os }}-${{ matrix.compiler.name }}-${{ matrix.build_type }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ env.cache_date }}
-      #     restore-keys: conanp-${{ matrix.os }}-${{ matrix.compiler.name }}-${{ matrix.build_type }}-${{ matrix.compiler.version }}-${{ matrix.std }}-
+      # Dependencies are always Release, so one slice serves the Debug and
+      # Release jobs of a compiler alike.
+      - name: Cache conan packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2/p
+          key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ env.cache_date }}
+          restore-keys: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-
 
       - uses: hendrikmuhs/ccache-action@v1.2
         if: runner.os == 'Linux'
         with:
-          key: ${{ matrix.os }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ matrix.build_type }}
-          max-size: 250M
+          key: ${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ matrix.build_type }}
+          max-size: 1G
           verbose: 1
 
       - name: Setup build context
@@ -80,24 +81,92 @@ jobs:
 
       - name: Install additional python dependencies
         shell: bash
-        run: pip install -U junitparser docker testcontainers
+        run: pip install junitparser==5.0.1
 
       - name: Compile base libraries
         shell: bash
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-          # export ENABLE_EXAMPLES=true
+          export ENABLE_EXAMPLES=${{ matrix.enable_examples }}
           export ENABLE_TESTS=true
           export ENABLE_COVERAGE=${{ matrix.enable_coverage }}
 
-          conan install . -s:a build_type=${{ matrix.build_type }} --build=missing
-          conan build . -s:a build_type=${{ matrix.build_type }}
+          # & applies build_type to the sen package only; dependencies stay at
+          # the profiles' Release default, which is what binary remotes serve.
+          conan install . -s "&:build_type=${{ matrix.build_type }}" \
+            -s "&:compiler.cppstd=${{ matrix.std }}" --build=missing
+          conan build . -s "&:build_type=${{ matrix.build_type }}" \
+            -s "&:compiler.cppstd=${{ matrix.std }}"
 
       - name: Run tests
+        if: ${{ !matrix.enable_coverage }}
         shell: bash
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           cmake --build build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/ --target run_tests
+
+      # The report target runs the suite itself, so this replaces the step above
+      # rather than following it. Without it the leg pays for instrumentation
+      # and produces no report.
+      - name: Run tests and report coverage
+        if: matrix.enable_coverage
+        shell: bash
+        run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          cmake --build build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/ \
+            --target generate-coverage-report
+
+      - name: Publish the coverage report
+        if: matrix.enable_coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          if-no-files-found: error
+          path: build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/coverage_reports/
+
+      # The floor is a few points below what the suite measured on
+      # 2026-08-18 (66.74% of lines), so ordinary movement does not fail a
+      # pull request while a real drop does. Raise it when coverage rises.
+      - name: Show the coverage total and hold the floor
+        if: matrix.enable_coverage
+        shell: bash
+        env:
+          MINIMUM_LINE_COVERAGE: "63"
+        run: |
+          summary="build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/coverage_reports/coverage.txt"
+          {
+            echo "### Coverage"
+            echo '```'
+            tail -2 "$summary"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # llvm-cov's TOTAL row: regions, then functions, then lines, then
+          # branches, each as count, missed and percentage.
+          lines=$(awk '$1 == "TOTAL" { gsub("%", "", $10); print $10 }' "$summary")
+          case "$lines" in
+            "" | *[!0-9.]*)
+              echo "Could not read the line coverage from $summary; the report format changed."
+              exit 1
+              ;;
+          esac
+          echo "line coverage: $lines% (floor $MINIMUM_LINE_COVERAGE%)"
+          # Compared as whole percent, so no locale can reinterpret the
+          # decimal separator; dropping the fraction only makes it stricter.
+          if [ "${lines%%.*}" -lt "$MINIMUM_LINE_COVERAGE" ]; then
+              echo "line coverage $lines% is below the $MINIMUM_LINE_COVERAGE% floor"
+              exit 1
+          fi
+
+      # The release workflow attaches this archive and the installer unpacks
+      # it, so its layout is a contract. Building it here keeps a dropped
+      # install rule from surfacing only at release time.
+      - name: Build and check the package archive
+        if: matrix.check_package
+        shell: bash
+        run: |
+          cmake --build build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/ --target package
+          python .github/scripts/check_package_archive.py build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/
 
       # TODO(SEN-1726): Connect App to Airbus Org.
       # - name: Upload coverage to Codecov
@@ -108,6 +177,7 @@ jobs:
       #     token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Remove unwanted parts from conan cache before backup
+        if: always()
         shell: bash
         run: |
           conan cache clean "*" -s -b -d

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,5 +52,14 @@ repos:
       args: [--fix]
     - id: ruff-format
 
+# Scoped to the CI scripts: repo-wide mypy is blocked by duplicate test
+# module names under apps/cli_gen; widen the scope when that is resolved.
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v2.3.1
+  hooks:
+    - id: mypy
+      files: ^\.github/scripts/
+      additional_dependencies: [types-PyYAML==6.0.12.20260815]
+
 # Global Configuration
 exclude: (examples/packages/hla_fom/.*|test/util/dummy_entities/hla/.*|.*.svg|.*.excalidraw|stl.tmLanguage.json)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,32 @@
+# Authors
+
+Sen is developed at Airbus; the copyright headers name the legal owner.
+This file credits the people behind the code.
+
+## Original author
+
+Sen was created and designed by:
+
+- Enrique Parodi Spalazzi
+
+## Core team
+
+Sen is evolved and maintained by:
+
+- Enrique Parodi Spalazzi
+- Luis Gutierrez Pereda
+- Manuel Goesswein
+- Gema Aparicio Cantalapiedra
+
+Past core team:
+
+- Florian Sattler
+
+## Contributors
+
+- Luis Ramirez Gonzalez (project management and sponsorship)
+- Francisco Javier Velacoracho Uriel
+- Aridane Sarrionandia
+- Tania Guillot Colls
+
+The authoritative record is the git history (`git shortlog -sne`).

--- a/cmake/util/coverage.cmake
+++ b/cmake/util/coverage.cmake
@@ -57,23 +57,28 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   )
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   get_filename_component(COMPILER_DIRECTORY ${CMAKE_CXX_COMPILER} DIRECTORY)
+  string(
+    REGEX MATCH
+          "[0-9]+"
+          _llvm_major
+          "${CMAKE_CXX_COMPILER_VERSION}"
+  )
   find_program(
     LLVM_PROFDATA_PATH
-    llvm-profdata
-    ${COMPILER_DIRECTORY}
-    NO_DEFAULT_PATH
+    NAMES llvm-profdata "llvm-profdata-${_llvm_major}"
+    HINTS ${COMPILER_DIRECTORY} "/usr/lib/llvm-${_llvm_major}/bin"
   )
   find_program(
     LLVM_COV_PATH
-    llvm-cov
-    ${COMPILER_DIRECTORY}
-    NO_DEFAULT_PATH
+    NAMES llvm-cov "llvm-cov-${_llvm_major}"
+    HINTS ${COMPILER_DIRECTORY} "/usr/lib/llvm-${_llvm_major}/bin"
   )
   find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
   if(NOT LLVM_PROFDATA_PATH OR NOT LLVM_COV_PATH)
-    message(WARNING "Could not find llvm-profdata or llvm-cov, skipping coverage generation.")
-    return()
+    message(FATAL_ERROR "Coverage was enabled but llvm-profdata or llvm-cov could not be found. "
+                        "Install llvm-${_llvm_major}, or configure without SEN_COVERAGE_ENABLE."
+    )
   endif()
 
   set(SEN_COVERAGE_TARGETS

--- a/cmake/util/sen_utils.cmake
+++ b/cmake/util/sen_utils.cmake
@@ -43,7 +43,7 @@ if(NOT SEN_DISABLE_CLANG_TIDY)
   find_program(clang_tidy_cache_path NAMES "cltcache")
 
   if(clang_tidy_cache_path)
-    find_program(_clang_tidy_path NAMES "clang-tidy" "clang-tidy-20")
+    find_program(_clang_tidy_path NAMES "clang-tidy-20" "clang-tidy" REQUIRED)
 
     set(clang_tidy_path
         "${clang_tidy_cache_path};${_clang_tidy_path}"
@@ -51,7 +51,11 @@ if(NOT SEN_DISABLE_CLANG_TIDY)
     )
     message(NOTICE "-- Using cltcache to speedup builds")
   else()
-    find_program(clang_tidy_path NAMES "clang-tidy" "clang-tidy-20")
+    # Versioned name first: an older clang-tidy from the system would otherwise
+    # win and analyse with different checks. REQUIRED because analysis was asked
+    # for; without it a missing tool leaves the lane green having analysed
+    # nothing.
+    find_program(clang_tidy_path NAMES "clang-tidy-20" "clang-tidy" REQUIRED)
   endif()
   message(STATUS "Clang-tidy enabled")
 else()

--- a/cmake/util/test.cmake
+++ b/cmake/util/test.cmake
@@ -21,7 +21,7 @@ set(CMAKE_COMMON_CTEST_ARGUMENTS
     "20"
     ${CMAKE_COMMON_CTEST_ARGUMENTS}
 )
-if(${CTEST_RANDOMIZE_TESTS})
+if(${SEN_CTEST_RANDOMIZE_TESTS})
   list(APPEND CMAKE_COMMON_CTEST_ARGUMENTS "--schedule-random")
 endif()
 
@@ -31,18 +31,24 @@ else()
   set(CTEST_PARALLEL_ARGS "--parallel" 0)
 endif()
 
+# An empty main selection is a mistake, not a pass: without --no-tests=error a
+# dropped suite or a filter typo leaves ctest reporting success over zero tests.
 set(CMAKE_CTEST_ARGUMENTS
     ${CTEST_PARALLEL_ARGS}
     "--output-junit"
     "ctestParallelReport.xml"
+    "--no-tests=error"
     ${CMAKE_COMMON_CTEST_ARGUMENTS}
 )
 
+# The flaky pass may legitimately select nothing: a build configuration is
+# allowed to carry no flaky tests at all.
 set(CMAKE_FLAKY_CTEST_ARGUMENTS
     "--repeat"
     "until-pass:5"
     "--output-junit"
     "ctestFlakyReport.xml"
+    "--no-tests=ignore"
     ${CMAKE_COMMON_CTEST_ARGUMENTS}
 )
 
@@ -68,7 +74,7 @@ add_custom_command(
   POST_BUILD TARGET run_unit_tests
   COMMAND ${CMAKE_CTEST_COMMAND} ${CMAKE_CTEST_ARGUMENTS} -L "unit" -LE "flaky"
   VERBATIM
-  COMMAND ${CMAKE_CTEST_COMMAND} ${CMAKE_FLAKY_CTEST_ARGUMENTS} -L "unit" "flaky"
+  COMMAND ${CMAKE_CTEST_COMMAND} ${CMAKE_FLAKY_CTEST_ARGUMENTS} -L "unit" -L "flaky"
   VERBATIM USES_TERMINAL
 )
 
@@ -116,6 +122,16 @@ function(add_sen_unit_test_suite test_name)
 
   add_executable(${test_name} ${_arg_UNPARSED_ARGUMENTS})
 
+  # Tests must see the same char signedness as the code under test: the
+  # production flags force -fsigned-char (sen_misc_utils.cmake). A test built
+  # with the platform default poisons shared inline definitions on platforms
+  # where char is unsigned by default (arm): in Debug nothing is inlined, one
+  # copy is picked for the whole process, and values like
+  # numeric_limits<char>::max() become wrong in the other translation units.
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(${test_name} PRIVATE -fsigned-char)
+  endif()
+
   target_link_libraries(${test_name} PRIVATE GTest::gmock_main ${_arg_LINK_DEPS})
 
   if(TARGET sen_coverage_flags)
@@ -124,7 +140,7 @@ function(add_sen_unit_test_suite test_name)
 
   set(labels "unit")
   if(${_arg_FLAKY})
-    list(APPEND labels "LABELS;flaky")
+    list(APPEND labels "flaky")
   endif()
 
   set(environment "")
@@ -143,9 +159,9 @@ function(add_sen_unit_test_suite test_name)
   gtest_discover_tests(
     ${test_name} DISCOVERY_MODE PRE_TEST
     PROPERTIES LABELS
-               ${labels}
+               "${labels}"
                ENVIRONMENT
-               ${environment}
+               "${environment}"
   )
 
   add_dependencies(run_unit_tests ${test_name})
@@ -176,9 +192,9 @@ function(add_sen_integration_test test_name)
 
   set(labels "integration")
   if(${_arg_FLAKY})
-    list(APPEND labels "LABELS;flaky")
+    list(APPEND labels "flaky")
   endif()
-  set_tests_properties(${test_name} PROPERTIES LABELS ${labels})
+  set_tests_properties(${test_name} PROPERTIES LABELS "${labels}")
 
   # disable log buffering in integration tests that use python
   append_test_env_modification(${test_name} "PYTHONUNBUFFERED=set:1")
@@ -281,9 +297,9 @@ function(add_sen_run_smoke_test test_name)
 
   set(labels "smoke")
   if(${_arg_FLAKY})
-    list(APPEND labels "LABELS;flaky")
+    list(APPEND labels "flaky")
   endif()
-  set_tests_properties(${test_name} PROPERTIES LABELS ${labels})
+  set_tests_properties(${test_name} PROPERTIES LABELS "${labels}")
 
   if(_arg_WILL_FAIL)
     set_tests_properties(${test_name} PROPERTIES WILL_FAIL TRUE)
@@ -338,9 +354,9 @@ function(add_sen_smoke_test test_name)
 
   set(labels "smoke")
   if(${_arg_FLAKY})
-    list(APPEND labels "LABELS;flaky")
+    list(APPEND labels "flaky")
   endif()
-  set_tests_properties(${_arg_NAME} PROPERTIES LABELS ${labels})
+  set_tests_properties(${test_name} PROPERTIES LABELS "${labels}")
 
   add_dependencies(run_smoke_tests ${_arg_REQ_DEPS})
   add_dependencies(run_tests ${_arg_REQ_DEPS})


### PR DESCRIPTION
This PR moves the pipeline onto GitHub's runners and reorganises what runs when.

- For documentation-only and draft PRs, we only run cheap checks. Everything else runs four builds (GCC debug and release, Clang debug with coverage, and ARM), each compiling Sen and the examples and running the full test suite.

- We now test the packaging and compile a small consumer against it, and release archives are also built and their contents inspected.

- Documentation is published only from main and from version tags. Each release keeps its own copy. The site's front page opens the newest release.

- Caching of conan packages and compiled objects is switched back on.

This PR also fixes some build errors on ARM platforms.
