### PR TITLE
fix: give newcomers a working build path

### DIFF
--- a/.conan/profiles/sen_gcc
+++ b/.conan/profiles/sen_gcc
@@ -14,3 +14,4 @@ build_type=Release
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
 tools.cmake.cmake_layout:build_folder_vars=['settings.compiler']
+tools.build:compiler_executables={"c": "gcc-12", "cpp": "g++-12"}

--- a/.conan/profiles/sen_gcc_arm
+++ b/.conan/profiles/sen_gcc_arm
@@ -2,5 +2,3 @@ include(sen_gcc)
 
 [settings]
 arch=armv8
-
-[conf]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,66 @@ During this initial publication phase, we are limiting external code contributio
 feature suggestions are welcome and will be evaluated. The contribution policy may be reviewed and updated
 at a later stage.
 
+## Building and Testing
+
+The [README](README.md) covers the build. For a contribution, build with the tests enabled and
+run them before opening the pull request:
+
+```shell
+conan install . --profile=sen_gcc_x86 --build=missing -o "sen/*:with_tests=True"
+conan build . --profile=sen_gcc_x86                  # sen_gcc_arm on arm hardware
+pip install junitparser                                  # run_tests merges the ctest reports with it
+cmake --build build/gcc/Release --target run_tests
+```
+
+`run_tests` runs the suite in two passes: the ordinary tests, then the ones marked flaky, which
+are retried until they pass. While working on one library, `run_unit_tests` is quicker.
+
+If your editor supports devcontainers, the one under `.devcontainer/` already has the compilers,
+Conan and the test tools installed.
+
+## Editors
+
+`conan install` writes `CMakeUserPresets.json` at the repository root, pointing at the presets
+Conan generated for the build folder. Run it once, then open the repository folder in your
+editor and pick the preset it lists: `conan-gcc-release` for the profiles above, or
+`conan-msvc-release` when you build with `sen_msvc_x86` on Windows. VS Code reads presets
+through the CMake Tools extension; CLion and Visual Studio read them natively, pointed at the
+folder rather than at `CMakeLists.txt`.
+
+Two things decide what your editor shows you, and both are set before CMake ever runs:
+
+- `-o "sen/*:with_tests=True"` and `-o "sen/*:with_examples=True"` on the `conan install` line.
+  Without them the
+  project has no test or example targets at all, and the editor is not hiding them.
+- The environment you ran `conan install` in. The generated files hold absolute paths, so a
+  build folder belongs to the environment that configured it.
+
+### In a container
+
+The devcontainer is the least work: its image already carries the compilers, Conan and the
+editor tools, and its setup step installs the profiles and selects the one matching the
+container's architecture. In its terminal, the whole build is:
+
+```shell
+conan install . --build=missing -o "sen/*:with_tests=True"
+cmake --build --preset conan-gcc-release --target run_unit_tests
+```
+
+No package-manager settings are needed there, unlike on a bare machine: the image already has
+the system libraries, and inside the container you are not root.
+
+Editors mount the sources at different paths, `/workspaces/<name>` and `/IdeaProjects/<name>`
+among them, and Conan writes that path into the presets. So configure where you build. If you
+move between a container and your machine, delete `CMakeUserPresets.json` and re-run
+`conan install`: Conan keeps entries for build folders that no longer exist, and CMake then
+refuses to read the file at all. A build folder configured in a container also cannot be built
+on the host, and the other way round; the error names a directory that cannot be created.
+
+CLion builds the profile from the preset by itself, so there is no need to add one by hand. If
+its run widget stays empty after a reload, the project model is still loading; the commands
+above work from the terminal regardless.
+
 ## Commit Messages and Pull Requests
 
 Commit subjects follow the conventional format `type(scope): summary`:

--- a/README.md
+++ b/README.md
@@ -155,23 +155,50 @@ Take a look at the examples, but there's much more to Sen, so don't forget to re
 
 ## 🔨 How to Build
 
