### PR TITLE
ci: document the pipeline and guard it with linting and tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!--
+The title becomes the commit subject on main (squash merge): use the
+conventional format, for example `fix(kernel): guard reconnect against replay`.
+-->
+
+## What and why
+
+## Checklist
+
+- [ ] The title follows `type(scope): summary` and stays under 72 characters
+- [ ] This pull request is a single logical change
+- [ ] Tests cover the change where practical
+- [ ] `conan.lock` was regenerated if `conanfile.py` changed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,12 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    commit-message:
+      prefix: "chore(deps)"
 
   - package-ecosystem: docker
     directory: /tools/ci
     schedule:
       interval: monthly
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/scripts/check_dependency_alignment.py
+++ b/.github/scripts/check_dependency_alignment.py
@@ -1,0 +1,72 @@
+# === check_dependency_alignment.py ====================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Checks that dependencies resolve at the profiles' Release default.
+
+The cache design shares one dependency slice per compiler across build
+types, which only holds while build_type applies to the sen package alone.
+This resolves a Debug consumer graph and fails if any dependency followed.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROFILE = ".conan/profiles/sen_gcc_x86"
+CONSUMER_BUILD_TYPE = "Debug"
+
+
+def misaligned_nodes(graph: dict) -> list[str]:
+    """Returns a description of every node that left its expected build_type."""
+    problems = []
+    for node in graph["graph"]["nodes"].values():
+        name = node.get("name") or "conanfile"
+        build_type = (node.get("settings") or {}).get("build_type")
+        if name == "sen":
+            if build_type != CONSUMER_BUILD_TYPE:
+                problems.append(f"sen resolved as {build_type}, expected {CONSUMER_BUILD_TYPE}")
+        elif build_type not in (None, "Release"):
+            problems.append(f"{name} resolved as {build_type}, expected Release")
+
+    return problems
+
+
+def main() -> int:
+    """Resolves the graph and reports any node off its expected build_type."""
+    result = subprocess.run(
+        [
+            "conan",
+            "graph",
+            "info",
+            ".",
+            "-pr:a",
+            PROFILE,
+            "-s",
+            f"&:build_type={CONSUMER_BUILD_TYPE}",
+            "--format=json",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    problems = misaligned_nodes(json.loads(result.stdout))
+    for problem in problems:
+        print(problem, file=sys.stderr)
+
+    if problems:
+        print("ERROR: build_type must apply to the sen package only.", file=sys.stderr)
+        return 1
+
+    print("dependency build_type alignment holds")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/classify_changes.py
+++ b/.github/scripts/classify_changes.py
@@ -1,0 +1,148 @@
+# === classify_changes.py ==============================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Classifies a change set so the orchestrator can gate the heavy lanes.
+
+Docs-only pull requests stop after the cheap checks. Without a base commit
+to diff against (pushes, manual dispatch), everything counts as code, and the
+image is rebuilt and checked.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+DOCS_PREFIXES = ("docs/",)
+DOCS_SUFFIXES = (".md",)
+
+# docs/ also holds CMakeLists.txt files that every configure parses, so a build
+# file is never documentation however it is named or wherever it lives.
+BUILD_SUFFIXES = (".cmake", "CMakeLists.txt")
+
+# What the documentation build reads: the handbook, the example tree and the
+# component definitions it copies snippets from, the site configuration, the
+# conan recipe and profiles it builds with, and its own workflow.
+DOCS_BUILD_PREFIXES = ("docs/", "examples/", "components/", ".conan/", ".github/actions/build_documentation/")
+DOCS_BUILD_FILES = ("mkdocs.yml", "conanfile.py", "conan.lock", "LICENSE.txt", ".github/workflows/docs_check.yaml")
+
+# What defines the build environment image, and the workflow that validates it.
+IMAGE_PREFIXES = ("tools/ci/",)
+IMAGE_FILES = (".github/workflows/ci-image.yaml",)
+
+
+def is_build_path(path: str) -> bool:
+    """Returns True when the path takes part in the build."""
+    return path.endswith(BUILD_SUFFIXES)
+
+
+def is_docs_path(path: str) -> bool:
+    """Returns True when the path only affects documentation."""
+    if is_build_path(path):
+        return False
+
+    return path.startswith(DOCS_PREFIXES) or path.endswith(DOCS_SUFFIXES)
+
+
+def affects_docs_build(path: str) -> bool:
+    """Returns True when the path is an input of the documentation build."""
+    return path.startswith(DOCS_BUILD_PREFIXES) or path in DOCS_BUILD_FILES or path.endswith(DOCS_SUFFIXES)
+
+
+def is_docs_build_change(paths: list[str]) -> bool:
+    """Returns True when any changed path is an input of the docs build.
+
+    An empty change set counts as docs-affecting, failing open for the same
+    reason as is_code_change.
+    """
+    if not paths:
+        return True
+
+    return any(affects_docs_build(path) for path in paths)
+
+
+def affects_image(path: str) -> bool:
+    """Returns True when the path defines the build environment image."""
+    return path.startswith(IMAGE_PREFIXES) or path in IMAGE_FILES
+
+
+def is_image_change(paths: list[str]) -> bool:
+    """Returns True when the image has to be rebuilt and checked.
+
+    Documentation is excluded even under tools/ci: the Dockerfile copies
+    nothing out of the repository, so a paragraph cannot change the image. An
+    empty change set fails open, as the other classifications do.
+    """
+    if not paths:
+        return True
+
+    if not is_code_change(paths):
+        return False
+
+    return any(affects_image(path) for path in paths)
+
+
+def is_code_change(paths: list[str]) -> bool:
+    """Returns True unless every changed path is documentation.
+
+    An empty change set counts as code: failing open runs the full matrix,
+    failing closed would skip it on a classification bug.
+    """
+    if not paths:
+        return True
+
+    return any(not is_docs_path(path) for path in paths)
+
+
+def changed_paths(base_sha: str) -> list[str]:
+    """Lists the paths that changed since the merge base with base_sha."""
+    # --no-renames: a rename reports only its destination, so moving a source
+    # file into docs/ would otherwise read as a documentation change.
+    result = subprocess.run(
+        ["git", "diff", "--no-renames", "--name-only", f"{base_sha}...HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def main() -> int:
+    """Writes the code=true/false classification to GITHUB_OUTPUT."""
+    parser = argparse.ArgumentParser(
+        prog="classify_changes",
+        description="Classifies the change set for workflow gating.",
+    )
+    parser.add_argument(
+        "--base-sha", default="", help="Base commit of the pull request; empty means not a pull request."
+    )
+    args = parser.parse_args()
+
+    code = True
+    docs = True
+    image = True
+    if args.base_sha:
+        paths = changed_paths(args.base_sha)
+        code = is_code_change(paths)
+        docs = is_docs_build_change(paths)
+        image = is_image_change(paths)
+
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if not output_file:
+        raise SystemExit("Error: No output file specified to write to.")
+
+    flags = {"code": code, "docs": docs, "image": image}
+    with open(output_file, "a", encoding="utf-8") as handle:
+        for name, value in flags.items():
+            handle.write(f"{name}={'true' if value else 'false'}\n")
+
+    print(" ".join(f"{name}={'true' if value else 'false'}" for name, value in flags.items()))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_check_dependency_alignment.py
+++ b/.github/scripts/test_check_dependency_alignment.py
@@ -1,0 +1,48 @@
+# === test_check_dependency_alignment.py ===============================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Pins the graph verdicts of the dependency build_type alignment check."""
+
+from check_dependency_alignment import misaligned_nodes
+
+
+def graph(nodes: dict) -> dict:
+    """Wraps node entries in the conan graph info json shape."""
+    return {"graph": {"nodes": nodes}}
+
+
+def test_aligned_graph_passes():
+    """A Debug consumer over Release dependencies is the expected shape."""
+    nodes = {
+        "0": {"name": "sen", "settings": {"build_type": "Debug"}},
+        "1": {"name": "zstd", "settings": {"build_type": "Release"}},
+        "2": {"name": "cmake", "settings": {}},
+    }
+    assert misaligned_nodes(graph(nodes)) == []
+
+
+def test_dependency_following_the_consumer_fails():
+    """A dependency that resolved Debug breaks the shared cache slice."""
+    nodes = {
+        "0": {"name": "sen", "settings": {"build_type": "Debug"}},
+        "1": {"name": "zstd", "settings": {"build_type": "Debug"}},
+    }
+    assert misaligned_nodes(graph(nodes)) == ["zstd resolved as Debug, expected Release"]
+
+
+def test_consumer_losing_its_build_type_fails():
+    """The sen package must keep the requested build_type."""
+    nodes = {"0": {"name": "sen", "settings": {"build_type": "Release"}}}
+    assert misaligned_nodes(graph(nodes)) == ["sen resolved as Release, expected Debug"]
+
+
+def test_settings_free_nodes_are_ignored():
+    """Tool packages without a build_type setting are fine."""
+    nodes = {
+        "0": {"name": "sen", "settings": {"build_type": "Debug"}},
+        "1": {"name": "meson", "settings": None},
+    }
+    assert misaligned_nodes(graph(nodes)) == []

--- a/.github/scripts/test_classify_changes.py
+++ b/.github/scripts/test_classify_changes.py
@@ -1,0 +1,115 @@
+# === test_classify_changes.py =========================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Pins the docs-only classification that gates the heavy workflow lanes."""
+
+from classify_changes import is_code_change, is_docs_build_change, is_image_change
+
+
+def test_docs_directory_only_is_not_code():
+    """Changes confined to docs/ stop after the cheap checks."""
+    assert not is_code_change(["docs/users_guide/util_library.md", "docs/index.md"])
+
+
+def test_markdown_anywhere_is_not_code():
+    """Markdown outside docs/ also counts as documentation."""
+    assert not is_code_change(["README.md", "examples/config/0_counter/readme.md"])
+
+
+def test_mixed_changes_are_code():
+    """One source file among documentation runs the full matrix."""
+    assert is_code_change(["docs/index.md", "libs/core/src/base/hash32.cpp"])
+
+
+def test_workflow_changes_are_code():
+    """CI definition changes run the full matrix."""
+    assert is_code_change([".github/workflows/main.yaml"])
+
+
+def test_empty_change_set_is_code():
+    """No diff information fails open into the full matrix."""
+    assert is_code_change([])
+
+
+def test_docs_lookalike_source_is_code():
+    """Paths that merely mention docs are not documentation."""
+    assert is_code_change(["libs/core/docs_generator.cpp", "apps/cli_gen/src/mkdocs/mkdocs_generator.cpp"])
+
+
+def test_docs_paths_trigger_the_docs_build():
+    """Handbook, snippet-source and site-configuration paths build the docs."""
+    assert is_docs_build_change(["docs/index.md"])
+    assert is_docs_build_change(["examples/config/14_jsonrpc/3_explorer.yaml"])
+    assert is_docs_build_change(["mkdocs.yml"])
+    assert is_docs_build_change(["README.md"])
+
+
+def test_pure_source_changes_skip_the_docs_build():
+    """Source-only changes do not build the docs on the pull request."""
+    assert not is_docs_build_change(["libs/core/src/base/hash32.cpp", ".github/workflows/main.yaml"])
+
+
+def test_empty_change_set_builds_the_docs():
+    """No diff information fails open into building the docs."""
+    assert is_docs_build_change([])
+
+
+def test_build_files_under_docs_are_code():
+    """docs/CMakeLists.txt is parsed by every configure, so it is not documentation."""
+    assert is_code_change(["docs/CMakeLists.txt"])
+    assert is_code_change(["docs/doxygen/CMakeLists.txt"])
+    assert is_code_change(["cmake/util/test.cmake"])
+
+
+def test_non_markdown_documentation_is_still_documentation():
+    """The docs/ prefix rule carries its own weight, independent of the .md rule."""
+    assert not is_code_change(["docs/requirements.txt"])
+    assert not is_code_change(["docs/assets/logo.svg"])
+
+
+def test_docs_build_inputs_beyond_the_handbook():
+    """The documentation build reads the recipe, the profiles and its own action."""
+    assert is_docs_build_change(["conanfile.py"])
+    assert is_docs_build_change(["conan.lock"])
+    assert is_docs_build_change([".conan/profiles/sen_build_docs"])
+    assert is_docs_build_change(["LICENSE.txt"])
+    assert is_docs_build_change(["components/ether/stl/configuration.stl"])
+    assert is_docs_build_change([".github/actions/build_documentation/action.yaml"])
+    assert is_docs_build_change([".github/workflows/docs_check.yaml"])
+
+
+def test_a_source_change_still_skips_the_docs_build():
+    """Source-only changes do not build the documentation on the pull request."""
+    assert not is_docs_build_change(["libs/core/src/base/hash32.cpp"])
+    assert not is_docs_build_change([".github/workflows/main.yaml"])
+
+
+def test_the_image_is_checked_when_its_definition_changes():
+    """A change to the environment definition rebuilds and checks the image."""
+    assert is_image_change(["tools/ci/Dockerfile"])
+    assert is_image_change(["tools/ci/runtime.Dockerfile"])
+    assert is_image_change([".github/workflows/ci-image.yaml"])
+    assert is_image_change(["libs/core/src/base/hash32.cpp", "tools/ci/Dockerfile"])
+
+
+def test_the_image_is_left_alone_by_unrelated_changes():
+    """Nothing outside the environment definition triggers an image build."""
+    assert not is_image_change(["libs/core/src/base/hash32.cpp"])
+    assert not is_image_change([".github/workflows/nightly.yaml"])
+    assert not is_image_change(["tools/release/publish.py"])
+
+
+def test_documentation_never_triggers_an_image_build():
+    """The Dockerfile copies nothing from the repository, so prose cannot change it."""
+    assert not is_image_change(["tools/ci/architecture.md"])
+    assert not is_image_change(["tools/ci/architecture.md", "docs/index.md"])
+    # a build file alongside the prose makes it a code change again
+    assert is_image_change(["tools/ci/architecture.md", "tools/ci/Dockerfile"])
+
+
+def test_an_empty_change_set_checks_the_image():
+    """Without diff information the image is checked, like every other lane."""
+    assert is_image_change([])

--- a/.github/scripts/test_conan_lock.py
+++ b/.github/scripts/test_conan_lock.py
@@ -1,0 +1,67 @@
+# === test_conan_lock.py ===============================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Tests the conan.lock management script against a mocked conan."""
+
+import subprocess
+from pathlib import Path
+
+import conan_lock
+
+
+def fake_conan(recorded: list[list[str]], content: str):
+    """Builds a subprocess.run stand-in that records commands and writes the lockfile output."""
+
+    def run(command, cwd=None, check=True, **kwargs):  # noqa: ARG001 - mirrors subprocess.run
+        parts = [str(part) for part in command]
+        recorded.append(parts)
+        for part in parts:
+            if part.startswith("--lockfile-out="):
+                Path(part.split("=", 1)[1]).write_text(content, encoding="utf-8")
+        return subprocess.CompletedProcess(parts, 0)
+
+    return run
+
+
+def test_update_resolves_every_profile_in_order(monkeypatch, tmp_path):
+    """Update runs one resolution per profile and chains the lockfile through them."""
+    lockfile = tmp_path / "conan.lock"
+    recorded: list[list[str]] = []
+    monkeypatch.setattr(conan_lock, "LOCKFILE", lockfile)
+    monkeypatch.setattr(conan_lock.subprocess, "run", fake_conan(recorded, "LOCKED\n"))
+
+    assert conan_lock.update() == 0
+    assert lockfile.read_text(encoding="utf-8") == "LOCKED\n"
+
+    profiles = [part for command in recorded for part in command if part.startswith(".conan/profiles/")]
+    assert profiles == [f".conan/profiles/{profile}" for profile in conan_lock.PROFILES]
+    assert not any(part.startswith("--lockfile=") for part in recorded[0])
+    assert all(f"--lockfile={lockfile}" in command for command in recorded[1:])
+
+
+def test_check_passes_when_resolution_matches(monkeypatch, tmp_path):
+    """Check succeeds when resolving inside the lockfile changes nothing."""
+    lockfile = tmp_path / "conan.lock"
+    lockfile.write_text("LOCKED\n", encoding="utf-8")
+    recorded: list[list[str]] = []
+    monkeypatch.setattr(conan_lock, "LOCKFILE", lockfile)
+    monkeypatch.setattr(conan_lock.subprocess, "run", fake_conan(recorded, "LOCKED\n"))
+
+    assert conan_lock.check() == 0
+    assert f"--lockfile={lockfile}" in recorded[0]
+
+
+def test_check_fails_when_the_conanfile_outgrows_the_lock(monkeypatch, tmp_path, capsys):
+    """Check fails and points at update when resolution adds entries."""
+    lockfile = tmp_path / "conan.lock"
+    lockfile.write_text("LOCKED\n", encoding="utf-8")
+    monkeypatch.setattr(conan_lock, "LOCKFILE", lockfile)
+    monkeypatch.setattr(conan_lock.subprocess, "run", fake_conan([], "LOCKED\nnew-dependency\n"))
+
+    assert conan_lock.check() == 1
+    captured = capsys.readouterr()
+    assert "does not cover" in captured.err
+    assert "new-dependency" in captured.out

--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -51,13 +51,18 @@ jobs:
       - name: Check the tools are present
         shell: bash
         run: |
+          # The action that installs the toolchain on runners pins the same
+          # conan version; the image is the definition, so read it from there.
+          conan_version=$(sed -n 's/^ARG CONAN_VERSION=//p' tools/ci/Dockerfile)
           docker run --rm sen-ci:probe bash -lc '
             set -e
-            for tool in conan python3 pip3 ccache git g++-12 gcc-12 \
+            for tool in conan python3 pip3 ccache git make g++-12 gcc-12 \
                         clang++-20 clang-tidy-20 gcovr lcov genhtml \
                         pytest junitparser; do
                 command -v "$tool" > /dev/null || { echo "missing: $tool"; exit 1; }
             done
+            conan --version | grep -F "'"$conan_version"'"
+            python3 -c "import junitparser, pytest"
             # The coverage report target calls these by their versioned names
             # or through the LLVM directory, never from PATH.
             for tool in llvm-profdata llvm-cov; do

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,47 +43,8 @@ jobs:
         name: Classify changed paths
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          # docs/ holds CMakeLists.txt files that every configure parses, so a
-          # build file never counts as documentation. --no-renames keeps a
-          # rename from hiding the path it moved away from. Without diff
-          # information both classifications fail open.
-          code=true
-          docs=true
-          image=true
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            changed=$(git diff --no-renames --name-only "$BASE_SHA"...HEAD)
-            build_files='(^|/)CMakeLists\.txt$|\.cmake$'
-            docs_files='^docs/|\.md$'
-            docs_inputs='^docs/|^examples/|^components/|^\.conan/|\.md$'
-            docs_inputs="$docs_inputs|^mkdocs\.yml$|^conanfile\.py$|^conan\.lock$|^LICENSE\.txt$"
-            docs_inputs="$docs_inputs|^\.github/actions/build_documentation/"
-            docs_inputs="$docs_inputs|^\.github/workflows/docs_check\.yaml$"
-            image_files='^tools/ci/|^\.github/workflows/ci-image\.yaml$'
-            if [ -n "$changed" ] &&
-               ! echo "$changed" | grep -qvE "$docs_files" &&
-               ! echo "$changed" | grep -qE "$build_files"; then
-              code=false
-            fi
-            if [ -n "$changed" ] && ! echo "$changed" | grep -qE "$docs_inputs"; then
-              docs=false
-            fi
-            if [ -n "$changed" ] && ! echo "$changed" | grep -qE "$image_files"; then
-              image=false
-            fi
-            # A documentation-only change cannot affect the image: the
-            # Dockerfile copies nothing out of the repository.
-            if [ "$code" = false ]; then
-              image=false
-            fi
-          fi
-          {
-            echo "code=$code"
-            echo "docs=$docs"
-            echo "image=$image"
-          } >> "$GITHUB_OUTPUT"
+        run: python3 .github/scripts/classify_changes.py --base-sha "$BASE_SHA"
 
   # Not on a push: after the merge the hook range is empty, so every hook
   # environment would install to check nothing.
@@ -97,15 +58,33 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: 3.x
-      - name: Install pytest
+      - name: Install checkers
         shell: bash
-        run: pip install pytest==9.1.1 pyyaml==6.0.3
+        run: pip install pytest==9.1.1 gitlint==0.19.1 pyyaml==6.0.3
       - name: Run repository script tests
         shell: bash
         run: python -m pytest .github/scripts/ -v
+      # From the pull request's own base, not from main: a stacked pull request
+      # sits on the branch below it, and origin/main would drag in every commit
+      # underneath and lint those again.
+      - name: Lint commit messages
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: gitlint --commits "${BASE_SHA:-origin/main}..HEAD"
+      # The squash merge turns the title into the commit subject on main.
+      - name: Lint the pull request title
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s\n' "$PR_TITLE" | gitlint
 
   conan-lock-check:
     name: "Check conan.lock"
@@ -124,6 +103,10 @@ jobs:
         shell: bash
         run: python .github/scripts/conan_lock.py check
 
+      - name: Verify dependency build_type alignment
+        shell: bash
+        run: python .github/scripts/check_dependency_alignment.py
+
   # Draft pull requests stop after the pre-commit checks; docs-only pull
   # requests stop there regardless of draft state.
   standard-tests:
@@ -135,8 +118,9 @@ jobs:
     with:
       building-main: ${{ github.ref == 'refs/heads/main' }}
 
-  # Builds the documentation without publishing it. Pushes to main skip it:
-  # build_docs.yaml builds and publishes there anyway.
+  # Builds the documentation without publishing it; classify_changes.py
+  # decides what counts as an input. Pushes to main skip it: build_docs.yaml
+  # builds and publishes there anyway.
   docs-build:
     needs: detect-changes
     if: >-

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,14 @@
+# === .gitlint =========================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+
+[general]
+# Subject-only commits are fine; when a body exists it explains why.
+ignore=body-is-missing
+contrib=contrib-title-conventional-commits
+
+[contrib-title-conventional-commits]
+types=build,chore,ci,docs,feat,fix,perf,refactor,revert,test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,9 @@
 #     pre-commit autoupdate
 #
 
+# install both stages with a single `pre-commit install`
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0
@@ -90,6 +93,11 @@ repos:
     - id: mypy
       files: ^\.github/scripts/
       additional_dependencies: [types-PyYAML==6.0.12.20260815]
+
+- repo: https://github.com/jorisroovers/gitlint
+  rev: v0.19.1
+  hooks:
+    - id: gitlint
 
 - repo: local
   hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,24 @@ During this initial publication phase, we are limiting external code contributio
 feature suggestions are welcome and will be evaluated. The contribution policy may be reviewed and updated
 at a later stage.
 
+## Commit Messages and Pull Requests
+
+Commit subjects follow the conventional format `type(scope): summary`:
+
+- Types in use: `feat`, `fix`, `test`, `chore`, `refactor`, `docs`, `build`, `ci`, `perf`,
+  `revert`. The scope is optional, lowercase and without spaces (`fix(core,kernel): ...`);
+  a `!` before the colon marks a breaking change.
+- Keep the subject under 72 characters, without a trailing period.
+- A body is optional. When one helps, one to three sentences explaining why the change is
+  needed are enough; the diff shows what changed.
+
+gitlint checks these rules. Run `pre-commit install` once after cloning: it installs the
+file hooks and the commit message hook together.
+
+Pull requests are squash-merged, so **the pull request title becomes the commit subject on
+main** and follows the same format. Keep each pull request to a single logical change:
+whatever lands is one commit.
+
 ## Reporting Bugs
 
 A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -1,0 +1,418 @@
+# CI and release pipeline -- Architecture
+
+This page explains how the CI pipeline is organized and why. The workflow
+definitions live in [`.github/workflows/`](../../.github/workflows). The build
+image is defined next to this file. The job matrix comes from
+[`generate_matrix_jobs.py`](../../.github/scripts/generate_matrix_jobs.py).
+
+## Purpose
+
+Pull requests get a fast and reliable test result on free GitHub-hosted
+runners. The slow checks (sanitizers, clang-tidy over the whole tree, repeated
+test runs, benchmarks) run every night instead of on every pull request.
+Releases are built from locked, reproducible inputs. Third-party code is
+compiled as rarely as possible. Every input that can change (dependencies,
+actions, tools) is pinned to a fixed version, so a version change always
+appears as a reviewable diff.
+
+## Workflow inventory
+
+| File                 | Trigger                                    | Purpose                                     |
+| -------------------- | ------------------------------------------ | ------------------------------------------- |
+| `main.yaml`          | pull_request, push to main, merge_group, nightly cron, dispatch | starts the checks, tests and packaging |
+| `pre-commit.yaml`    | called by main.yaml                        | lint and format checks on the changed files |
+| `standard_test.yaml` | called by main.yaml                        | the build-and-test matrix                   |
+| `conan.yaml`         | called by main.yaml                        | the `conan create` packaging jobs           |
+| `nightly.yaml`       | nightly cron, dispatch                     | sanitizers, clang-tidy, repeated test runs, benchmarks, full lint, documentation build, coverage report, newest compiler |
+| `docs_check.yaml`    | called by main.yaml and nightly.yaml       | builds the documentation without publishing it |
+| `ci-image.yaml`      | called by main.yaml, dispatch              | builds the build-environment image and checks the tools inside it |
+| `build_release.yaml` | version tags                               | release artifacts and the GitHub release draft |
+| `build_docs.yaml`    | push to main, version tags                 | mkdocs + doxygen, published to gh-pages     |
+
+## What runs on a pull request
+
+`main.yaml` starts three cheap jobs on every push:
+
+- pre-commit, which lints and formats only the changed files,
+- a check that `conan.lock` still matches `conanfile.py`,
+- a python-checks job, which tests the repository scripts and checks the
+  commit messages and the pull request title (after a squash merge, the
+  title becomes the commit subject on main).
+
+A fourth job looks at which paths changed. The expensive build-and-test
+matrix only runs when it is needed:
+
+- Draft pull requests stop after the cheap checks. Marking the pull request
+  ready runs everything. Converting it back to a draft cancels a run that
+  is still in progress.
+- Pull requests that only change documentation (`docs/` and `*.md` paths)
+  also stop after the cheap checks. They still run the documentation build
+  described below.
+- Every other pull request runs the matrix from `generate_matrix_jobs.py`.
+
+The matrix legs build the examples together with the production code and
+run the example smoke tests. The shipping leg (Linux gcc Release) also
+builds the CPack archive and checks that it still holds the binaries, the
+public headers and the exported cmake configuration, and that its name
+still matches what the release upload expects. That archive is what the
+release attaches and what the installer unpacks, so a dropped install rule
+would otherwise surface only at release time. The Windows legs build
+neither; building the examples there is still open.
+
+The clang leg is the one that measures coverage. It builds the report as it
+runs the suite, uploads it, prints the total in the job summary, and fails if
+the share of covered lines falls below the floor recorded in
+`standard_test.yaml`. The floor sits a few points under the measured figure,
+because the number moves slightly between runs; the browsable report is
+published by the nightly run.
+
+A separate job builds the documentation (the API reference and the
+handbook) without publishing it. It runs when a changed path is an input
+of the documentation build: `docs/`, `examples/` (the handbook copies its
+snippets from there), `mkdocs.yml`, or any markdown file. A broken
+documentation change is caught on the pull request instead of after the
+merge.
+
+Building and publishing are separate workflows on purpose. Publishing
+needs write access to the `gh-pages` branch, and the documentation build
+runs unreviewed pull-request content (the CMake files, the conan recipe
+and the mkdocs configuration all execute during it). Pull requests
+therefore call `docs_check.yaml`, which is read-only;
+`build_docs.yaml` keeps the write permissions and runs only on pushes to
+main and on version tags. The build steps themselves live in one place,
+the `build_documentation` composite action, so both paths build the
+documentation the same way.
+
+The last job is `CI OK`, and branch protection requires only this one check.
+The other jobs are skipped on purpose in normal situations (drafts,
+documentation-only changes, a packaging lane that does not run on pull
+requests), and a required check that never reports would block the merge
+forever, so the aggregator is the one job that always runs and always
+reports.
+
+Because GitHub reports a **skipped** job as a successful check, the
+aggregator has to decide explicitly rather than simply exist. It fails when
+a job it waited for failed or was cancelled, when the run itself was
+cancelled, and when the test matrix was skipped although the change was
+classified as code. Without those conditions, cancelling a run would satisfy
+the required check with nothing built. A test in `test_main_yaml.py` makes
+sure every job appears in the `needs` list; a job missing there could fail
+without blocking the merge.
+
+A draft is deliberately not failed. Its run did what a draft run is meant to
+do, and GitHub does not allow a draft to be merged, so failing it would make
+the check report "unfinished" as well as "broken" -- and a check that cries
+failure for work that never started is a check people learn to ignore. The
+cost is one narrow race: the moment a draft is marked ready, the green
+result of the draft run still sits on that commit until the new run reports.
+Auto-merge is off for exactly this reason; do not merge in the seconds
+between marking ready and the new run appearing.
+
+Two rules keep this setup working:
+
+- A job that must not always run is skipped with a job-level `if:`
+  condition, never with a workflow-level `paths:` filter. A skipped job
+  counts as passed, which the aggregator handles explicitly. A workflow that
+  never starts reports nothing, and the pull request can then never be
+  merged.
+- Auto-merge stays off. When a draft is marked ready, there is a short
+  moment before the new run appears in which the green result from the
+  draft phase would still allow a merge.
+
+Only one run per branch and trigger kind exists at a time (the
+`concurrency` group): a new push to a pull request cancels the run that is
+still in progress. Cancellation is limited to pull requests, so two merges
+landing minutes apart cannot cancel each other's post-merge validation. The
+event name is part of the group key, so a manual run and a push to main do
+not collide.
+
+**Packaging on a pull request builds one configuration.** Packaging is the
+only check that builds Sen as a package and then builds a consumer against
+it, so a broken conan recipe or an unusable exported configuration shows up
+there and nowhere else. (Whether every install rule still ships what it
+should is a different question, answered by the package-archive check
+below.) Running every configuration on every push flooded the runner queue,
+so a pull request runs the configuration that ships (Linux gcc Release) and
+the full set runs after a merge, in the merge queue, every night and on
+manual dispatch. It runs in parallel with the test matrix.
+
+## The job matrix
+
+`generate_matrix_jobs.py` decides which compiler, architecture and
+build-type combinations exist and which workflow runs them. Each job
+description is a dataclass that checks its own fields when it is created. A
+selection that cannot be classified raises an error instead of silently
+producing an empty matrix. `test_generate_matrix_jobs.py` pins the exact
+list of jobs, so changing the matrix also means updating the expected list
+in the same commit. These tests run in stage 0 and as a local pre-commit
+hook, and one of them asserts that every declared leg is selected by some
+workflow, so a leg that reads as coverage but can never run does not
+survive.
+
+Besides compiler, build type and language standard, each leg carries two
+switches: whether it builds the examples, and whether it builds and checks
+the package archive. The
+standard is passed to the compiler, so adding a leg for a different one
+tests what its name claims; every leg currently builds C++17, which is what
+the project promises its consumers.
+
+## Dependencies
+
+**`conan.lock` pins every dependency by version and recipe revision.** One
+lockfile covers all graph shapes (Linux and Windows resolve differently;
+the build type does not change the graph). Conan picks the file up
+automatically. `conan_lock.py check` resolves the graph with the lockfile
+as input, so changes in upstream recipes stay invisible and only changes in
+our own conanfile show up. `conan_lock.py update` regenerates the lockfile.
+The conan version itself is pinned in three places that must stay
+identical: the image (`CONAN_VERSION` build argument),
+`setup_build_context`, and the lockfile check job.
+
+**Dependencies always build as Release, independent of the build type of
+the sen package** (`-s "&:build_type=..."`, or `sen/*:` in `conan create`,
+whose test_package graph has a different consumer). This way one set of
+dependency binaries serves both the Debug and the Release jobs of a
+compiler, and it matches what binary remotes provide. There is one
+exception: an MSVC Debug test job must not use Release dependencies,
+because MSVC links different C runtimes in Debug and Release (MDd/MD). All
+current Windows jobs are Release, so the rule is safe today; revisit it
+when Windows tests are enabled. A stage-0 check resolves a Debug consumer
+graph and fails if any dependency left the Release default.
+
+**Caches.** Conan packages: one Actions cache entry per compiler
+(`conanp-<os>-<compiler>-<version>-<std>-<date>`). Both workflows and all
+build types share it. It is restored by prefix, so the newest snapshot
+wins. Sources and build folders are cleaned before saving. ccache: one
+cache entry per compiler and build type. The nightly sanitizer runs reuse
+the conan cache (dependencies build without sanitizer flags) but do not use
+ccache: object files built with sanitizer flags must not end up in the
+normal cache entries.
+
+## The build image
+
+[`Dockerfile`](Dockerfile) defines the build environment: gcc-12, clang-20
+and clang-tidy-20 from a pinned apt.llvm.org repository, ccache, pinned
+versions of conan, junitparser and pytest, and the coverage tools
+(gcovr, lcov and the LLVM equivalents). cmake, ninja and node are not
+installed in the image: Conan provides them as tool_requires. Anything that calls cmake
+directly must source the generated `conanbuild.sh` first.
+`setup_build_context` installs the same toolchain directly on hosted
+runners; keep the two in sync.
+
+The Dockerfile has two stages. `base` is the image described above, the one
+the pipeline is measured against. `dev` adds cmake, ninja, gdb and graphviz,
+because an editor detects a toolchain by looking for the first three and the
+dependency-graph target needs the fourth, and the devcontainer builds that
+stage. Its cmake comes from pip rather than the distribution:
+Conan writes `CMakeUserPresets.json` at version 4, which Ubuntu 22.04's cmake
+3.22 refuses to read. Builds still use the cmake and ninja that Conan pins, so
+the rule above is unchanged; the editor tools exist for the editor.
+
+`ci-image.yaml` builds both stages and then checks what is inside them. For
+`base`: the expected tools are present, cmake and ninja are absent, clang can
+link a sanitizer binary, and the image does not run as root. For `dev`: cmake,
+ninja, gdb and dot are present and cmake is new enough to read the presets. A Dockerfile
+that still builds but lost a tool therefore fails in the pull request that
+broke it. `main.yaml` calls it when a change touches the build environment,
+and `ci-ok` needs it, so a broken image blocks the merge instead of showing up
+as a red mark beside it. Documentation under `tools/ci/` does not trigger it:
+the Dockerfile copies nothing out of the repository. Docker layer caching in the Actions cache keeps
+rebuilds without changes fast. No registry hosts the image: the
+devcontainer and any self-hosted machine build it from this file, and the
+revision of the file identifies the environment. (The apt packages inside
+the Dockerfile stay unpinned on purpose: the Ubuntu archive removes old
+package versions, so exact pins would break within weeks.)
+
+The devcontainer builds this same image, keeps the conan and ccache state
+in named volumes, and installs the repository profiles with a default that
+matches the machine architecture.
+
+## Where this is heading
+
+The pieces above describe the pipeline as it is. This section describes the
+shape it is being moved towards, so that changes can be judged against it.
+
+**The environment should have one definition.** Today it has three: the
+Dockerfile, the `setup_build_context` action that installs the toolchain on
+runners, and packages installed by individual workflow steps. Nothing keeps
+them in agreement, and every difference between them has produced a real
+defect: clang-tidy present in one and missing in the other, coverage tools
+missing from both, conan pinned in one place and floating in another, a
+devcontainer that could not finish a build. The target is a single image,
+built from the file in this repository, published to the GitHub container
+registry when a change lands on main, and used by both the pull-request jobs
+and the devcontainer. Then a tool either exists for everyone or for nobody,
+and "a check that quietly analysed nothing" stops being possible.
+
+Publishing to that registry has been confirmed to work for this repository
+with the ordinary workflow token, so it needs no organisation-level change.
+Two pieces of work remain before jobs can run inside the image: the image
+must be built for both x86 and arm, because one test configuration runs on
+arm hardware, and workflows must refer to an exact image rather than a
+moving label. Images are private when first published, and a public image is
+what allows somebody who has just cloned the repository to pull it without
+credentials.
+
+**One cmake, not two.** Conan provides cmake and ninja as tool requirements,
+so they stay out of the image. The rule that follows is that any step
+invoking cmake must do so inside the environment Conan generates. When a step
+calls the cmake that happens to be installed on the runner instead, it
+disagrees with the one that configured the build, and the whole project
+relinks; that is a real cost that was measured, not a theoretical concern.
+
+**One compiler version across the Linux configurations.** All of them build
+with gcc-12, including the arm configuration, so the profiles no longer
+differ by architecture and the image needs a single compiler. Coverage of a
+newer compiler moves to the nightly run, where a build with the newest gcc
+catches the stricter diagnostics that a newer release brings.
+
+**C++17 is what every pull request checks**, because that is what the project
+promises. Newer standards are checked nightly: the library compiled as C++20,
+and a small consumer compiled against the installed package as C++20 and
+C++23. Consumers compile these headers in their own dialect, so that
+consumer-side check is the one that matches the promise.
+
+**Coverage is measured with clang**, which is the only configuration where it
+is switched on. Sending coverage to an external service stays a separate
+decision, because it means data about this code leaving Airbus. What exists
+instead is described under the pull-request flow and the nightly runs: the
+pull request measures coverage, prints the figure and holds a floor, and the
+nightly run publishes the browsable report beside the documentation.
+
+**A requested check must never quietly do nothing.** Where a tool is missing,
+the build fails rather than warning, whenever the feature was explicitly
+asked for. This is the rule that the coverage and clang-tidy lanes broke: the
+tools were absent, the build warned, and the lanes passed having measured and
+analysed nothing.
+
+**Windows stays outside the image.** MSVC cannot be containerised, so that
+configuration keeps its own setup, and the documentation says so rather than
+implying the container covers every platform.
+
+## Nightly runs
+
+| Job               | What it does                                                | Why                                         |
+| ----------------- | ----------------------------------------------------------- | ------------------------------------------- |
+| TSan / ASan+UBSan | clang Debug build of sen with `-o sen/*:sanitizer=thread` / `=address`, full test suite | finds data races and undefined behavior; the Debug build also compiles the `SEN_DEBUG_ASSERT` checks |
+| clang-tidy        | full build with `-o sen/*:with_clang_tidy=True`             | pull requests never run clang-tidy; this covers the whole tree |
+| repeated tests    | unit test suite with `--repeat until-fail:5`                | repetition exposes tests that fail only sometimes, so they get fixed instead of retried |
+| benchmarks        | `run_benchmarks`, JSON results stored per run               | performance history; see below              |
+| pre-commit full   | every hook over every file                                  | the pull-request job only checks changed files |
+| documentation     | full `doxydocs` + `mkdocs` build, without publishing        | covers documentation inputs the pull-request gate does not watch; catches a failing build, not yet a warning (see the limitations) |
+| packaging         | `conan create` for every packaged configuration             | the pull request builds only the shipping configuration |
+| public headers under C++20 | sen itself built at C++20                            | its own sources have to compile under a newer standard, not only C++17 |
+| newest gcc        | whole tree with the newest gcc on a runner, then the sample consumer at C++20 and C++23 | pull requests build with the oldest supported compiler and only C++17 |
+| coverage          | clang Debug build with coverage, report published to `<site>/coverage/` | the clang leg does not run on main, so the published report needs its own lane |
+
+When a nightly job fails, it creates or updates a single tracking issue, so
+all nightly failures are collected in one place.
+
+**The coverage report** is published to `<site>/coverage/` on the `gh-pages`
+branch, beside the versioned documentation that `mike` manages. The lane that
+measures it and the job that publishes it are separate, so that a build never
+holds a token which can write to the repository. Publishing shares the
+`gh-pages-deploy` concurrency group with the documentation deploy, and if a
+deploy still lands first, the report is replayed on top of it rather than
+merged: that branch is a published directory, not a line of development.
+The pull-request pipeline measures the same figure on its clang leg, prints it
+in the job summary and fails if it falls below the floor recorded in
+`standard_test.yaml`.
+
+**Benchmarks** come with the full mode and stay out of the default target,
+so they cost nothing until `run_benchmarks` asks for them: a library adds a
+`benchmark/` directory next to its
+`test/` directory and registers its executables with `add_sen_benchmark`
+([`cmake/util/benchmark.cmake`](../../cmake/util/benchmark.cmake)).
+`libs/core/benchmark/` is the working example.
+
+## Releases
+
+A version tag (`[0-9]+.[0-9]+.[0-9]+`, optional `-rc` suffix) builds the
+release jobs of the matrix, packages them, and attaches the artifacts to a
+draft GitHub release. Release builds do not restore any caches: release
+artifacts are built only from the locked sources.
+
+A release tag (not a release candidate) also publishes the documentation.
+The site keeps one frozen copy per release next to `latest`, which follows
+main. The name `stable` always points at the newest release, and the
+site's front page opens it, so visitors land on the documentation for what
+they can actually install.
+
+**How a release is made.** Releases are cut from a release branch
+(`release/0.6.x`), not from main. Fixes that a release needs are written
+on main first and then cherry-picked onto the release branch. Tagging that
+branch starts everything else: the version comes from `git describe`, so
+there is no version number to edit anywhere. Candidates are tagged
+`X.Y.Z-rc1` and up; they build artifacts and a prerelease draft, but no
+documentation. The final tag `X.Y.Z` builds the artifacts, generates the
+changelog from the commit messages since the previous release branch, and
+opens a **draft** GitHub release. A person reviews that draft and presses
+publish; nothing reaches users automatically.
+
+## Static checks
+
+Pre-commit owns linting and formatting: clang-format (its version follows
+the LLVM major version of the toolchain; do not bump it on its own),
+cmake-format, ruff + ruff-format + mypy, pymarkdown, check-yaml, actionlint
+(with shellcheck), hadolint, gitleaks, gitlint (commit messages, rules in
+`.gitlint`; `pre-commit install` also sets up the commit-msg stage), and
+the merge-conflict and Windows-filename checks. Pull requests check only
+the changed files; the nightly run checks everything. The nightly run is
+what catches problems caused by updated hooks or rules.
+
+Exceptions are always written down where they apply: `.hadolint.yaml`
+(DL3008, see the image section), `.pymarkdown.yaml` (MD046, upstream
+crash), `.ruff.toml` per-file ignores (tutorial scripts),
+`.gitleaksignore` (documentation placeholders).
+
+## Maintenance
+
+- **Add or update a dependency**: edit `conanfile.py`, run
+  `python .github/scripts/conan_lock.py update`, commit both files. The
+  stage-0 check fails if you forget.
+- **Change the matrix**: edit `generate_matrix_jobs.py` and its tests
+  together.
+- **Update a tool**: conan is pinned in the three places listed above;
+  actions are pinned by commit SHA (dependabot updates them monthly, and
+  the docker ecosystem watches the base image); pre-commit versions are
+  updated with `pre-commit autoupdate`, except clang-format.
+- **Add a benchmark or a nightly job**: follow the existing shape; a new
+  nightly job joins the `needs` list of the tracking-issue job, so its
+  failures are reported.
+
+## Known limitations
+
+- MSVC jobs build but do not run tests (SEN-1725). Uploading coverage to an
+  external service is wired but disabled (SEN-1726); the published report and
+  the floor cover the same ground without sending anything outside.
+- No container-based suite runs yet. The `object_sync` suite is revived in a
+  change of its own, which brings the runtime image and the steps that build
+  it; the other suites (transport, runtime compatibility, crash report, type
+  clash) are still disabled and need the same verify-and-enable treatment.
+- The Windows legs do not build the examples yet.
+- What runs on a pull request is decided by the pull request's own copy of
+  the workflows and of `classify_changes.py`, because that is how GitHub
+  runs `pull_request` workflows. A green `CI OK` therefore means "the checks
+  this branch asked for passed"; reading the diff of anything under
+  `.github/` is part of reviewing a pull request.
+- The arm leg builds Debug only and is neither packaged nor released, so
+  failures that need optimisation to appear are invisible on that
+  architecture and there is no arm artifact.
+- The TypeScript client and the web frontend have their type checks and
+  bundle builds in the test suite, but their own unit suites are not
+  registered as tests and therefore do not run.
+- The documentation build fails only when doxygen or mkdocs fail, not when
+  they warn: doxygen prints its warnings but `WARN_AS_ERROR` is off, and
+  mkdocs does not run with `--strict`. So a malformed doc comment or a
+  broken internal link still reaches the published site. The remaining
+  warnings, and a doxygen version difference that has to be resolved first,
+  are written down in the backlog.
+- mypy covers `.github/scripts/` only: duplicate test module names under
+  `apps/cli_gen` break a repo-wide run.
+- A fresh runner builds all dependencies from source once per cache
+  lifetime; the first run of a day (or after the cache was removed) is the
+  slow one.
+- clang-tidy and the sanitizers run only at night. Planned pull-request
+  additions -- a combined ASan+UBSan build, TSan for tests with the
+  `threading` label, and clang-tidy on the changed lines -- are tracked in
+  the backlog and should exist before the concurrency work starts.


### PR DESCRIPTION
architecture.md describes the pipeline, gitlint enforces the commit
format that squash merging puts on main, and the pipeline scripts get
tests.

