### PR TITLE
fix(core,kernel): subscription-path + buildQuery correctness fixes

### DIFF
--- a/libs/core/include/sen/core/obj/detail/native_object_proxy.h
+++ b/libs/core/include/sen/core/obj/detail/native_object_proxy.h
@@ -70,29 +70,31 @@ protected:  // called by the generated code
   void senImplRemoveUntypedConnection(ConnId id, MemberHash memberHash) override;
 
 private:
-  struct EventCallbackData
+  // Held by shared_ptr: senImplEventEmitted queues work items that capture this and may
+  // run after senImplRemoveUntypedConnection erases the slot.
+  struct PropertyCallbackData
   {
     uint32_t id;
     std::shared_ptr<EventCallback<VarList>> callback;
   };
 
-  using EventCallbackList = std::vector<EventCallbackData>;
+  using PropertyCallbackList = std::vector<PropertyCallbackData>;
 
-  struct EventData
+  struct PropertyData
   {
-    EventCallbackList list;
+    PropertyCallbackList list;
     TransportMode transportMode;
   };
 
-  using EventCallbackMap = std::unordered_map<MemberHash, EventData>;
+  using PropertyCallbackMap = std::unordered_map<MemberHash, PropertyData>;
 
 private:
   NativeObject* owner_;
   std::shared_ptr<Object> guard_;
   std::string localName_;
   TimeStamp lastCommitTime_;
-  std::unique_ptr<EventCallbackMap> eventCallbacks_;
-  std::recursive_mutex eventCallbacksMutex_;
+  std::unique_ptr<PropertyCallbackMap> propertyCallbacks_;
+  std::recursive_mutex propertyCallbacksMutex_;
 };
 
 }  // namespace impl

