### PR TITLE
ci: add nightly lanes, image validation and the benchmark structure

### DIFF
--- a/.github/actions/prepare_build/action.yaml
+++ b/.github/actions/prepare_build/action.yaml
@@ -1,0 +1,64 @@
+# === action.yaml ======================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+#
+# Everything a lane needs between checking out and building: the conan package
+# cache and the toolchain. The nightly lanes each run as their own job, so
+# without this the same four steps would be written once per lane and the cache
+# keys would drift apart.
+#
+# Checkout stays with the caller: a local action cannot be resolved before the
+# repository is on disk.
+
+name: Prepare a build
+description: Restores the conan package cache and installs the toolchain for one lane.
+
+inputs:
+  compiler-name:
+    description: gcc or clang
+    required: true
+  compiler-version:
+    description: Major version of the compiler
+    required: true
+  runner-label:
+    description: Runner label, which the cache key is built from (for example ubuntu-24.04)
+    required: true
+  arch:
+    description: x86 or arm
+    required: false
+    default: x86
+  std:
+    description: C++ standard the cache slice belongs to
+    required: false
+    default: "17"
+
+runs:
+  using: composite
+  steps:
+    # A daily key: dependencies are rebuilt at most once a day, and a restore
+    # key still finds yesterday's entry.
+    - name: Generate daily cache id
+      id: cache-id
+      shell: bash
+      run: echo "date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_OUTPUT"
+
+    # The key scheme matches standard_test.yaml, so a lane restores what the
+    # day's builds already populated. No ccache anywhere in the nightly lanes:
+    # sanitized and instrumented objects must not mix into the slices that the
+    # pull-request builds keep, and each lane compiles every file once anyway.
+    - name: Cache conan packages
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: ~/.conan2/p
+        key: conanp-${{ inputs.runner-label }}-${{ inputs.compiler-name }}-${{ inputs.compiler-version }}-${{ inputs.std }}-${{ steps.cache-id.outputs.date }}
+        restore-keys: conanp-${{ inputs.runner-label }}-${{ inputs.compiler-name }}-${{ inputs.compiler-version }}-${{ inputs.std }}-
+
+    - name: Setup build context
+      uses: ./.github/actions/setup_build_context
+      with:
+        compiler-name: ${{ inputs.compiler-name }}
+        compiler-version: ${{ inputs.compiler-version }}
+        arch: ${{ inputs.arch }}