-You need [Conan](https://conan.io/) and a C++17 compiler (GCC, Clang, Visual Studio).
-
-To install conan, do `pip install conan`.
-
-You can find some commonly-used conan profiles in the `.conan/profiles` folder. Those can be
-installed by running `conan config install -tf profiles .conan/profiles/<profile>`. Here we use 'sen_gcc'
-but you can use the profile of your choice.
+You need [Conan](https://conan.io/), a C++17 compiler (GCC, Clang, Visual Studio), CMake and
+pkg-config; the last two are used by the third-party recipes when they build from source.
+On Debian/Ubuntu:
 
 ```shell
-conan install . --profile=sen_gcc --build=missing # Fetch third-party dependencies (only needed once)
-conan build   . --profile=sen_gcc                 # Build Sen
+sudo apt install build-essential g++-12 cmake pkg-config python3-pip
+pip install conan
+conan profile detect  # Once per machine: creates conan's default build profile
 ```
+
+The `.conan/profiles` folder holds the profiles this project builds with. Install the whole
+folder, because the per-architecture profiles include a shared base:
+
+```shell
+conan config install -tf profiles .conan/profiles/
+```
+
+Then build with the profile that matches your machine: `sen_gcc_x86` on Intel and AMD,
+`sen_gcc_arm` on arm hardware such as Apple Silicon. Both pin `gcc-12`, which has to exist on
+your machine. Picking the wrong one fails while installing system libraries, because Conan
+then looks for packages built for the other architecture.
+
+```shell
+conan install . --profile=sen_gcc_x86 --build=missing \
+    -c tools.system.package_manager:mode=install \
+    -c tools.system.package_manager:sudo=True    # Fetch third-party dependencies (only needed once)
+conan build   . --profile=sen_gcc_x86            # Build Sen
+```
+
+The package manager conf lets recipes install the system libraries they need (drop the sudo
+line when you already run as root, for example in a container). The first install compiles
+every third-party dependency and takes a while; later builds reuse them.
+
+To also build the examples, pass `-o "sen/*:with_examples=True"` to `conan install`, and see
+[examples/README.md](examples/README.md) for running them.
+
+Opening Sen in an editor: `conan install` writes `CMakeUserPresets.json` at the repository root,
+so VS Code, CLion and Visual Studio list the generated preset once you open the folder. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the details.
 
 Alternatively, if you want to control the CMake usage, you can do:
 
 ```shell
-conan install . --profile=sen_gcc --build=missing # Fetch third-party dependencies (only needed once)
+conan install . --profile=sen_gcc_x86 --build=missing # Fetch third-party dependencies (only needed once)
 source build/gcc/Release/generators/conanbuild.sh # Make all the required tools available
 cmake --preset conan-gcc-release                  # Generate the build system
 cmake --build build/gcc/Release                   # Build Sen

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -183,12 +183,13 @@ find_package(sen REQUIRED)
 
 **Sen** requires at least C++17.
 
-Use Conan to fetch the third-party dependencies `conan install . --profile=sen_gcc --build=missing`
-(you can replace 'sen_gcc' with the preset of your choice).
+Install the profiles with `conan config install -tf profiles .conan/profiles/`, then fetch the
+third-party dependencies with `conan install . --profile=sen_gcc_x86 --build=missing`. Use
+`sen_gcc_arm` on arm hardware: the profiles pin the architecture, and the wrong one fails while
+installing system libraries.
 
-To build, use `conan build . --profile=sen_gcc`. Alternatively, use
-`cmake -S . -B build -G Ninja --preset sen_gcc && cmake --build build` (you can replace 'sen_gcc'
-with the preset of your choice).
+To build, use `conan build . --profile=sen_gcc_x86`. Alternatively drive CMake yourself with the
+preset Conan generated: `cmake --preset conan-gcc-release && cmake --build --preset conan-gcc-release`.
 
 ??? note "Build options"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,41 @@
+# Sen Examples
+
+How this directory is laid out:
+
+- `packages/` holds the example code: one Sen package per directory, each with its STL
+  interface, C++ implementation and a runnable `config.yaml`.
+- `config/` holds the documentation pages for the example walkthroughs. They are sources for
+  the [documentation site](https://airbus.github.io/sen/latest/) and reference the code in
+  `packages/`; read them there rather than on GitHub.
+- `apps/` holds larger example applications.
+
+## Building the examples
+
+The examples build with the rest of the tree when the `with_examples` option is on. Options are
+read at `conan install`, the step that generates the build files:
+
+```shell
+conan install . --profile=sen_gcc_x86 --build=missing -o "sen/*:with_examples=True"
+conan build . --profile=sen_gcc_x86
+```
+
+Use `sen_gcc_arm` instead on arm hardware; the README explains the profiles.
+
+Each example package lands as a shared library in `build/gcc/Release/bin/` next to the `sen`
+application.
+
+## Running an example
+
+From the repository root, with the tree built as above:
+
+```shell
+source build/gcc/Release/generators/conanrun.sh          # Third-party library paths
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(pwd)/build/gcc/Release/bin"
+cd examples/packages/my_counter
+../../../build/gcc/Release/bin/sen run config.yaml
+```
+
+This boots the tutorial counter with an interactive Sen shell attached; the `counters` bus is
+already open, so you can inspect the ticking `myCounter` object directly. Every package under
+`packages/` follows the same pattern through its own `config.yaml`; the path segments
+(`build/gcc/Release`) follow the profile you built with.


### PR DESCRIPTION
The documented build failed four times on a stock machine. The
prerequisites are now real, the profiles name their compilers, and the
examples are documented.