--- a/libs/core/src/obj/native_object_proxy.cpp
+++ b/libs/core/src/obj/native_object_proxy.cpp
@@ -70,11 +70,11 @@ void NativeObjectProxy::invokeUntyped(const Method* method, const VarList& args,
 
 ConnectionGuard NativeObjectProxy::onPropertyChangedUntyped(const Property* prop, EventCallback<VarList>&& callback)
 {
-  std::scoped_lock<std::recursive_mutex> lock(eventCallbacksMutex_);
+  std::scoped_lock<std::recursive_mutex> lock(propertyCallbacksMutex_);
 
-  if (!eventCallbacks_)
+  if (!propertyCallbacks_)
   {
-    eventCallbacks_ = std::make_unique<EventCallbackMap>();
+    propertyCallbacks_ = std::make_unique<PropertyCallbackMap>();
   }
 
   if (auto callbackLock = callback.lock(); callbackLock.isValid())
@@ -82,7 +82,7 @@ ConnectionGuard NativeObjectProxy::onPropertyChangedUntyped(const Property* prop
     const auto connId = senImplMakeConnectionId();
     const auto memberHash = prop->getId();
 
-    auto [itr, done] = eventCallbacks_->try_emplace(memberHash, EventData {{}, prop->getTransportMode()});
+    auto [itr, done] = propertyCallbacks_->try_emplace(memberHash, PropertyData {{}, prop->getTransportMode()});
     itr->second.list.push_back({connId.get(), std::make_shared<EventCallback<VarList>>(std::move(callback))});
 
     return senImplMakeConnectionGuard(connId, memberHash, false);
@@ -103,29 +103,29 @@ Var NativeObjectProxy::getPropertyUntyped(const Property* prop) const { return s
 
 void NativeObjectProxy::senImplEventEmitted(MemberHash id, std::function<VarList()>&& argsGetter, const EventInfo& info)
 {
-  std::scoped_lock<std::recursive_mutex> lock(eventCallbacksMutex_);
+  std::scoped_lock<std::recursive_mutex> lock(propertyCallbacksMutex_);
 
-  if (!eventCallbacks_)
+  if (!propertyCallbacks_)
   {
     return;
   }
 
-  auto itr = eventCallbacks_->find(id);
-  if (itr != eventCallbacks_->end())
+  auto itr = propertyCallbacks_->find(id);
+  if (itr != propertyCallbacks_->end())
   {
-    const auto& eventData = itr->second;
+    const auto& propertyData = itr->second;
 
-    if (!eventData.list.empty())
+    if (!propertyData.list.empty())
     {
       const auto args = argsGetter();
-      for (const auto& elem: eventData.list)
+      for (const auto& elem: propertyData.list)
       {
         if (auto callbackLock = elem.callback->lock(); callbackLock.isValid())
         {
           // Capture the shared_ptr by value: the entry may be erased before the workQueue
           // drains, and Callback::invoke is a no-op on an invalidated CallbackData.
           callbackLock.pushAnswer([args, info, callback = elem.callback]() { callback->invoke(info, args); },
-                                  impl::cannotBeDropped(eventData.transportMode));
+                                  impl::cannotBeDropped(propertyData.transportMode));
         }
       }
     }
@@ -136,12 +136,12 @@ void NativeObjectProxy::removeTypedConnectionOnOwner(ConnId connId) { owner_->se
 
 void NativeObjectProxy::senImplRemoveUntypedConnection(ConnId id, MemberHash memberHash)
 {
-  std::scoped_lock<std::recursive_mutex> lock(eventCallbacksMutex_);
+  std::scoped_lock<std::recursive_mutex> lock(propertyCallbacksMutex_);
 
-  if (eventCallbacks_)
+  if (propertyCallbacks_)
   {
-    auto itr = eventCallbacks_->find(memberHash.get());
-    if (itr != eventCallbacks_->end())
+    auto itr = propertyCallbacks_->find(memberHash.get());
+    if (itr != propertyCallbacks_->end())
     {
       auto& callbackList = itr->second.list;
 
@@ -158,13 +158,13 @@ void NativeObjectProxy::senImplRemoveUntypedConnection(ConnId id, MemberHash mem
       // delete the entry for this member if empty
       if (callbackList.empty())
       {
-        eventCallbacks_->erase(itr);
+        propertyCallbacks_->erase(itr);
       }
 
       // delete the callbacks container if empty
-      if (eventCallbacks_->empty())
+      if (propertyCallbacks_->empty())
       {
-        eventCallbacks_ = {};
+        propertyCallbacks_ = {};
       }
     }
   }

--- a/libs/core/src/obj/object_filter.cpp
+++ b/libs/core/src/obj/object_filter.cpp
@@ -122,6 +122,13 @@ public:
     }
   }
 
+  /// Tracks the given objects and evaluates them, notifying listeners about the ones that match.
+  void seedFromExistingObjects(const std::unordered_map<ObjectId, std::shared_ptr<Object>>& objects)
+  {
+    startTracking(objects);
+    evaluateTrackedObjects();
+  }
+
   void evaluateTrackedObjects()
   {
     // clear it because we will recompute this here
@@ -440,8 +447,7 @@ std::shared_ptr<ObjectProvider> ObjectFilter::getOrCreateNamedProvider(const std
   providers_.push_back(ptr);
 
   ptr->setName(name);
-  ptr->startTracking(lastPresentObjects_);
-  ptr->evaluateTrackedObjects();
+  ptr->seedFromExistingObjects(lastPresentObjects_);
 
   return ptr;
 }
@@ -506,8 +512,7 @@ void ObjectFilter::addSubscriber(std::shared_ptr<Interest> interest,
 
   if (notifyAboutExisting)
   {
-    provider->startTracking(lastPresentObjects_);
-    provider->evaluateTrackedObjects();
+    provider->seedFromExistingObjects(lastPresentObjects_);
   }
 }
 

--- a/libs/core/test/obj/native_object_proxy_test.cpp
+++ b/libs/core/test/obj/native_object_proxy_test.cpp
@@ -319,3 +319,41 @@ TEST(NativeObjectProxy, RemoveTypedConnectionFallback)
 
   EXPECT_TRUE(ownerTriggered);
 }
+
+/// @test
+/// Removing a property-change connection while a work item is still queued must not crash
+/// and must not deliver the callback on drain.
+TEST(NativeObjectProxy, RemoveDuringEmitNoCrashAndCallbackInvalidated)
+{
+  const ProxyTestFixture fixture;
+  const auto* metaClass = example_class::ExampleClassInterface::meta().type();
+  const auto* propertyInfo = metaClass->searchPropertyByName("prop1");
+
+  bool callbackTriggered = false;
+  {
+    auto guard = fixture.proxy->onPropertyChangedUntyped(
+      propertyInfo,
+      EventCallback<VarList>(fixture.getQueue(), [&](const auto&, const auto&) { callbackTriggered = true; }));
+
+    // Positive control. Without it the assertion below also passes for a connection that
+    // was never wired up, or a property lookup that returned the wrong member.
+    fixture.owner->setNextProp1("control_emit");
+    fixture.owner->commit(TimeStamp {100});
+    fixture.proxy->drainInputs();
+    while (fixture.getQueue()->executeAll())
+    {
+    }
+    ASSERT_TRUE(callbackTriggered);
+    callbackTriggered = false;
+
+    fixture.owner->setNextProp1("first_emit");
+    fixture.owner->commit(TimeStamp {200});
+    fixture.proxy->drainInputs();
+  }  // guard destructs -> remove runs while the work item is still queued
+
+  while (fixture.getQueue()->executeAll())
+  {
+  }
+
+  EXPECT_FALSE(callbackTriggered);
+}

--- a/libs/core/test/obj/object_filter_test.cpp
+++ b/libs/core/test/obj/object_filter_test.cpp
@@ -650,3 +650,51 @@ TEST(ObjectFilter, Subscriber_RemoveWithInterestHandlesExpiredProvider)
 
   EXPECT_EQ(listener.providerToDrop, nullptr);
 }
+
+/// @test
+/// addSubscriber(..., notifyAboutExisting=true) seeds a newly-created provider's listener
+/// with the filter's current match set.
+TEST(ObjectFilter, Subscriber_NotifyAboutExistingTrueSeedsNewProvider)
+{
+  TestObjectFilter filter(getTestOwnerId());
+  const auto interest = createEmptyInterest();
+
+  auto obj = std::make_shared<TestOwner>("TestObj1");
+  TestObjectFilter::ObjectSet set;
+  set.newObjects[obj->getId()] = obj;
+  set.currentObjects[obj->getId()] = obj;
+  filter.evaluate(set);
+
+  MockListener listener;
+  filter.addSubscriber(interest, &listener, true);
+
+  // Unsubscribe before asserting: an ASSERT_ returns, and the filter would outlive a
+  // listener it still holds a pointer to.
+  const auto added = listener.added;
+  filter.removeSubscriber(interest, &listener, false);
+
+  ASSERT_EQ(added.size(), 1U);
+  EXPECT_EQ(added[0], obj->getId());
+}
+
+/// @test
+/// addSubscriber(..., notifyAboutExisting=false) does not broadcast existing matches.
+TEST(ObjectFilter, Subscriber_NotifyAboutExistingFalseStaysSilent)
+{
+  TestObjectFilter filter(getTestOwnerId());
+  const auto interest = createEmptyInterest();
+
+  auto obj = std::make_shared<TestOwner>("TestObj1");
+  TestObjectFilter::ObjectSet set;
+  set.newObjects[obj->getId()] = obj;
+  set.currentObjects[obj->getId()] = obj;
+  filter.evaluate(set);
+
+  MockListener listener;
+  filter.addSubscriber(interest, &listener, false);
+
+  const auto added = listener.added;
+  filter.removeSubscriber(interest, &listener, false);
+
+  EXPECT_TRUE(added.empty());
+}

--- a/libs/kernel/include/sen/kernel/component_api.h
+++ b/libs/kernel/include/sen/kernel/component_api.h
@@ -46,6 +46,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -142,22 +143,27 @@ public:
   /// The work queue of this runner
   [[nodiscard]] ::sen::impl::WorkQueue* getWorkQueue() const noexcept;
 
+  /// Subscribe to every object of type T on `bus`. The returned Subscription owns the
+  /// kernel-side wiring; destruct it to stop.
+  ///
+  /// Callback lifetime (this overload, the next, and selectFrom): onAdded / onRemoved
+  /// fire on the kernel's run() thread between subscribe and the Subscription's
+  /// destruction. References they capture must outlive the Subscription. Capture state
+  /// by shared_ptr or via a component member.
   template <typename T, typename Bus>
   [[nodiscard]] std::shared_ptr<Subscription<T>> selectAllFrom(const Bus& bus);
 
-  /// Overload of selectAllFrom that installs addition and removal callbacks before subscribing,
-  /// so they fire for objects already present at subscription time.
-  /// Pass nullptr for either callback to skip it.
+  /// As above, plus addition/removal callbacks installed before subscribing so they fire
+  /// for objects already present. Pass nullptr to skip either.
   template <typename T, typename Bus>
   [[nodiscard]] std::shared_ptr<Subscription<T>> selectAllFrom(
     const Bus& bus,
     typename sen::ObjectList<T>::Callback onAdded,
     typename sen::ObjectList<T>::Callback onRemoved = nullptr);
 
-  /// Creates a subscription for objects matching the given Sen query string.
-  /// Unlike selectAllFrom, this lets you supply an arbitrary query with WHERE conditions.
-  /// Example: selectFrom<Shape>(bus, "SELECT Shape FROM local.bus WHERE color IN (\"red\")").
-  /// It installs addition and removal callbacks before subscribing. Pass nullptr for either callback to skip it.
+  /// Subscription against an arbitrary Sen query (with WHERE conditions).
+  /// Example: `selectFrom<Shape>(bus, R"(SELECT Shape FROM local.bus WHERE color IN ("red"))")`.
+  /// Installs the callbacks before subscribing. Pass nullptr to skip either.
   template <typename T, typename Bus>
   [[nodiscard]] std::shared_ptr<Subscription<T>> selectFrom(const Bus& bus,
                                                             const std::string& query,
@@ -400,17 +406,34 @@ inline std::shared_ptr<Subscription<T>> KernelApi::selectFrom(const Bus& bus,
   return sub;
 }
 
+namespace impl
+{
+
+/// The type name a query selects: the qualified class name, or "*" for the base Object.
+/// The assert is on meta(), not inheritance: a generated interface is not an Object but
+/// does carry a ClassType, where an enum or a sequence would give a null one.
+template <typename T>
+[[nodiscard]] inline std::string_view queryTypeName()
+{
+  if constexpr (std::is_same_v<T, Object>)
+  {
+    return "*";
+  }
+  else
+  {
+    static_assert(std::is_same_v<decltype(T::meta()), ::sen::ConstTypeHandle<::sen::ClassType>>,
+                  "a subscription type must be a Sen object class");
+    return T::meta()->getQualifiedName();
+  }
+}
+
+}  // namespace impl
+
 template <typename T>
 inline std::string KernelApi::buildQuery(const BusAddress& address) const
 {
-  const ClassType* meta = nullptr;
-  if constexpr (!std::is_same_v<T, Object>)
-  {
-    meta = &T::meta();
-  }
-
   std::string query = "SELECT ";
-  query.append(meta ? meta->getQualifiedName() : "*");
+  query.append(impl::queryTypeName<T>());
   query.append(" FROM ");
   query.append(address.sessionName);
   query.append(".");
@@ -422,14 +445,8 @@ inline std::string KernelApi::buildQuery(const BusAddress& address) const
 template <typename T>
 inline std::string KernelApi::buildQuery(std::string_view bus) const
 {
-  const ClassType* meta = nullptr;
-  if constexpr (!std::is_same_v<T, Object>)
-  {
-    meta = T::meta()->asClassType();
-  }
-
   std::string query = "SELECT ";
-  query.append(meta ? meta->getQualifiedName() : "*");
+  query.append(impl::queryTypeName<T>());
   query.append(" FROM ");
   query.append(bus);
 

--- a/libs/kernel/src/pipeline_component.cpp
+++ b/libs/kernel/src/pipeline_component.cpp
@@ -18,6 +18,7 @@
 #include "sen/core/meta/custom_type.h"
 #include "sen/core/meta/type.h"
 #include "sen/core/meta/type_registry.h"
+#include "sen/core/obj/native_object.h"
 #include "sen/core/obj/object_source.h"
 #include "sen/kernel/component_api.h"
 #include "sen/kernel/kernel_config.h"
@@ -259,6 +260,23 @@ void PipelineComponent::validateConfig(const CustomTypeRegistry& reg) const
 
   for (const auto& obj: config_.objects)
   {
+    // Both names set (bus-published) or both empty (not bus-published). A half-empty
+    // address would otherwise be silently dropped at connection time.
+    const bool hasSession = !obj.bus.sessionName.empty();
+    const bool hasBus = !obj.bus.busName.empty();
+    if (hasSession != hasBus)
+    {
+      std::string err;
+      err.append("object '");
+      err.append(obj.name);
+      err.append("' has an incomplete bus address (sessionName='");
+      err.append(obj.bus.sessionName);
+      err.append("', busName='");
+      err.append(obj.bus.busName);
+      err.append("'); both must be set, or both omitted");
+      throw std::runtime_error(err);
+    }
+
     auto basicType = reg.get(obj.className);
     if (!basicType)
     {

--- a/libs/kernel/test/unit/test_kernel/test_kernel_test.cpp
+++ b/libs/kernel/test/unit/test_kernel/test_kernel_test.cpp
@@ -24,6 +24,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <stdexcept>
+#include <string>
 
 //--------------------------------------------------------------------------------------------------------------
 // Helpers
@@ -200,4 +202,33 @@ TEST(TestKernel, repeatedNames)
 
   sen::kernel::TestKernel kernel(&component);
   kernel.step();
+}
+
+/// @test
+/// A pipeline object with one side of `bus` empty (trailing or leading dot) is rejected
+/// at config-validation time.
+TEST(TestKernel, busAddressMustBeFullySpecified)
+{
+  const auto* yaml = R"yaml(
+build:
+  - name: comp
+    group: 1
+    freqHz: 100
+    imports: [my_package]
+    objects:
+      - name: obj
+        class: my_package.MyClass
+        bus: "session."
+)yaml";
+  try
+  {
+    sen::kernel::TestKernel::fromYamlString(yaml);
+    FAIL() << "an incomplete bus address should have been rejected";
+  }
+  catch (const std::runtime_error& e)
+  {
+    // Not merely that something threw: loading throws runtime_error for an unregistered
+    // class or a bad field too, so only the message pins the path this test is about.
+    EXPECT_NE(std::string(e.what()).find("incomplete bus address"), std::string::npos) << e.what();
+  }
 }


### PR DESCRIPTION
Fixes in the subscription and query path, found while building the functional
stack on top of this branch.

- buildQuery<T> could not compile for a typed T through the BusAddress overload.
  T::meta() returns a ConstTypeHandle by value and the old code took its address,
  which is ill-formed. `if constexpr` discarded the branch for Object, so it never
  surfaced. selectAllFrom<T>(busAddress) now compiles.
- A bus address with one half empty ("s." or ".b") used to be skipped silently at
  connection time. It now fails at config validation, with the object name and both
  halves of the address in the message.
- ~~`imports` is no longer required in a pipeline block; a pipeline that omits it
  imports nothing.~~ **Reverted before merge, 2026-08-28.** `imports` remains
  required. The relaxation's only justification was that it made a test pass, and
  that test was passing on the wrong error either way; every config in the tree
  already declares the key.
- ObjectFilter::addSubscriber and getOrCreateNamedProvider both seed a new provider
  through one seedFromExistingObjects call instead of repeating the startTracking +
  evaluateTrackedObjects pair. Ordering is unchanged.
- The proxy's Event* types become Property*, which is what they track.
- selectAllFrom and selectFrom document the callback-lifetime contract: callbacks
  may fire after the caller's lifetime, so capture state through a shared_ptr the
  callback owns. Pre-existing convention, newly written down.

Tests: notifyAboutExisting true and false; a property connection removed while a
work item is still queued; a half-empty bus address; ~~a pipeline with no imports~~
(removed with the revert above).

This branch is the base of the functional stack (libs/gen, jsonrpc, web-explorer).

---

*Description corrected 2026-09-02: it advertised a change that was reverted before this merged, so main was credited with behaviour it deliberately does not have. No code changed.*