--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -1,0 +1,108 @@
+# === ci-image.yaml ====================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+
+name: CI Image
+
+# main.yaml calls this when a change touches the build environment, so that a
+# broken image fails the one check the branch protection requires. Cancellation
+# and grouping belong to the caller.
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: "Build and check the image"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      # Proves the Dockerfile builds; no registry hosts the image, so the
+      # devcontainer and any self-hosted machine build it from this file.
+      # Layer caching in the Actions cache keeps unchanged rebuilds fast; only
+      # the final layers are cached, since nothing here builds on this image.
+      - name: Build image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: tools/ci
+          file: tools/ci/Dockerfile
+          # The Dockerfile's last stage is the editor-facing one; this is the
+          # image the pipeline is described against.
+          target: base
+          push: false
+          load: true
+          tags: sen-ci:probe
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+
+      # Every tool below has been missing at some point, and a missing tool
+      # shows up as a check that silently analysed nothing or a configure step
+      # that fails on a developer's machine only.
+      - name: Check the tools are present
+        shell: bash
+        run: |
+          docker run --rm sen-ci:probe bash -lc '
+            set -e
+            for tool in conan python3 pip3 ccache git g++-12 gcc-12 \
+                        clang++-20 clang-tidy-20 gcovr lcov genhtml \
+                        pytest junitparser; do
+                command -v "$tool" > /dev/null || { echo "missing: $tool"; exit 1; }
+            done
+            # The coverage report target calls these by their versioned names
+            # or through the LLVM directory, never from PATH.
+            for tool in llvm-profdata llvm-cov; do
+                test -x "/usr/lib/llvm-20/bin/$tool" || { echo "missing: $tool"; exit 1; }
+            done
+            # Coverage and the sanitizers need the clang runtime library, which
+            # --no-install-recommends leaves out unless it is asked for.
+            printf "int main(){return 0;}" > /tmp/probe.cpp
+            clang++-20 -fsanitize=address -o /tmp/probe /tmp/probe.cpp
+            # cmake and ninja must come from Conan, so that every build uses
+            # the pinned versions; finding them here would defeat that.
+            for tool in cmake ninja; do
+                ! command -v "$tool" > /dev/null || { echo "unexpected: $tool"; exit 1; }
+            done
+            test "$(id -un)" = sen || { echo "image runs as $(id -un)"; exit 1; }
+            echo "all expected tools present"
+          '
+
+      # The devcontainer builds this stage, and an editor cannot detect a
+      # toolchain without these three.
+      - name: Build the editor-facing stage
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: tools/ci
+          file: tools/ci/Dockerfile
+          target: dev
+          push: false
+          load: true
+          tags: sen-ci:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+
+      - name: Check the editor tools are present
+        shell: bash
+        run: |
+          docker run --rm sen-ci:dev bash -lc '
+            set -e
+            for tool in cmake ninja gdb dot; do
+                command -v "$tool" > /dev/null || { echo "missing: $tool"; exit 1; }
+            done
+            # Conan writes CMakeUserPresets.json at version 4, which needs at
+            # least cmake 3.23; the distribution ships 3.22.
+            cmake --version | head -1
+            printf "%s\n" "$(cmake --version | head -1 | grep -oE "[0-9]+\.[0-9]+")" |
+                awk -F. "{ exit (\$1 > 3 || (\$1 == 3 && \$2 >= 23)) ? 0 : 1 }"
+            test "$(id -un)" = sen || { echo "image runs as $(id -un)"; exit 1; }
+            echo "editor tools present"
+          '

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,6 +34,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
+      image: ${{ steps.filter.outputs.image }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -51,6 +52,7 @@ jobs:
           # information both classifications fail open.
           code=true
           docs=true
+          image=true
           if [ "$EVENT_NAME" = "pull_request" ]; then
             changed=$(git diff --no-renames --name-only "$BASE_SHA"...HEAD)
             build_files='(^|/)CMakeLists\.txt$|\.cmake$'
@@ -59,6 +61,7 @@ jobs:
             docs_inputs="$docs_inputs|^mkdocs\.yml$|^conanfile\.py$|^conan\.lock$|^LICENSE\.txt$"
             docs_inputs="$docs_inputs|^\.github/actions/build_documentation/"
             docs_inputs="$docs_inputs|^\.github/workflows/docs_check\.yaml$"
+            image_files='^tools/ci/|^\.github/workflows/ci-image\.yaml$'
             if [ -n "$changed" ] &&
                ! echo "$changed" | grep -qvE "$docs_files" &&
                ! echo "$changed" | grep -qE "$build_files"; then
@@ -67,9 +70,20 @@ jobs:
             if [ -n "$changed" ] && ! echo "$changed" | grep -qE "$docs_inputs"; then
               docs=false
             fi
+            if [ -n "$changed" ] && ! echo "$changed" | grep -qE "$image_files"; then
+              image=false
+            fi
+            # A documentation-only change cannot affect the image: the
+            # Dockerfile copies nothing out of the repository.
+            if [ "$code" = false ]; then
+              image=false
+            fi
           fi
-          echo "code=$code" >> "$GITHUB_OUTPUT"
-          echo "docs=$docs" >> "$GITHUB_OUTPUT"
+          {
+            echo "code=$code"
+            echo "docs=$docs"
+            echo "image=$image"
+          } >> "$GITHUB_OUTPUT"
 
   # Not on a push: after the merge the hook range is empty, so every hook
   # environment would install to check nothing.
@@ -131,6 +145,16 @@ jobs:
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     uses: ./.github/workflows/docs_check.yaml
 
+  # A change to the build environment has to prove the image still builds and
+  # still holds the tools it promises. ci-ok needs this job, so a broken image
+  # blocks the merge rather than showing up as a red mark beside it.
+  image-check:
+    needs: detect-changes
+    if: >-
+      needs.detect-changes.outputs.image == 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    uses: ./.github/workflows/ci-image.yaml
+
   # Packaging is the only check that builds Sen as a package and consumes it
   # from outside, so a pull request runs the shipping configuration; running
   # every configuration on every push flooded the queue. The full set runs
@@ -168,6 +192,7 @@ jobs:
       - conan-lock-check
       - standard-tests
       - docs-build
+      - image-check
       - conan-packaging
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,436 @@
+# === nightly.yaml =====================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+#
+# Lanes that are too slow for the pull-request path. A failing lane files or
+# refreshes the tracking issue instead of failing silently overnight.
+#
+# Each lane checks out, calls .github/actions/prepare_build for the cache and
+# the toolchain, and then does its own work.
+#
+# The timeouts are generous on purpose: a cold cache builds every dependency
+# from source. They exist to cap a hang, not to police duration.
+
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sanitizers:
+    name: "${{ matrix.lane }}"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 150
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane: "TSan"
+            sanitizer: thread
+          - lane: "ASan+UBSan"
+            sanitizer: address
+    env:
+      CC: clang-20
+      CXX: clang++-20
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare the build
+        uses: ./.github/actions/prepare_build
+        with:
+          compiler-name: clang
+          compiler-version: 20
+          runner-label: ubuntu-24.04
+
+      - name: Install additional python dependencies
+        shell: bash
+        run: pip install junitparser==5.0.1
+
+      # Debug also compiles the SEN_DEBUG_ASSERT invariant checks, which
+      # RelWithDebInfo builds leave out.
+      - name: Build with ${{ matrix.lane }}
+        shell: bash
+        run: |
+          conan install . -s "&:build_type=Debug" --build=missing \
+            -o "sen/*:with_tests=True" \
+            -o "sen/*:sanitizer=${{ matrix.sanitizer }}"
+          # conan build regenerates the toolchain, so it needs the same options.
+          conan build . -s "&:build_type=Debug" \
+            -o "sen/*:with_tests=True" \
+            -o "sen/*:sanitizer=${{ matrix.sanitizer }}"
+
+      - name: Run tests
+        shell: bash
+        run: cmake --build build/clang/Debug/ --target run_tests
+
+  clang-tidy:
+    name: "clang-tidy full tree"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 150
+    env:
+      CC: clang-20
+      CXX: clang++-20
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare the build
+        uses: ./.github/actions/prepare_build
+        with:
+          compiler-name: clang
+          compiler-version: 20
+          runner-label: ubuntu-24.04
+
+      # SEN_DISABLE_CLANG_TIDY=OFF attaches clang-tidy to every target
+      # (CXX_CLANG_TIDY), so the full tree is checked as it compiles.
+      - name: Build with clang-tidy
+        shell: bash
+        run: |
+          conan install . -s "&:build_type=Release" --build=missing \
+            -o "sen/*:with_tests=True" -o "sen/*:with_clang_tidy=True"
+          conan build . -s "&:build_type=Release" \
+            -o "sen/*:with_tests=True" -o "sen/*:with_clang_tidy=True"
+
+  flake-hunt:
+    name: "Unit test repeat loop"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    env:
+      CC: gcc-12
+      CXX: g++-12
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare the build
+        uses: ./.github/actions/prepare_build
+        with:
+          compiler-name: gcc
+          compiler-version: 12
+          runner-label: ubuntu-22.04
+
+      - name: Install additional python dependencies
+        shell: bash
+        run: pip install junitparser==5.0.1
+
+      - name: Build
+        shell: bash
+        run: |
+          conan install . -s "&:build_type=Release" --build=missing -o "sen/*:with_tests=True"
+          conan build . -s "&:build_type=Release" -o "sen/*:with_tests=True"
+
+      # An intermittent test is a defect: this loop exists to catch it, not
+      # to retry it away.
+      - name: Repeat the unit suite until a failure
+        shell: bash
+        run: |
+          ctest --test-dir build/gcc/Release --parallel "$(nproc)" \
+              -L unit -LE flaky --repeat until-fail:5 --output-on-failure
+
+      - name: Archive test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: flake-hunt-logs
+          path: build/gcc/Release/Testing/
+
+  benchmarks:
+    name: "Benchmarks"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CC: gcc-12
+      CXX: g++-12
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare the build
+        uses: ./.github/actions/prepare_build
+        with:
+          compiler-name: gcc
+          compiler-version: 12
+          runner-label: ubuntu-22.04
+
+      - name: Build benchmarks
+        shell: bash
+        run: |
+          conan install . -s "&:build_type=Release" --build=missing
+          conan build . -s "&:build_type=Release"
+
+      - name: Run benchmarks
+        shell: bash
+        run: cmake --build build/gcc/Release/ --target run_benchmarks
+
+      # Result history lives in these artifacts until a baseline comparison
+      # exists to fail on.
+      - name: Archive benchmark results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: benchmark-results
+          # An empty archive would mean the benchmarks never ran, which is the
+          # kind of quiet nothing this pipeline is not supposed to allow.
+          if-no-files-found: error
+          path: build/gcc/Release/**/*_benchmark*.json
+
+  # Catches documentation breakage from paths the pull-request gate does not
+  # watch, for example doxygen comments in headers.
+  docs-build:
+    uses: ./.github/workflows/docs_check.yaml
+
+  # Every packaged configuration, which a pull request does not run: it builds
+  # only the configuration that ships.
+  packaging:
+    uses: ./.github/workflows/conan.yaml
+
+  # Sen promises consumers "at least C++17", and they compile its headers in
+  # their own dialect. Building Sen itself at C++20 compiles those headers the
+  # way a C++20 consumer would; the dependencies keep their own standard, so
+  # this costs one build and no dependency rebuild.
+  cppstd-20:
+    name: "Public headers under C++20"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    env:
+      CC: gcc-12
+      CXX: g++-12
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare the build
+        uses: ./.github/actions/prepare_build
+        with:
+          compiler-name: gcc
+          compiler-version: 12
+          runner-label: ubuntu-22.04
+
+      - name: Build the package and its consumer with C++20 headers
+        shell: bash
+        run: |
+          conan create . --user airbus --channel dev \
+              --test-folder .conan/test_packages/package \
+              --build=missing -s "sen/*:compiler.cppstd=20"
+
+  # Pull requests build with gcc-12, the oldest compiler the project supports.
+  # A newer release rejects code the older one accepts and warns about more, so
+  # the whole tree, examples and tests included, is compiled once a day with the
+  # newest gcc available on a runner.
+  #
+  # The same lane then checks the promise the project makes to consumers: they
+  # get "at least C++17" and compile these headers in their own dialect. The
+  # package is created the way it is released, at C++17, and the small consumer
+  # under .conan/test_packages is then compiled against it once per newer
+  # standard. Only the consumer's standard changes, so nothing is rebuilt.
+  newest-compiler:
+    name: "Newest gcc and newer consumer standards"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 150
+    env:
+      CC: gcc-14
+      CXX: g++-14
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare the build
+        uses: ./.github/actions/prepare_build
+        with:
+          compiler-name: gcc
+          compiler-version: 14
+          runner-label: ubuntu-24.04
+
+      - name: Build the whole tree with the newest gcc
+        shell: bash
+        run: |
+          conan create . --user airbus --channel dev \
+              --test-folder .conan/test_packages/package \
+              --build=missing -s "sen/*:compiler.cppstd=17" \
+              -o "sen/*:with_tests=True" -o "sen/*:with_examples=True"
+
+      - name: Compile the consumer under newer standards
+        shell: bash
+        run: |
+          version=$(conan inspect . --format=json |
+              python3 -c 'import json, sys; print(json.load(sys.stdin)["version"])')
+          for std in 20 23; do
+              echo "::group::consumer at C++$std"
+              # & is the consumer here, so sen and its dependencies keep the
+              # settings they were built with.
+              conan test .conan/test_packages/package "sen/$version@airbus/dev" \
+                  -s "&:compiler.cppstd=$std"
+              echo "::endgroup::"
+          done
+
+  # The pull-request pipeline measures coverage but keeps the report as a run
+  # artifact, which nobody looks at. The clang leg does not run on main, so
+  # measuring here once a day is what gives the report a stable home.
+  coverage:
+    name: "Coverage report"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 150
+    env:
+      CC: clang-20
+      CXX: clang++-20
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare the build
+        uses: ./.github/actions/prepare_build
+        with:
+          compiler-name: clang
+          compiler-version: 20
+          runner-label: ubuntu-24.04
+
+      - name: Install additional python dependencies
+        shell: bash
+        run: pip install junitparser==5.0.1
+
+      # The report target runs the suite as it measures it.
+      - name: Build and measure
+        shell: bash
+        run: |
+          conan install . -s "&:build_type=Debug" -s "&:compiler.cppstd=17" --build=missing \
+            -o "sen/*:with_tests=True" -o "sen/*:with_coverage=True"
+          conan build . -s "&:build_type=Debug" -s "&:compiler.cppstd=17" \
+            -o "sen/*:with_tests=True" -o "sen/*:with_coverage=True"
+          cmake --build build/clang/Debug/ --target generate-coverage-report
+
+      - name: Publish the coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: coverage-report
+          if-no-files-found: error
+          path: build/clang/Debug/coverage_reports/
+
+  # Kept apart from the job above so that the build never holds a token that
+  # can write to the repository.
+  publish-coverage:
+    name: "Publish the report to the documentation site"
+    needs: coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    # build_docs.yaml uses this group as well, so a deploy queues behind
+    # another instead of racing it; the loser of a race is rejected.
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Check the documentation site exists
+        id: site
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh api "repos/${{ github.repository }}/branches/gh-pages" > /dev/null 2>&1; then
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::The documentation has never been published, so there is no site to publish the report into."
+          fi
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        if: steps.site.outputs.exists == 'true'
+        with:
+          ref: gh-pages
+          fetch-depth: 1
+
+      # Downloaded outside the checkout, so that replaying the change on top
+      # of a documentation deploy does not need the report to survive a reset.
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        if: steps.site.outputs.exists == 'true'
+        with:
+          name: coverage-report
+          path: ${{ runner.temp }}/incoming
+
+      # mike owns the versioned directories; this one sits beside them and it
+      # is served at <site>/coverage/.
+      - name: Replace the published report
+        if: steps.site.outputs.exists == 'true'
+        shell: bash
+        env:
+          REPORT: ${{ runner.temp }}/incoming
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+          # A documentation deploy can land between the checkout and the push.
+          # Losing that race is normal, so take the site as it now stands and
+          # put the report back on top rather than merging histories: this
+          # branch is a published directory, not a line of development.
+          for attempt in 1 2 3; do
+              rm -rf coverage
+              mkdir coverage
+              cp -R "$REPORT"/. coverage/
+
+              git add --all coverage
+              if git diff --cached --quiet; then
+                  echo "the report has not changed"
+                  exit 0
+              fi
+              git commit --quiet --message "docs: refresh the coverage report"
+
+              if git push origin HEAD:gh-pages; then
+                  exit 0
+              fi
+              echo "gh-pages moved on, replaying the report (attempt $attempt)"
+              git fetch --depth 1 origin gh-pages
+              git reset --hard FETCH_HEAD
+          done
+          exit 1
+
+  report:
+    name: "File or refresh the tracking issue"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      [
+        sanitizers,
+        clang-tidy,
+        flake-hunt,
+        benchmarks,
+        docs-build,
+        packaging,
+        cppstd-20,
+        newest-compiler,
+        coverage,
+        publish-coverage,
+      ]
+    # A lane that was cancelled or hit its timeout never reaches failure().
+    if: failure() || cancelled()
+    permissions:
+      issues: write
+    steps:
+      - name: Update the nightly tracking issue
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Nightly lane failure"
+          body="Failed run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          number=$(gh issue list --repo "${{ github.repository }}" --state open \
+              --search "in:title \"$title\"" --json number --jq '.[0].number')
+          if [ -n "$number" ]; then
+              gh issue comment "$number" --repo "${{ github.repository }}" --body "$body"
+          else
+              gh issue create --repo "${{ github.repository }}" --title "$title" --body "$body"
+          fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # build options
 option(SEN_BUILD_EXAMPLES "Build examples" ON)
 option(SEN_BUILD_TESTS "Build tests" ON)
+option(SEN_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(SEN_BUILD_DOCS "Build documentation" ON)
 option(SEN_DISABLE_CLANG_TIDY "Disable clang-tidy" ON)
 option(SEN_COVERAGE_ENABLE "Enable coverage generation" OFF)
@@ -49,6 +50,7 @@ project(
 include(util/sen_internal_utils)
 include(util/sanitizers)
 include(util/test)
+include(util/benchmark)
 
 # libs
 add_subdirectory(libs/core)

--- a/cmake/util/benchmark.cmake
+++ b/cmake/util/benchmark.cmake
@@ -1,0 +1,58 @@
+# === benchmark.cmake ==================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+
+# Benchmark initialization code. Benchmarks come with the full mode, which sets
+# SEN_BUILD_BENCHMARKS, and live in a benchmark/ directory next to a library's test/
+# directory. Configure with -DSEN_BUILD_BENCHMARKS=OFF to leave them out entirely.
+
+if(SEN_BUILD_BENCHMARKS)
+  find_package(benchmark REQUIRED)
+endif()
+
+add_custom_target(run_benchmarks)
+
+# add_sen_benchmark(
+#   <name> <sources>...
+#   [LINK_DEPS <deps>...]
+# )
+#
+# Registers a google-benchmark executable and hooks it into the
+# run_benchmarks target. Each run writes <name>.json next to the binary so
+# results can be archived and compared across runs.
+function(add_sen_benchmark benchmark_name)
+  if(NOT SEN_BUILD_BENCHMARKS)
+    return()
+  endif()
+
+  set(_options)
+  set(_one_value_args)
+  set(_multi_value_args LINK_DEPS)
+
+  cmake_parse_arguments(
+    _arg
+    "${_options}"
+    "${_one_value_args}"
+    "${_multi_value_args}"
+    ${ARGN}
+  )
+
+  # Left out of the default target: run_benchmarks is what builds them, so a full
+  # build does not pay for benchmarks nobody is going to run.
+  add_executable(${benchmark_name} EXCLUDE_FROM_ALL ${_arg_UNPARSED_ARGUMENTS})
+  target_link_libraries(${benchmark_name} PRIVATE benchmark::benchmark_main ${_arg_LINK_DEPS})
+
+  # The runner is a per-benchmark target: commands can only attach to targets
+  # created in the same directory, and run_benchmarks lives at the top level.
+  add_custom_target(
+    run_${benchmark_name}
+    COMMAND ${benchmark_name} "--benchmark_out=$<TARGET_FILE:${benchmark_name}>.json"
+            "--benchmark_out_format=json"
+    VERBATIM USES_TERMINAL
+  )
+  add_dependencies(run_${benchmark_name} ${benchmark_name})
+  add_dependencies(run_benchmarks run_${benchmark_name})
+endfunction()

--- a/conan.lock
+++ b/conan.lock
@@ -25,6 +25,7 @@
         "concurrentqueue/1.0.4#1e48e1c712bcfd892087c9c622a51502%1687274728.048",
         "cli11/2.3.2#2df6d985bb950b2babffcc4daca1e9ff%1730283383.142",
         "c4core/0.1.11#f4ab4857c7ade25213739379104e6717%1718607621.941",
+        "benchmark/1.9.5#b885dc73ad67b40a55d45684d1c88ad1%1774363287.434",
         "asio/1.36.0#75a50dae6e50af10cfb2150286b7df39%1756280309.023"
     ],
     "build_requires": [

--- a/conanfile.py
+++ b/conanfile.py
@@ -77,6 +77,9 @@ class SenConan(ConanFile):
         self.tool_requires("cmake/3.28.1")
         self.tool_requires("ninja/1.13.2")
         self.test_requires("gtest/1.17.0")
+        # Benchmarks belong to the full build, so the dependency is fetched only there.
+        if str(self.options.mode) == "full":
+            self.test_requires("benchmark/1.9.5")
         if self.options.with_docs:
             self.tool_requires("doxygen/[>=1.15.0]")
 
@@ -194,6 +197,9 @@ class SenConan(ConanFile):
         tc.cache_variables["SEN_BUILD_EXAMPLES"] = "ON" if self.options.with_examples else "OFF"
         tc.cache_variables["SEN_BUILD_TESTS"] = "ON" if self.options.with_tests else "OFF"
         tc.cache_variables["SEN_BUILD_DOCS"] = "ON" if self.options.with_docs else "OFF"
+        # Available in the full build, built only when asked for: the benchmark targets
+        # are left out of the default one. -DSEN_BUILD_BENCHMARKS=OFF turns them off.
+        tc.cache_variables["SEN_BUILD_BENCHMARKS"] = "ON" if str(self.options.mode) == "full" else "OFF"
         tc.cache_variables["SEN_USE_SANITIZER"] = {
             "none": "None",
             "address": "ASanUBSan",

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -329,3 +329,7 @@ sen_internal_install(core)
 if(SEN_BUILD_TESTS)
   add_subdirectory(test)
 endif()
+
+if(SEN_BUILD_BENCHMARKS)
+  add_subdirectory(benchmark)
+endif()

--- a/libs/core/benchmark/CMakeLists.txt
+++ b/libs/core/benchmark/CMakeLists.txt
@@ -1,0 +1,13 @@
+# === CMakeLists.txt ===================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+
+add_sen_benchmark(
+  core_benchmark
+  base/hash32_benchmark.cpp
+  LINK_DEPS
+  sen::core
+)

--- a/libs/core/benchmark/base/hash32_benchmark.cpp
+++ b/libs/core/benchmark/base/hash32_benchmark.cpp
@@ -1,0 +1,34 @@
+// === hash32_benchmark.cpp ============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#include "sen/core/base/hash32.h"
+
+// 3rd party
+#include <benchmark/benchmark.h>
+
+// std
+#include <cstdint>
+#include <string>
+
+namespace
+{
+
+void crc32String(benchmark::State& state)
+{
+  const std::string input(static_cast<std::size_t>(state.range(0)), 'x');
+
+  for (auto _: state)
+  {
+    benchmark::DoNotOptimize(sen::crc32(input));
+  }
+
+  state.SetBytesProcessed(static_cast<std::int64_t>(state.iterations()) * state.range(0));
+}
+
+BENCHMARK(crc32String)->Range(8, 4096);
+
+}  // namespace


### PR DESCRIPTION
Sanitizers, clang-tidy, a flake hunt and benchmarks run nightly and
file a tracking issue on failure; ci-image.yaml proves the Dockerfile
still builds.

