### PR TITLE
feat(db-python): read-side bindings with type registry and annotations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,9 @@ add_subdirectory(components/rest)
 add_subdirectory(components/jsonrpc)
 add_subdirectory(components/tracy)
 
-# Python bindings under libs/db
+# Python bindings under libs/db. Not a Sen "component" (no conanfile.py COMPONENTS entry,
+# no sen_internal_component_guard). Just a Python module that exposes sen::db; piggybacks
+# on the existing SEN_BUILD_PY toggle rather than declaring its own option.
 if(SEN_BUILD_PY)
   add_subdirectory(libs/db/bindings/python)
 endif()

--- a/docs/users_guide/db_library.md
+++ b/docs/users_guide/db_library.md
@@ -25,8 +25,8 @@ by default.
 The `sen::db` API uses a cursor model: open the recording, seek to a position, and iterate forward
 or backward. The replayer component wraps this with real-time clock synchronisation.
 
-For scripted post-processing, Sen ships Python bindings that expose the same cursor API - see the
-[Recorder example](../../examples/config/6_recorder/readme.md) for a working script.
+For scripted post-processing, Sen ships [Python bindings](db_python_bindings.md) that expose the
+same cursor API.
 
 ## Writing a recording
 

--- a/docs/users_guide/db_python_bindings.md
+++ b/docs/users_guide/db_python_bindings.md
@@ -1,0 +1,390 @@
+# sen::db Python bindings
+
+The `sen_db_python` module exposes the [sen::db](db_library.md) cursor API to Python.
+Scripts can open a recording, walk its contents, and inspect every value, type, snapshot,
+and annotation without the original C++ binaries.
+
+## Importing
+
+```python
+import sen_db_python as sen
+```
+
+The conventional alias is `sen`. The rest of this document assumes it.
+
+## Opening a recording
+
+```python
+inp = sen.Input("/path/to/recording_directory")
+print(inp.path)        # str -- the recording directory
+summary = inp.summary  # Summary object
+```
+
+`Summary` carries:
+
+| Attribute             | Type                  | Meaning                                |
+| --------------------- | --------------------- | -------------------------------------- |
+| `firstTime`           | `datetime.timedelta`  | time of the first sample, since epoch  |
+| `lastTime`            | `datetime.timedelta`  | time of the last sample, since epoch   |
+| `keyframeCount`       | `int`                 | number of keyframes                    |
+| `objectCount`         | `int`                 | number of distinct objects             |
+| `typeCount`           | `int`                 | number of distinct types               |
+| `annotationCount`     | `int`                 | number of annotations                  |
+| `indexedObjectCount`  | `int`                 | number of objects with random access   |
+
+## The cursor model
+
+A `DataCursor` iterates over the runtime data. Three constructors:
+
+| API                                | Cursor over                                  |
+| ---------------------------------- | -------------------------------------------- |
+| `inp.begin()`                      | the whole recording, from the start          |
+| `inp.at(keyframeIndex)`            | the whole recording, from a chosen keyframe  |
+| `inp.makeCursor(objectIndexDef)`   | a single object's entries only               |
+
+Walk pattern:
+
+```python
+cursor = inp.begin()
+cursor.advance()              # move to the first entry
+while not cursor.atEnd:
+    entry = cursor.entry
+    # entry.time     -> datetime.timedelta since epoch
+    # entry.payload  -> one of PropertyChange / Event / Keyframe /
+    #                   Creation / Deletion / End
+    ...
+    cursor.advance()
+```
+
+`cursor.atStart` is `True` before any `advance()`; in that state `entry.payload` is `None`.
+`cursor.atEnd` is `True` once the cursor reaches the recording's end.
+
+The payload accessor returns the active variant alternative directly, so `isinstance()`
+dispatches against concrete classes:
+
+```python
+if isinstance(entry.payload, sen.PropertyChange):
+    ...
+elif isinstance(entry.payload, sen.Event):
+    ...
+```
+
+## Payload classes
+
+### `PropertyChange`
+
+| Attribute    | Type                       |
+| ------------ | -------------------------- |
+| `.objectId`  | `int`                      |
+| `.name`      | `str` -- property name     |
+| `.value`     | converted Python value     |
+
+### `Event`
+
+| Attribute    | Type                                   |
+| ------------ | -------------------------------------- |
+| `.objectId`  | `int`                                  |
+| `.name`      | `str` -- event name                    |
+| `.args`      | `list[object]` -- one converted value per argument |
+
+### `Keyframe`
+
+| Attribute     | Type                              |
+| ------------- | --------------------------------- |
+| `.snapshots`  | sequence of `Snapshot`            |
+
+### `Creation`
+
+Delegates attribute lookup to the embedded `Snapshot`. Read object fields directly:
+`creation.name`, `creation.className`, `creation.<propertyName>`, etc. See
+[Snapshot reflection](#snapshot-reflection).
+
+### `Deletion`
+
+| Attribute    | Type    |
+| ------------ | ------- |
+| `.objectId`  | `int`   |
+
+### `End`
+
+Sentinel marking the end of the cursor. The idiomatic check is `cursor.atEnd`.
+
+## Snapshot reflection
+
+`Snapshot` exposes attributes via reflection against the object's class. Built-in
+attributes return identity and class metadata; any other name resolves as a property
+defined on the class (walking parents).
+
+| Attribute          | Returns                                            |
+| ------------------ | -------------------------------------------------- |
+| `.name`            | `str` -- object name                               |
+| `.busName`         | `str`                                              |
+| `.sessionName`     | `str`                                              |
+| `.objectId`        | `int` -- object id                                 |
+| `.className`       | `str` -- qualified class name                      |
+| `.propertyNames`   | `list[str]` -- every property, including inherited |
+| `.<propertyName>`  | the property's converted Python value              |
+
+Reading an attribute that is neither built-in nor a known property raises
+`AttributeError`.
+
+```python
+snap = keyframe.snapshots[0]
+print(snap.className)              # 'school.Student'
+print(snap.propertyNames)          # ['firstName', 'surName', 'focusLevel', ...]
+print(snap.focusLevel)             # 0.42
+```
+
+## Value conversion
+
+Sen values are converted to native Python equivalents. The mapping is uniform across
+`PropertyChange.value`, `Event.args`, `Annotation.value`, and every
+`Snapshot.<propertyName>` accessor.
+
+| Sen value                               | Python value                                   |
+| --------------------------------------- | ---------------------------------------------- |
+| `bool`, integers, floats                | matching Python builtin                        |
+| `string`                                | `str`                                          |
+| `TimeStamp`, `Duration`                 | `datetime.timedelta`                           |
+| `VarList` (sequence)                    | `list`                                         |
+| `VarMap` (named fields)                 | `dict`                                         |
+| `KeyedVar` (tagged variant alternative) | `{"type": "<qualifiedName>", "value": <converted>}` -- same shape as the type registry uses |
+| structs                                 | `dict` (via `VarMap`)                          |
+
+## Type registry
+
+`inp.getTypes()` returns a `TypeRegistry` snapshot describing every class, struct,
+variant, alias, enum, and quantity present in the recording.
+
+| API                                  | Returns                                                                |
+| ------------------------------------ | ---------------------------------------------------------------------- |
+| `len(registry)`                      | `int` -- number of registered types                                    |
+| `name in registry`                   | `bool`                                                                 |
+| `.classNames`                        | `list[str]` -- every qualified name                                    |
+| `.getTypeSpec(qualifiedName)`        | `dict` describing the type, or `None` if absent                        |
+| `.getAllTypeSpecs()`                 | `dict[str, dict]` -- every type, keyed by qualified name               |
+
+The dict shape is the kernel's external `CustomTypeSpec` encoding. Top level:
+
+| Key             | Type                          | Meaning                                  |
+| --------------- | ----------------------------- | ---------------------------------------- |
+| `qualifiedName` | `str`                         | fully qualified type name                |
+| `name`          | `str`                         | short name (without the package prefix)  |
+| `description`   | `str`                         | description from the STL definition      |
+| `data`          | `{type: str, value: dict}`    | tagged union -- shape depends on `type`  |
+
+`data.type` is one of:
+
+| Tag                              | `data.value` shape                                                                                |
+| -------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `sen.kernel.ClassTypeSpec`       | `{properties, methods, events, constructor, parents, isInterface}`                                |
+| `sen.kernel.StructTypeSpec`      | `{fields, parent}` -- each field has `name`, `description`, `type`; `parent` empty for none       |
+| `sen.kernel.VariantTypeSpec`     | `{fields}` -- each field has `key`, `description`, `type`                                         |
+| `sen.kernel.EnumTypeSpec`        | `{enums, storageType}` -- each enum has `name`, `key`, `description`                              |
+| `sen.kernel.AliasTypeSpec`       | `{aliasedType}`                                                                                   |
+| `sen.kernel.QuantityTypeSpec`    | `{elementType, unit, minValue, maxValue}`                                                         |
+| `sen.kernel.SequenceTypeSpec`    | `{elementType, maxSize, fixedSize}`                                                               |
+| `sen.kernel.OptionalTypeSpec`    | `{type}`                                                                                          |
+
+`ClassTypeSpec` members:
+
+- **properties[i]**: `name`, `description`, `category` (`staticRO` / `staticRW` / `dynamicRO` / `dynamicRW`), `type`,
+  `transportMode`, `tags`, `checkedSet`.
+- **methods[i]**: `name`, `description`, `args` (list of `{name, description, type}`), `transportMode`, `constness`,
+  `deferred`, `returnType`, `propertyRelation`, `localOnly`.
+- **events[i]**: `name`, `description`, `args` (same shape as method args), `transportMode`.
+- **constructor**: same shape as `methods[i]`.
+- **parents**: list of qualified parent class names.
+- **isInterface**: `bool`.
+
+Inheritance is walked via `parents`. To find an event defined on an ancestor:
+
+```python
+def find_event(reg, class_name, event_name):
+    spec = reg.getTypeSpec(class_name)
+    if spec is None:
+        return None
+    data = spec["data"]["value"]
+    for event in data.get("events", []):
+        if event["name"] == event_name:
+            return event
+    for parent in data.get("parents", []):
+        found = find_event(reg, parent, event_name)
+        if found is not None:
+            return found
+    return None
+```
+
+## Indexes
+
+| API                                       | Returns                                                                |
+| ----------------------------------------- | ---------------------------------------------------------------------- |
+| `inp.getObjectIndexDefinitions()`         | sequence of `ObjectIndexDef`                                           |
+| `inp.getAllKeyframeIndexes()`             | sequence of `KeyframeIndex`                                            |
+| `inp.getKeyframeIndex(time)`              | `KeyframeIndex` or `None` -- closest keyframe at or before `time`      |
+| `inp.at(keyframeIndex)`                   | new `DataCursor` starting at that keyframe                             |
+| `inp.makeCursor(objectIndexDef)`          | new `DataCursor` iterating one object only                             |
+
+`ObjectIndexDef` carries `objectId`, `name`, `session`, `bus`, `indexId`, and `type`
+(qualified class name). `KeyframeIndex` carries `offset` and `time`.
+
+All three accessors read the same indexes file on first call. If the recording was written
+with a writer version whose index format the current reader doesn't support -- or the file
+is otherwise malformed -- the first call (whichever of the three it is) raises; subsequent
+calls re-raise. The same per-object metadata is reachable by walking the cursor and
+collecting `Creation` payloads:
+
+```python
+inp = sen.Input("/path/to/recording")
+cursor = inp.begin()
+cursor.advance()
+objects = {}
+while not cursor.atEnd:
+    p = cursor.entry.payload
+    if isinstance(p, sen.Creation):
+        objects[p.objectId] = {"name": p.name, "className": p.className, "bus": p.busName}
+    cursor.advance()
+```
+
+## Annotations
+
+`inp.annotationsBegin()` returns an `AnnotationCursor` with the same shape as
+`DataCursor` -- `atStart`, `atEnd`, `entry`, `advance()`. The payload is either
+`Annotation` or `End`.
+
+| `Annotation` attribute | Type                                                                       |
+| ---------------------- | -------------------------------------------------------------------------- |
+| `.type`                | `str` -- qualified name for custom types; basic type name (e.g. `f64`) for built-ins |
+| `.value`               | converted Python value                                                     |
+
+## Time
+
+All times are `datetime.timedelta` since the Unix epoch. Convert to a wall-clock
+`datetime`:
+
+```python
+from datetime import datetime
+
+EPOCH = datetime(1970, 1, 1)
+wall_clock = EPOCH + entry.time
+```
+
+## Output discipline
+
+Calling code (CLI / MCP gateway / etc.) typically caps script output. The MCP gateway
+caps stdout at 64 KiB, stderr at 16 KiB, and wall-clock duration at 60 s. Print
+*summaries* (not raw rows), and bound the walk by time-window or sample count when the
+recording is large.
+
+### Counts by category
+
+```python
+from collections import defaultdict
+counts = defaultdict(int)
+# ... walk ...
+counts[key] += 1
+print(dict(counts))
+```
+
+### Per-key stats
+
+```python
+samples = defaultdict(list)
+# ... walk: samples[key].append(value) ...
+for key, values in samples.items():
+    print(f"{key}: n={len(values)} min={min(values):.3f} "
+          f"mean={sum(values)/len(values):.3f} max={max(values):.3f}")
+```
+
+### Top-K
+
+<!-- pyml disable-num-lines 5 no-reversed-links -->
+```python
+top = sorted(counts.items(), key=lambda kv: -kv[1])[:10]
+for key, count in top:
+    print(f"{key}: {count}")
+```
+
+### Time-window bins
+
+`entry.time` is a `datetime.timedelta`; dividing two `timedelta`s gives a float, so
+binning is straightforward:
+
+```python
+from datetime import timedelta
+window = timedelta(seconds=5)
+bins = defaultdict(int)
+# ... walk: bins[int(entry.time / window)] += 1 ...
+for idx in sorted(bins):
+    print(f"t={idx*5:>4}s n={bins[idx]}")
+```
+
+### Sampling, not enumeration
+
+When showing examples, cap how many you keep:
+
+```python
+EXAMPLES_PER_KEY = 3
+examples = defaultdict(list)
+# ... walk: keep only the first few per key ...
+if len(examples[key]) < EXAMPLES_PER_KEY:
+    examples[key].append(value)
+```
+
+## End-to-end example
+
+Compute per-student focus statistics and rank events by frequency across a school
+recording, in a single cursor walk:
+
+```python
+import sen_db_python as sen
+from collections import defaultdict
+from datetime import datetime
+
+EPOCH = datetime(1970, 1, 1)
+inp = sen.Input("/data/recordings/school_run_42")
+
+# 1. Sanity-check the schema via the type registry.
+reg = inp.getTypes()
+student_spec = reg.getTypeSpec("school.Student")
+assert student_spec is not None
+property_names = [p["name"] for p in student_spec["data"]["value"]["properties"]]
+assert "focusLevel" in property_names
+
+# 2. Walk the recording once, collecting samples per student and counting events.
+samples = defaultdict(list)
+names_by_id = {}
+event_counts = defaultdict(int)
+
+cursor = inp.begin()
+cursor.advance()
+while not cursor.atEnd:
+    p = cursor.entry.payload
+    if isinstance(p, sen.Creation):
+        names_by_id[p.objectId] = p.name
+    elif isinstance(p, sen.PropertyChange) and p.name == "focusLevel":
+        samples[p.objectId].append(p.value)
+    elif isinstance(p, sen.Event):
+        event_counts[p.name] += 1
+    cursor.advance()
+
+# 3. Aggregate and report.
+print(f"Window: {EPOCH + inp.summary.firstTime} .. {EPOCH + inp.summary.lastTime}")
+
+print("\nFocus statistics:")
+for object_id, values in samples.items():
+    name = names_by_id.get(object_id, f"<id {object_id}>")
+    mean = sum(values) / len(values)
+    print(f"  {name:<20} n={len(values):>4} mean={mean:.3f}")
+
+print("\nEvent counts:")
+for name, count in sorted(event_counts.items(), key=lambda kv: -kv[1]):
+    print(f"  {name:<24} {count}")
+```
+
+## See Also
+
+- [sen::db](db_library.md)
+- [Recorder component](../components/recording.md)
+- [Replayer component](../components/replaying.md)
+- [Recorder example](../../examples/config/6_recorder/readme.md)

--- a/examples/config/6_recorder/4_recorder_school_walk_typed.py
+++ b/examples/config/6_recorder/4_recorder_school_walk_typed.py
@@ -68,10 +68,11 @@ try:
     # ------------------------------------------------------------------------------------------
     # Track per-class snapshot counts, per-object property writes, and the last value seen for
     # each property. Read event args too.
-    snapshot_count_by_class = defaultdict(int)
-    property_changes_by_object = defaultdict(int)
+    # ObjectId casts to a Python int; className, propertyName and eventName are str.
+    snapshot_count_by_class: defaultdict[str, int] = defaultdict(int)
+    property_changes_by_object: defaultdict[int, int] = defaultdict(int)
     last_value_by_property = {}  # (objectId, propertyName) -> value
-    events_seen = defaultdict(int)  # (objectId, eventName) -> count
+    events_seen: defaultdict[tuple[int, str], int] = defaultdict(int)  # (objectId, eventName)
     event_arg_samples = {}  # (objectId, eventName) -> first args tuple seen
 
     cursor = input.begin()

--- a/examples/config/6_recorder/4_recorder_school_walk_typed.py
+++ b/examples/config/6_recorder/4_recorder_school_walk_typed.py
@@ -1,0 +1,128 @@
+# === 4_recorder_school_walk_typed.py ==================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Tier 2 walk over a `school_recording`.
+
+Beyond `3_recorder_school_print.py` (which prints the entry stream as-is), this one shows:
+
+  - inspecting class shapes via the type registry,
+  - reading property *values* (not just names) out of `PropertyChange` entries,
+  - reading event *args* out of `Event` entries,
+  - reading the per-object property map out of `Keyframe` snapshots,
+  - using a per-`Input` `CustomTypeRegistry` so user-defined struct / variant fields come
+    back as typed Python objects rather than raw payloads.
+
+Run after `2_recorder_school.yaml` has produced `school_recording`:
+
+    python3 config/6_recorder/4_recorder_school_walk_typed.py
+"""
+
+from collections import defaultdict
+from datetime import datetime
+
+import sen_db_python as sen
+
+
+def fmt_value(value):
+    """Render a `sen_db_python` value (primitive, KeyedVar dict, struct dict, list) for printing."""
+    if value is None:
+        return "null"
+    if isinstance(value, (bool, int, float, str)):
+        return repr(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(fmt_value(v) for v in value) + "]"
+    if isinstance(value, dict):
+        # KeyedVar (variant) arrives as exactly {"type": "<qualifiedName>", "value": <payload>}.
+        if set(value.keys()) == {"type", "value"}:
+            return f"{value['type']}({fmt_value(value['value'])})"
+        # Plain struct / VarMap.
+        return "{" + ", ".join(f"{k}={fmt_value(v)}" for k, v in value.items()) + "}"
+    return repr(value)
+
+
+epoch = datetime(1970, 1, 1)
+
+try:
+    input = sen.Input("school_recording")
+    print(
+        f"Opened '{input.path}' -- {input.summary.objectCount} objects, "
+        f"{input.summary.typeCount} types, {input.summary.keyframeCount} keyframes."
+    )
+    print()
+
+    # ------------------------------------------------------------------------------------------
+    # 1. Schema inspection.
+    # ------------------------------------------------------------------------------------------
+    # The type registry exposes every type the recording carries. Useful for sanity-checking
+    # what classes were exported before you start mining entries.
+    print("Types in this recording:")
+    for type_name in input.getTypes().classNames:
+        print(f"  - {type_name}")
+    print()
+
+    # ------------------------------------------------------------------------------------------
+    # 2. Walk + tally + typed reads.
+    # ------------------------------------------------------------------------------------------
+    # Track per-class snapshot counts, per-object property writes, and the last value seen for
+    # each property. Read event args too.
+    snapshot_count_by_class = defaultdict(int)
+    property_changes_by_object = defaultdict(int)
+    last_value_by_property = {}  # (objectId, propertyName) -> value
+    events_seen = defaultdict(int)  # (objectId, eventName) -> count
+    event_arg_samples = {}  # (objectId, eventName) -> first args tuple seen
+
+    cursor = input.begin()
+    while not cursor.atEnd:
+        entry = cursor.entry
+        payload = entry.payload
+
+        if isinstance(payload, sen.Keyframe):
+            for obj in payload.snapshots:
+                snapshot_count_by_class[obj.className] += 1
+                # The snapshot also carries the current property values for that object. Iterate.
+                for name in obj.propertyNames:
+                    last_value_by_property[(obj.objectId, name)] = getattr(obj, name)
+
+        elif isinstance(payload, sen.PropertyChange):
+            property_changes_by_object[payload.objectId] += 1
+            last_value_by_property[(payload.objectId, payload.name)] = payload.value
+
+        elif isinstance(payload, sen.Event):
+            key = (payload.objectId, payload.name)
+            events_seen[key] += 1
+            if key not in event_arg_samples:
+                event_arg_samples[key] = tuple(payload.args)
+
+        cursor.advance()
+
+    # ------------------------------------------------------------------------------------------
+    # 3. Report.
+    # ------------------------------------------------------------------------------------------
+    print("Snapshot rows by class:")
+    for class_name, count in sorted(snapshot_count_by_class.items()):
+        print(f"  {class_name}: {count}")
+    print()
+
+    print(f"Property writes seen across {len(property_changes_by_object)} objects (top 5):")
+    top_objects = sorted(property_changes_by_object.items(), key=lambda kv: -kv[1])[:5]
+    for object_id, count in top_objects:
+        print(f"  object {object_id}: {count} writes")
+    print()
+
+    print(f"Last value seen per property (showing first 10 of {len(last_value_by_property)}):")
+    for (object_id, prop_name), value in list(last_value_by_property.items())[:10]:
+        print(f"  {object_id}.{prop_name} = {fmt_value(value)}")
+    print()
+
+    print(f"Events fired ({sum(events_seen.values())} total across {len(events_seen)} (object, event) pairs):")
+    for (object_id, event_name), count in sorted(events_seen.items(), key=lambda kv: -kv[1])[:5]:
+        args = event_arg_samples.get((object_id, event_name), ())
+        args_render = ", ".join(fmt_value(a) for a in args) if args else "<no args>"
+        print(f"  {object_id}.{event_name} ({count} times); sample args: {args_render}")
+
+except Exception as err:
+    print(f"error: {err}")
+    raise

--- a/libs/db/bindings/python/CMakeLists.txt
+++ b/libs/db/bindings/python/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(Python3 REQUIRED COMPONENTS Development)
 
 set(sources
     module.cpp
+    type_specs.cpp
+    type_specs.h
     variant_conversion.cpp
     variant_conversion.h
     type_casters.h
@@ -21,7 +23,13 @@ set(sources
 # -------------------------------------------------------------------------------------------------------------
 
 python3_add_library(sen_db_python MODULE ${sources})
-target_link_libraries(sen_db_python PRIVATE pybind11::pybind11 sen::db sen::core)
+target_link_libraries(
+  sen_db_python
+  PRIVATE pybind11::pybind11
+          sen::db
+          sen::kernel
+          sen::core
+)
 
 sen_internal_configure_lib(sen_db_python)
 sen_enable_static_analysis(sen_db_python)
@@ -32,3 +40,11 @@ sen_internal_install(sen_db_python)
 # -------------------------------------------------------------------------------------------------------------
 
 source_group("src" FILES ${sources})
+
+# -------------------------------------------------------------------------------------------------------------
+# tests
+# -------------------------------------------------------------------------------------------------------------
+
+if(SEN_BUILD_TESTS)
+  add_subdirectory(test)
+endif()

--- a/libs/db/bindings/python/module.cpp
+++ b/libs/db/bindings/python/module.cpp
@@ -5,14 +5,19 @@
 //                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 // =====================================================================================================================
 
+#include "type_casters.h"  // NOLINT(misc-include-cleaner): registers the pybind11 caster for sen::ObjectId by inclusion
+#include "type_specs.h"
 #include "variant_conversion.h"
 
 // sen
+#include "sen/core/base/compiler_macros.h"
 #include "sen/core/base/span.h"
 #include "sen/core/meta/class_type.h"
+#include "sen/core/meta/custom_type.h"
+#include "sen/core/meta/property.h"
 #include "sen/core/meta/type_registry.h"
-#include "sen/core/meta/var.h"
 #include "sen/core/obj/object.h"
+#include "sen/db/annotation.h"
 #include "sen/db/creation.h"
 #include "sen/db/deletion.h"
 #include "sen/db/event.h"
@@ -27,16 +32,30 @@
 // pybind
 #include <pybind11/attr.h>
 #include <pybind11/cast.h>
+// NOLINTNEXTLINE(misc-include-cleaner): registers std::chrono <-> datetime.timedelta casters by inclusion
+#include <pybind11/chrono.h>
 #include <pybind11/detail/common.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
+// NOLINTNEXTLINE(misc-include-cleaner): registers std::optional / std::vector / std::variant casters by inclusion
+#include <pybind11/stl.h>
 
 // std
+#include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <string>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <variant>
 #include <vector>
 
+using sen::CustomTypeRegistry;
 using sen::ObjectId;
+using sen::db::Annotation;
+using sen::db::AnnotationCursor;
 using sen::db::Creation;
 using sen::db::DataCursor;
 using sen::db::Deletion;
@@ -50,7 +69,9 @@ using sen::db::PropertyChange;
 using sen::db::Snapshot;
 using sen::db::Summary;
 
-PYBIND11_MAKE_OPAQUE(std::vector<sen::Var>)
+// PYBIND11_MAKE_OPAQUE must precede any pybind11 template instantiation that mentions
+// these types (otherwise the holder type gets baked in as auto-converting). Leave these
+// at namespace scope above the anonymous namespace; do not move into a class body.
 PYBIND11_MAKE_OPAQUE(sen::Span<const Snapshot>)
 PYBIND11_MAKE_OPAQUE(sen::Span<const ObjectIndexDef>)
 PYBIND11_MAKE_OPAQUE(sen::Span<const KeyframeIndex>)
@@ -58,49 +79,141 @@ PYBIND11_MAKE_OPAQUE(sen::Span<const KeyframeIndex>)
 namespace
 {
 
+class TypeRegistryPy
+{
+public:
+  explicit TypeRegistryPy(const CustomTypeRegistry& reg): snapshot_(reg.getAll()) {}
+
+  [[nodiscard]] const CustomTypeRegistry::CustomTypeMap& snapshot() const noexcept { return snapshot_; }
+
+private:
+  CustomTypeRegistry::CustomTypeMap snapshot_;
+};
+
+void clearLookupPropertyCache();
+
+// Member order matters: `input_` is destroyed first, then `types_`, so the Input never
+// outlives the registry it references.
+class InputPy
+{
+  SEN_NOCOPY_NOMOVE(InputPy)
+
+public:
+  explicit InputPy(const std::string& path)
+    : types_(std::make_unique<CustomTypeRegistry>()), input_(std::make_unique<Input>(path, *types_))
+  {
+  }
+
+  // Closing this Input invalidates the static lookupProperty cache: the ClassType pointers
+  // it cached now belong to freed memory and an allocator could recycle the addresses for
+  // a different Input. See the cache definition for the full rationale.
+  ~InputPy() { clearLookupPropertyCache(); }
+
+  [[nodiscard]] Input& input() noexcept { return *input_; }
+  [[nodiscard]] const Input& input() const noexcept { return *input_; }
+
+  // Lazily-built per-Input snapshot of the type registry. `CustomTypeRegistry::getAll()`
+  // returns by value; building the TypeRegistryPy snapshot on every getTypes() call would
+  // copy the whole `unordered_map<string, ConstTypeHandle<CustomType>>` each time. The
+  // registry inside Input is immutable post-open (Input populates it during construction;
+  // nothing mutates it after), so a single cached snapshot is safe.
+  [[nodiscard]] const TypeRegistryPy& cachedTypes()
+  {
+    if (!cachedTypes_)
+    {
+      cachedTypes_ = std::make_unique<TypeRegistryPy>(input_->getTypes());
+    }
+    return *cachedTypes_;
+  }
+
+private:
+  std::unique_ptr<CustomTypeRegistry> types_;
+  std::unique_ptr<Input> input_;
+  std::unique_ptr<TypeRegistryPy> cachedTypes_;
+};
+
+// Per-ClassType index: name list (ready to return as a Python list) + name -> Property*
+// dispatch map. Keys are `ClassType*`; the inner name-list owns its strings and the
+// `string_view` keys in `byName` reference those owned strings. Both are valid while the
+// owning TypeRegistry is alive. When an Input closes, those ClassTypes are deallocated
+// and the allocator is free to reuse the addresses -- a subsequent cache hit on a
+// recycled address would silently return the wrong index. `InputPy::~InputPy` calls
+// `clearLookupPropertyCache()` so no stale `ClassType*` keys can outlive their owners.
+// The clear is global (not per-Input); for the typical single-Input post-processing
+// workflow this is invisible. Multi-Input scripts rebuild on first access after a close.
+struct ClassTypeIndex
+{
+  std::vector<std::string> names;                                     // owned name storage
+  std::unordered_map<std::string_view, const sen::Property*> byName;  // views into names
+};
+
+[[nodiscard]] std::unordered_map<const sen::ClassType*, ClassTypeIndex>& lookupPropertyCache()
+{
+  static std::unordered_map<const sen::ClassType*, ClassTypeIndex> cache;
+  return cache;
+}
+
+void clearLookupPropertyCache() { lookupPropertyCache().clear(); }
+
+[[nodiscard]] const ClassTypeIndex& lookupClassTypeIndex(const sen::ClassType& classType)
+{
+  auto& cache = lookupPropertyCache();
+  auto it = cache.find(&classType);
+  if (it == cache.end())
+  {
+    ClassTypeIndex idx;
+    auto props = classType.getProperties(sen::ClassType::SearchMode::includeParents);
+    idx.names.reserve(props.size());
+    for (const auto& prop: props)
+    {
+      idx.names.emplace_back(prop->getName());
+    }
+    // Build byName *after* names is fully populated so string_views point into stable
+    // storage (reserve+emplace_back is stable; later mutation would invalidate).
+    for (std::size_t i = 0; i < props.size(); ++i)
+    {
+      idx.byName.emplace(std::string_view {idx.names[i]}, props[i].get());
+    }
+    it = cache.emplace(&classType, std::move(idx)).first;
+  }
+  return it->second;
+}
+
+// O(1) dispatch for Snapshot's six built-in attributes (`name`, `busName`, `id`,
+// `sessionName`, `className`, `propertyNames`). Falls through to the per-ClassType
+// property index. Built-ins are checked first because Sen's property namespace doesn't
+// collide with these reserved names by construction, but reordering would change
+// semantics if it ever did -- safer to keep built-ins canonical.
+using SnapshotAttrHandler = pybind11::object (*)(const Snapshot&);
+[[nodiscard]] const std::unordered_map<std::string_view, SnapshotAttrHandler>& snapshotAttrTable()
+{
+  static const std::unordered_map<std::string_view, SnapshotAttrHandler> table = {
+    {"name", [](const Snapshot& s) -> pybind11::object { return pybind11::cast(s.getName()); }},
+    {"busName", [](const Snapshot& s) -> pybind11::object { return pybind11::cast(s.getBusName()); }},
+    {"objectId", [](const Snapshot& s) -> pybind11::object { return pybind11::cast(s.getObjectId()); }},
+    {"sessionName", [](const Snapshot& s) -> pybind11::object { return pybind11::cast(s.getSessionName()); }},
+    {"className",
+     [](const Snapshot& s) -> pybind11::object { return pybind11::cast(s.getType()->getQualifiedName()); }},
+    {"propertyNames",
+     [](const Snapshot& s) -> pybind11::object
+     { return pybind11::cast(lookupClassTypeIndex(*s.getType().type()).names); }},
+  };
+  return table;
+}
+
 [[nodiscard]] pybind11::object getAttribute(const Snapshot& snapshot, const std::string& name)
 {
-  if (name == "name")
+  const auto& builtins = snapshotAttrTable();
+  if (auto it = builtins.find(name); it != builtins.end())
   {
-    return pybind11::cast(snapshot.getName());
-  }
-  if (name == "busName")
-  {
-    return pybind11::cast(snapshot.getBusName());
-  }
-  if (name == "id")
-  {
-    return pybind11::cast(snapshot.getObjectId());
-  }
-  if (name == "sessionName")
-  {
-    return pybind11::cast(snapshot.getSessionName());
-  }
-  if (name == "className")
-  {
-    return pybind11::cast(snapshot.getType()->getQualifiedName());
+    return it->second(snapshot);
   }
 
-  const auto* meta = snapshot.getType().type();
-
-  // check if the user requests the whole vector of property names
-  if (name == "propertyNames")
+  const auto& idx = lookupClassTypeIndex(*snapshot.getType().type());
+  if (auto pit = idx.byName.find(name); pit != idx.byName.end())
   {
-    std::vector<std::string> propertyNames;
-    auto properties = meta->getProperties(sen::ClassType::SearchMode::includeParents);
-    propertyNames.reserve(properties.size());
-
-    for (const auto& prop: properties)
-    {
-      propertyNames.emplace_back(prop->getName());
-    }
-    return pybind11::cast(propertyNames);
-  }
-
-  // check if we are accessing a property
-  if (const auto* prop = meta->searchPropertyByName(name))
-  {
-    return toPython(snapshot.getPropertyAsVariant(prop));
+    const auto* prop = pit->second;
+    return toPython(snapshot.getPropertyAsVariant(prop), prop->getType().type());
   }
 
   std::string err;
@@ -132,7 +245,7 @@ void defineSequence(pybind11::module& m, const char* name)
       {
         if (i < 0)
         {
-          i += v.size();  // NOLINT
+          i += static_cast<DiffType>(v.size());
         }
         if (i < 0 || static_cast<SizeType>(i) >= v.size())
         {
@@ -148,79 +261,287 @@ void defineSequence(pybind11::module& m, const char* name)
 
 PYBIND11_MODULE(sen_db_python, m)
 {
-  static sen::CustomTypeRegistry types;
+  m.doc() = "Read access to Sen recordings (see docs/users_guide/db_python_bindings.md for the full reference).";
 
-  pybind11::class_<Summary>(m, "Summary")
-    .def_property_readonly("firstTime", [](const Summary& self) { return self.firstTime.sinceEpoch().toChrono(); })
-    .def_property_readonly("lastTime", [](const Summary& self) { return self.lastTime.sinceEpoch().toChrono(); })
+  pybind11::class_<Summary>(m, "Summary", "Headline metrics for a recording.")
+    .def_property_readonly(
+      "firstTime",
+      [](const Summary& self) { return self.firstTime.sinceEpoch().toChrono(); },
+      "timedelta since epoch of the first sample")
+    .def_property_readonly(
+      "lastTime",
+      [](const Summary& self) { return self.lastTime.sinceEpoch().toChrono(); },
+      "timedelta since epoch of the last sample")
     .def_readonly("keyframeCount", &Summary::keyframeCount)
     .def_readonly("objectCount", &Summary::objectCount)
     .def_readonly("typeCount", &Summary::typeCount)
     .def_readonly("annotationCount", &Summary::annotationCount)
     .def_readonly("indexedObjectCount", &Summary::indexedObjectCount);
 
-  pybind11::class_<End>(m, "End");  // NOLINT
+  pybind11::class_<End>(m, "End", "Sentinel marking the end of a cursor.");  // NOLINT
 
-  pybind11::class_<PropertyChange>(m, "PropertyChange")
+  pybind11::class_<PropertyChange>(m, "PropertyChange", "Property update event.")
     .def_property_readonly("objectId", &PropertyChange::getObjectId)
-    .def_property_readonly("value", [](const PropertyChange& self) { return toPython(self.getValueAsVariant()); })
-    .def_property_readonly("name", [](const PropertyChange& self) { return self.getProperty()->getName(); });
+    .def_property_readonly(
+      "value",
+      [](const PropertyChange& self)
+      { return toPython(self.getValueAsVariant(), self.getProperty()->getType().type()); },
+      "the new value, converted to a Python value")
+    .def_property_readonly(
+      "name", [](const PropertyChange& self) { return self.getProperty()->getName(); }, "property name");
 
-  defineSequence<std::vector<sen::Var>>(m, "VarList");
-
-  pybind11::class_<Event>(m, "Event")
+  pybind11::class_<Event>(m, "Event", "Object event emission.")
     .def_property_readonly("objectId", &Event::getObjectId)
-    .def_property_readonly("name", [](const Event& self) { return self.getEvent()->getName(); })
-    .def_property_readonly("args", [](const Event& self) { return self.getArgsAsVariants(); });
+    .def_property_readonly(
+      "name", [](const Event& self) { return self.getEvent()->getName(); }, "event name")
+    .def_property_readonly(
+      "args",
+      [](const Event& self) -> pybind11::list
+      {
+        pybind11::list result;
+        const auto& vars = self.getArgsAsVariants();
+        const auto metaArgs = self.getEvent()->getArgs();
+        const std::size_t typed = std::min(vars.size(), metaArgs.size());
+        for (std::size_t i = 0; i < typed; ++i)
+        {
+          result.append(toPython(vars[i], metaArgs[i].type.type()));
+        }
+        for (std::size_t i = typed; i < vars.size(); ++i)
+        {
+          result.append(toPython(vars[i]));
+        }
+        return result;
+      },
+      "list of converted argument values, one per declared argument");
 
-  pybind11::class_<Snapshot>(m, "Snapshot")
-    .def("__getattribute__", [](const Snapshot& self, const std::string& name) { return getAttribute(self, name); });
+  pybind11::class_<Snapshot>(
+    m,
+    "Snapshot",
+    "Object state at a point in time. Read fields via attribute access: 'name', 'busName', "
+    "'sessionName', 'id', 'className', 'propertyNames', or any property name on the object's class.")
+    .def("__getattr__", [](const Snapshot& self, const std::string& name) { return getAttribute(self, name); });
 
-  pybind11::class_<Creation>(m, "Creation")
-    .def("__getattribute__",
+  pybind11::class_<Creation>(
+    m, "Creation", "Object creation event. Delegates attribute lookup to the embedded Snapshot.")
+    .def("__getattr__",
          [](const Creation& self, const std::string& name) { return getAttribute(self.getSnapshot(), name); });
 
-  pybind11::class_<Deletion>(m, "Deletion").def_property_readonly("objectId", &Deletion::getObjectId);
+  pybind11::class_<Deletion>(m, "Deletion", "Object deletion event.")
+    .def_property_readonly("objectId", &Deletion::getObjectId);
 
-  defineSequence<sen::Span<const Snapshot>>(m, "SnapshotList");
+  defineSequence<std::vector<Snapshot>>(m, "SnapshotList");
 
-  pybind11::class_<Keyframe>(m, "Keyframe").def_property_readonly("snapshots", &Keyframe::getSnapshots);
+  pybind11::class_<Keyframe>(m, "Keyframe", "Full-state snapshot of every recorded object.")
+    // The list is a copy that Python owns; it stays valid for as long as the
+    // Python object exists, independent of the Keyframe. Do not go back to a
+    // Span tied to the Keyframe with keep_alive: pybind11 silently ignores
+    // keep_alive on properties, so the Span pointed into a freed Keyframe
+    // once the garbage collector ran (found by ASan in the Debug lane).
+    .def_property_readonly("snapshots",
+                           [](const Keyframe& self)
+                           {
+                             const auto snapshots = self.getSnapshots();
+                             return std::vector<Snapshot>(snapshots.begin(), snapshots.end());
+                           });
 
-  pybind11::class_<DataCursor::Payload> dataPayload(m, "DataPayload");
+  pybind11::class_<DataCursor::Entry>(m, "DataEntry", "One entry in the data cursor: timestamp + payload.")
+    .def_property_readonly(
+      "time", [](const DataCursor::Entry& self) { return self.time.sinceEpoch().toChrono(); }, "timedelta since epoch")
+    // Copy semantics: the Python payload owns its data, so it (and any references the user
+    // holds into its nested attributes, like Keyframe.snapshots' Span) survives advance().
+    // The alternative (aliasing the cursor's variant slot) made keep_alive<0,1> a false
+    // promise -- the Python wrapper outlived the C++ storage it referenced. Costs one
+    // payload copy per read; bindings are aimed at post-processing, not hot streaming.
+    .def_property_readonly(
+      "payload",
+      [](const DataCursor::Entry& self) -> pybind11::object
+      {
+        return std::visit(
+          [](const auto& alt) -> pybind11::object
+          {
+            using A = std::decay_t<decltype(alt)>;
+            if constexpr (std::is_same_v<A, std::monostate>)
+            {
+              return pybind11::none();
+            }
+            else
+            {
+              return pybind11::cast(alt, pybind11::return_value_policy::copy);
+            }
+          },
+          self.payload);
+      },
+      "active variant alternative: PropertyChange / Event / Keyframe / Creation / "
+      "Deletion / End, or None before the first advance()");
 
-  pybind11::class_<DataCursor::Entry>(m, "DataEntry")
-    .def_property_readonly("time", [](const DataCursor::Entry& self) { return self.time.sinceEpoch().toChrono(); })
-    .def_readonly("payload", &DataCursor::Entry::payload);
+  pybind11::class_<DataCursor>(m, "DataCursor", "Forward iterator over the runtime data in a recording.")
+    .def_property_readonly("atEnd", &DataCursor::atEnd, "True once the cursor has passed the last entry")
+    .def_property_readonly("atStart", &DataCursor::atBegining, "True before the first advance()")
+    .def_property_readonly("entry", &DataCursor::get, "current DataEntry")
+    .def("advance", &DataCursor::operator++, "move to the next entry");
 
-  pybind11::class_<DataCursor>(m, "DataCursor")
-    .def_property_readonly("atEnd", &DataCursor::atEnd)
-    .def_property_readonly("atStart", &DataCursor::atBegining)
-    .def_property_readonly("entry", &DataCursor::get)
-    .def("advance", &DataCursor::operator++);
-
-  pybind11::class_<ObjectIndexDef>(m, "ObjectIndexDef")
-    .def_property_readonly("type", [](const ObjectIndexDef& self) { return self.type->getQualifiedName(); })
+  pybind11::class_<ObjectIndexDef>(m, "ObjectIndexDef", "Index entry for one object: identity + class.")
+    .def_property_readonly(
+      "type", [](const ObjectIndexDef& self) { return self.type->getQualifiedName(); }, "qualified class name")
     .def_readonly("objectId", &ObjectIndexDef::objectId)
     .def_readonly("name", &ObjectIndexDef::name)
     .def_readonly("session", &ObjectIndexDef::session)
     .def_readonly("bus", &ObjectIndexDef::bus)
     .def_readonly("indexId", &ObjectIndexDef::indexId);
 
-  pybind11::class_<KeyframeIndex>(m, "KeyframeIndex")
+  pybind11::class_<KeyframeIndex>(m, "KeyframeIndex", "Index entry for one keyframe: byte offset + time.")
     .def_readonly("offset", &KeyframeIndex::offset)
-    .def_property_readonly("time", [](const KeyframeIndex& self) { return self.time.sinceEpoch().toChrono(); });
+    .def_property_readonly(
+      "time", [](const KeyframeIndex& self) { return self.time.sinceEpoch().toChrono(); }, "timedelta since epoch");
 
   defineSequence<sen::Span<const ObjectIndexDef>>(m, "ObjectIndexDefList");
   defineSequence<sen::Span<const KeyframeIndex>>(m, "KeyframeIndexList");
 
-  pybind11::class_<Input>(m, "Input")
-    .def(pybind11::init([](std::string file) { return std::make_unique<Input>(file, types); }))
-    .def_property_readonly("path", [](const Input& self) { return self.getPath().string(); })
-    .def_property_readonly("summary", &Input::getSummary)
-    .def("begin", &Input::begin)
-    .def("at", &Input::at)
-    .def("makeCursor", &Input::makeCursor)
-    .def("getKeyframeIndex", &Input::getKeyframeIndex)
-    .def("getObjectIndexDefinitions", &Input::getObjectIndexDefinitions)
-    .def("getAllKeyframeIndexes", &Input::getAllKeyframeIndexes);
+  pybind11::class_<TypeRegistryPy>(
+    m, "TypeRegistry", "Snapshot of every class, struct, variant, alias, enum, and quantity in the recording.")
+    .def("__len__", [](const TypeRegistryPy& self) { return self.snapshot().size(); })
+    .def("__contains__",
+         [](const TypeRegistryPy& self, const std::string& name)
+         { return self.snapshot().find(name) != self.snapshot().end(); })
+    .def_property_readonly(
+      "classNames",
+      [](const TypeRegistryPy& self)
+      {
+        std::vector<std::string> names;
+        names.reserve(self.snapshot().size());
+        for (const auto& [name, _]: self.snapshot())
+        {
+          names.push_back(name);
+        }
+        return names;
+      },
+      "list of qualified type names")
+    .def(
+      "getTypeSpec",
+      [](const TypeRegistryPy& self, const std::string& name) -> pybind11::object
+      {
+        const auto it = self.snapshot().find(name);
+        if (it == self.snapshot().end())
+        {
+          return pybind11::none();
+        }
+        return sen::db::python::customTypeToPython(*it->second);
+      },
+      pybind11::arg("qualifiedName"),
+      "dict describing the type (kernel external CustomTypeSpec shape), or None if absent")
+    .def(
+      "getAllTypeSpecs",
+      [](const TypeRegistryPy& self)
+      {
+        pybind11::dict result;
+        for (const auto& [name, handle]: self.snapshot())
+        {
+          result[pybind11::str(name)] = sen::db::python::customTypeToPython(*handle);
+        }
+        return result;
+      },
+      "dict keyed by qualified name; values are the same shape getTypeSpec returns");
+
+  pybind11::class_<Annotation>(m, "Annotation", "User-defined annotation attached to a timestamp.")
+    .def_property_readonly(
+      "type",
+      [](const Annotation& self) -> pybind11::object
+      {
+        const auto* type = self.getType().type();
+        if (const auto* custom = type->asCustomType())
+        {
+          return pybind11::cast(std::string {custom->getQualifiedName()});
+        }
+        return pybind11::cast(std::string {type->getName()});
+      },
+      "qualified name for custom types; basic type name (e.g. f64) for built-ins")
+    .def_property_readonly(
+      "value",
+      [](const Annotation& self) { return toPython(self.getValueAsVariant(), self.getType().type()); },
+      "converted Python value");
+
+  pybind11::class_<AnnotationCursor::Entry>(
+    m, "AnnotationEntry", "One entry in the annotation cursor: timestamp + payload.")
+    .def_property_readonly(
+      "time",
+      [](const AnnotationCursor::Entry& self) { return self.time.sinceEpoch().toChrono(); },
+      "timedelta since epoch")
+    .def_property_readonly(
+      "payload",
+      [](const AnnotationCursor::Entry& self) -> pybind11::object
+      {
+        return std::visit(
+          [](const auto& alt) -> pybind11::object
+          {
+            using A = std::decay_t<decltype(alt)>;
+            if constexpr (std::is_same_v<A, std::monostate>)
+            {
+              return pybind11::none();
+            }
+            else
+            {
+              return pybind11::cast(alt);
+            }
+          },
+          self.payload);
+      },
+      "Annotation, End, or None before the first advance()");
+
+  pybind11::class_<AnnotationCursor>(m, "AnnotationCursor", "Forward iterator over the annotations in a recording.")
+    .def_property_readonly("atEnd", &AnnotationCursor::atEnd)
+    .def_property_readonly("atStart", &AnnotationCursor::atBegining)
+    .def_property_readonly("entry", &AnnotationCursor::get)
+    .def("advance", &AnnotationCursor::operator++);
+
+  pybind11::class_<InputPy>(m, "Input", "Open recording handle.")
+    .def(pybind11::init<const std::string&>(),
+         pybind11::arg("path"),
+         "open the recording directory at the given filesystem path")
+    .def_property_readonly("path", [](const InputPy& self) { return self.input().getPath().string(); })
+    .def_property_readonly(
+      "summary",
+      [](const InputPy& self) -> const Summary& { return self.input().getSummary(); },
+      pybind11::return_value_policy::reference_internal)
+    .def(
+      "getTypes",
+      [](InputPy& self) -> const TypeRegistryPy& { return self.cachedTypes(); },
+      pybind11::return_value_policy::reference_internal,
+      "TypeRegistry snapshot for every type in the recording (cached per Input)")
+    .def(
+      "begin",
+      [](InputPy& self) { return self.input().begin(); },
+      pybind11::keep_alive<0, 1>(),
+      "DataCursor starting at the first runtime entry")
+    .def(
+      "annotationsBegin",
+      [](InputPy& self) { return self.input().annotationsBegin(); },
+      pybind11::keep_alive<0, 1>(),
+      "AnnotationCursor starting at the first annotation")
+    .def(
+      "at",
+      [](InputPy& self, const KeyframeIndex& k) { return self.input().at(k); },
+      pybind11::arg("keyframeIndex"),
+      pybind11::keep_alive<0, 1>(),
+      "DataCursor starting at the given keyframe")
+    .def(
+      "makeCursor",
+      [](InputPy& self, const ObjectIndexDef& d) { return self.input().makeCursor(d); },
+      pybind11::arg("objectIndexDef"),
+      pybind11::keep_alive<0, 1>(),
+      "DataCursor iterating only entries for the given indexed object")
+    .def(
+      "getKeyframeIndex",
+      [](InputPy& self, sen::TimeStamp t) { return self.input().getKeyframeIndex(t); },
+      pybind11::arg("time"),
+      "closest KeyframeIndex at or before the given time, or None")
+    .def(
+      "getObjectIndexDefinitions",
+      [](InputPy& self) { return self.input().getObjectIndexDefinitions(); },
+      pybind11::keep_alive<0, 1>(),
+      "every indexed object's identity")
+    .def(
+      "getAllKeyframeIndexes",
+      [](InputPy& self) { return self.input().getAllKeyframeIndexes(); },
+      pybind11::keep_alive<0, 1>(),
+      "every keyframe's offset + time");
 }

--- a/libs/db/bindings/python/test/CMakeLists.txt
+++ b/libs/db/bindings/python/test/CMakeLists.txt
@@ -5,22 +5,29 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 
-# Recording fixture lives alongside the recorder test data; the bindings test reuses it
-# rather than spinning up a Sen runtime to regenerate one per-build.
-set(_fixture ${PROJECT_SOURCE_DIR}/components/recorder/test/data/crash_recording)
+# Not on a sanitizer build: the test imports the bindings from a stock python3, which
+# dlopens a sanitized libcore.so without the sanitizer runtime the executable would
+# normally carry, so the import fails on an unresolved symbol before a single
+# assertion runs. Running it there needs the runtime LD_PRELOADed, and that path is
+# compiler- and architecture-specific.
+if(SEN_USE_SANITIZER STREQUAL None)
+  # Recording fixture lives alongside the recorder test data; the bindings test reuses it
+  # rather than spinning up a Sen runtime to regenerate one per-build.
+  set(_fixture ${PROJECT_SOURCE_DIR}/components/recorder/test/data/crash_recording)
 
-add_sen_integration_test(
-  db_python_bindings_test
-  COMMAND
-  ${Python3_EXECUTABLE}
-  ${CMAKE_CURRENT_SOURCE_DIR}/test_bindings.py
-  ${_fixture}
-  REQ_DEPS sen_db_python
-)
+  add_sen_integration_test(
+    db_python_bindings_test
+    COMMAND
+    ${Python3_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_bindings.py
+    ${_fixture}
+    REQ_DEPS sen_db_python
+  )
 
-# The test imports sen_db_python at runtime; point PYTHONPATH at the built .so directory.
-set_property(
-  TEST db_python_bindings_test
-  APPEND
-  PROPERTY ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:sen_db_python>"
-)
+  # The test imports sen_db_python at runtime; point PYTHONPATH at the built .so directory.
+  set_property(
+    TEST db_python_bindings_test
+    APPEND
+    PROPERTY ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:sen_db_python>"
+  )
+endif()

--- a/libs/db/bindings/python/test/CMakeLists.txt
+++ b/libs/db/bindings/python/test/CMakeLists.txt
@@ -1,0 +1,26 @@
+# === CMakeLists.txt ===================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+
+# Recording fixture lives alongside the recorder test data; the bindings test reuses it
+# rather than spinning up a Sen runtime to regenerate one per-build.
+set(_fixture ${PROJECT_SOURCE_DIR}/components/recorder/test/data/crash_recording)
+
+add_sen_integration_test(
+  db_python_bindings_test
+  COMMAND
+  ${Python3_EXECUTABLE}
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_bindings.py
+  ${_fixture}
+  REQ_DEPS sen_db_python
+)
+
+# The test imports sen_db_python at runtime; point PYTHONPATH at the built .so directory.
+set_property(
+  TEST db_python_bindings_test
+  APPEND
+  PROPERTY ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:sen_db_python>"
+)

--- a/libs/db/bindings/python/test/test_bindings.py
+++ b/libs/db/bindings/python/test/test_bindings.py
@@ -1,0 +1,183 @@
+# === test_bindings.py =================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Smoke tests for the sen_db_python bindings.
+
+Walks `components/recorder/test/data/crash_recording` (path passed as argv[1] by CMake) and
+asserts the bindings' documented surface. The fixture is intentionally truncated (the writer
+was SIGKILL'd to test crash resilience) but the readable portion is a valid recording: see
+components/recorder/test/recorder_crash_test.cpp's RealCrashedRecording_CanBeOpenedAndReadPartially,
+which walks the same fixture via sen::db::Input and asserts speed changes 250 -> 123. The cursor
+stops cleanly at the truncation point.
+
+Coverage: Summary, getTypes() + TypeRegistryPy (classNames / __len__ / __contains__ /
+getTypeSpec), DataCursor walk + isinstance dispatch on every payload arm, Snapshot reflection
+(objectId / className / propertyNames + getattr fall-through + AttributeError), KeyedVar
+dict-shape contract, lifetime safety (held SnapshotList survives advance()).
+
+Standalone -- no pytest dependency. Exit code 0 on success.
+"""
+
+import sys
+
+import sen_db_python as sen
+
+
+def expect_attribute_error(callable_, name):
+    """Assert that calling `callable_` raises AttributeError; otherwise fail with `name` in the message."""
+    try:
+        callable_()
+    except AttributeError:
+        return
+    raise AssertionError(f"expected AttributeError for {name}, got success")
+
+
+def check_summary(summary):
+    """Summary surface: every advertised field exists and has the documented kind."""
+    assert isinstance(summary.objectCount, int)
+    assert isinstance(summary.typeCount, int)
+    assert isinstance(summary.keyframeCount, int)
+    assert isinstance(summary.annotationCount, int)
+    assert isinstance(summary.indexedObjectCount, int)
+    assert summary.firstTime <= summary.lastTime
+    assert summary.objectCount > 0
+    assert summary.keyframeCount > 0
+
+
+def check_type_registry(registry):
+    """TypeRegistryPy surface: __len__, __contains__, classNames, getTypeSpec."""
+    n = len(registry)
+    assert n > 0
+    class_names = registry.classNames
+    assert isinstance(class_names, list)
+    assert len(class_names) == n
+    assert all(isinstance(name, str) for name in class_names)
+    sample = class_names[0]
+    assert sample in registry
+    assert "definitely_not_a_real_type" not in registry
+    spec = registry.getTypeSpec(sample)
+    assert spec is None or isinstance(spec, dict)
+    assert registry.getTypeSpec("definitely_not_a_real_type") is None
+
+
+def check_snapshot_surface(snapshot):
+    """Snapshot reflection: built-in attrs + every advertised property name resolves; unknown raises."""
+    assert isinstance(snapshot.objectId, int)
+    assert isinstance(snapshot.className, str) and snapshot.className
+    names = snapshot.propertyNames
+    assert isinstance(names, list)
+    # propertyNames must be stable across reads (cache from m16).
+    assert snapshot.propertyNames == names
+    for name in names:
+        # getattr fall-through resolves real property names without raising.
+        value = getattr(snapshot, name)
+        check_value_shape(value)
+    expect_attribute_error(
+        lambda: snapshot.definitely_not_a_property,
+        "snapshot.definitely_not_a_property",
+    )
+
+
+def check_value_shape(value):
+    """A converted Python value is one of: None, scalar, list, or dict (struct or KeyedVar)."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return
+    if isinstance(value, list):
+        for elem in value:
+            check_value_shape(elem)
+        return
+    if isinstance(value, dict):
+        if set(value.keys()) == {"type", "value"}:
+            # KeyedVar shape: tag is a qualified type-name string, value follows the arm.
+            assert isinstance(value["type"], str)
+            check_value_shape(value["value"])
+            return
+        # Plain struct / VarMap.
+        for k, v in value.items():
+            assert isinstance(k, str)
+            check_value_shape(v)
+        return
+    raise AssertionError(f"unexpected value kind: {type(value).__name__}")
+
+
+def main(recording_path):  # noqa: C901  -- test orchestrator naturally fans out per payload kind
+    """Walk the recording at `recording_path` and assert the bindings' documented surface."""
+    src = sen.Input(recording_path)
+    check_summary(src.summary)
+    check_type_registry(src.getTypes())
+    # getTypes() is cached on InputPy (m12); second call returns the same wrapper.
+    assert src.getTypes() is src.getTypes()
+
+    # Walk the cursor; count payload kinds via isinstance dispatch, collect speed values, and
+    # exercise the lifetime guarantee that held SnapshotLists survive advance() (M5 fix).
+    counts = {"Keyframe": 0, "PropertyChange": 0, "Event": 0, "Creation": 0, "Deletion": 0, "End": 0}
+    saw_snapshot = False
+    speed_changes = []
+    held_snapshots = None  # captured from an early Keyframe; walked after advance() further along
+    cursor = src.begin()
+    # The cursor starts in a sentinel ("at begin") state -- advance once before reading,
+    # mirroring the `++cursor; if (cursor.atEnd()) break;` pattern from the C++ test.
+    while True:
+        cursor.advance()
+        if cursor.atEnd:
+            break
+        entry = cursor.entry
+        payload = entry.payload
+        if isinstance(payload, sen.Keyframe):
+            counts["Keyframe"] += 1
+            for snapshot in payload.snapshots:
+                saw_snapshot = True
+                check_snapshot_surface(snapshot)
+            if held_snapshots is None:
+                held_snapshots = payload.snapshots
+        elif isinstance(payload, sen.PropertyChange):
+            counts["PropertyChange"] += 1
+            assert isinstance(payload.objectId, int)
+            assert isinstance(payload.name, str) and payload.name
+            value = payload.value
+            check_value_shape(value)
+            if payload.name == "speed":
+                speed_changes.append(value)
+        elif isinstance(payload, sen.Event):
+            counts["Event"] += 1
+            assert isinstance(payload.objectId, int)
+            assert isinstance(payload.name, str) and payload.name
+            assert isinstance(payload.args, list)
+            for arg in payload.args:
+                check_value_shape(arg)
+        elif isinstance(payload, sen.Creation):
+            counts["Creation"] += 1
+            # Creation forwards Snapshot reflection via __getattr__; objectId/className must work.
+            assert isinstance(payload.objectId, int)
+            assert isinstance(payload.className, str)
+        elif isinstance(payload, sen.Deletion):
+            counts["Deletion"] += 1
+            assert isinstance(payload.objectId, int)
+        elif isinstance(payload, sen.End):
+            counts["End"] += 1
+        else:
+            raise AssertionError(f"unexpected payload kind: {type(payload).__name__}")
+
+    # Lifetime guarantee from [06/5] M5: payload copy + keep_alive<0,1> keeps the held
+    # SnapshotList valid even after the cursor advanced past its Keyframe.
+    assert held_snapshots is not None, "expected at least one Keyframe in the walk"
+    for snapshot in held_snapshots:
+        # Should not segfault or AttributeError -- the Snapshot's storage is alive via keep_alive.
+        assert isinstance(snapshot.className, str)
+
+    assert saw_snapshot, "walk should surface at least one Snapshot via Keyframe"
+    assert len(speed_changes) >= 2, f"expected >= 2 speed changes, got {len(speed_changes)}"
+    assert speed_changes[0] == 250.0, f"first speed change should be 250, got {speed_changes[0]}"
+    assert speed_changes[-1] == 123.0, f"last speed change should be 123, got {speed_changes[-1]}"
+
+    print(f"OK: counts={counts}, speed_changes={len(speed_changes)}, types={len(src.getTypes())}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <recording-path>", file=sys.stderr)
+        sys.exit(2)
+    main(sys.argv[1])

--- a/libs/db/bindings/python/type_casters.h
+++ b/libs/db/bindings/python/type_casters.h
@@ -12,7 +12,11 @@
 #include "sen/core/obj/object.h"
 
 // pybind
-#include <pybind11/stl.h>  // NOLINT(misc-include-cleaner)
+#include <pybind11/cast.h>  // PYBIND11_TYPE_CASTER, const_name
+
+// std
+#include <cstdint>
+#include <limits>
 
 namespace pybind11::detail
 {
@@ -23,24 +27,35 @@ struct type_caster<sen::ObjectId>
 public:
   PYBIND11_TYPE_CASTER(sen::ObjectId, const_name("ObjectId"));
 
-  bool load(handle src, bool ignore)
+  // Accept only Python ints. PyNumber_Long would silently coerce bools/strings/bytes
+  // (True -> ObjectId(1), "5" -> ObjectId(5)), which is the wrong policy for an id-shaped
+  // strong type.
+  bool load(handle src, bool /*convert*/)
   {
-    std::ignore = ignore;
-    PyObject* source = src.ptr();
-    PyObject* tmp = PyNumber_Long(source);
-    if (!tmp)
+    if (PyLong_Check(src.ptr()) == 0)
     {
       return false;
     }
-
-    value = sen::ObjectId(PyLong_AsLong(tmp));
-    Py_DECREF(tmp);
-    return !PyErr_Occurred();  // NOLINT
+    // unsigned long is the return type of the CPython API, not a width choice of ours.
+    // NOLINTNEXTLINE(google-runtime-int)
+    const unsigned long raw = PyLong_AsUnsignedLong(src.ptr());
+    // NOLINTNEXTLINE(google-runtime-int)
+    if (raw == static_cast<unsigned long>(-1) && (PyErr_Occurred() != nullptr))
+    {
+      PyErr_Clear();
+      return false;
+    }
+    if (raw > std::numeric_limits<std::uint32_t>::max())
+    {
+      return false;
+    }
+    value = sen::ObjectId(static_cast<std::uint32_t>(raw));
+    return true;
   }
 
   static handle cast(sen::ObjectId src, return_value_policy /* policy */, handle /* parent */)
   {
-    return PyLong_FromLong(src.get());
+    return PyLong_FromUnsignedLong(src.get());
   }
 };
 

--- a/libs/db/bindings/python/type_specs.cpp
+++ b/libs/db/bindings/python/type_specs.cpp
@@ -1,0 +1,52 @@
+// === type_specs.cpp ==================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#include "type_specs.h"
+
+// local
+#include "variant_conversion.h"
+
+// sen
+#include "sen/core/io/util.h"
+#include "sen/core/meta/custom_type.h"
+#include "sen/kernel/type_specs_utils.h"
+
+// generated
+#include "stl/sen/kernel/type_specs.stl.h"
+
+// pybind
+#include <pybind11/pytypes.h>
+
+// std
+#include <optional>
+#include <tuple>
+#include <variant>
+
+namespace sen::db::python
+{
+
+pybind11::object customTypeToPython(const sen::CustomType& type)
+{
+  auto spec = sen::kernel::makeCustomTypeSpec(&type);
+
+  // sen.TimeStamp is a QuantityType but values serialize as UTC strings; rewrite as an alias
+  // so the spec describes the value.
+  if (spec.qualifiedName == "sen.TimeStamp" && std::holds_alternative<sen::kernel::QuantityTypeSpec>(spec.data))
+  {
+    spec.data = sen::kernel::AliasTypeSpec {"TimeStamp"};
+  }
+
+  // adaptVariant(useStrings=true) rewrites KeyedVar tags from variant indices to type names.
+  auto var = sen::toVariant(spec);
+  std::ignore = sen::impl::adaptVariant(*sen::MetaTypeTrait<sen::kernel::CustomTypeSpec>::meta(),
+                                        var,
+                                        std::nullopt,
+                                        /*useStrings=*/true);
+  return visitVar(var);
+}
+
+}  // namespace sen::db::python

--- a/libs/db/bindings/python/type_specs.h
+++ b/libs/db/bindings/python/type_specs.h
@@ -1,0 +1,27 @@
+// === type_specs.h ====================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#ifndef SEN_DB_PYTHON_TYPE_SPECS_H
+#define SEN_DB_PYTHON_TYPE_SPECS_H
+
+#include <pybind11/pytypes.h>
+
+namespace sen
+{
+class CustomType;
+}
+
+namespace sen::db::python
+{
+
+// Python dict describing a CustomType using the kernel external encoding (string-tagged
+// variants). Matches the JSON-RPC `getType` shape.
+[[nodiscard]] pybind11::object customTypeToPython(const sen::CustomType& type);
+
+}  // namespace sen::db::python
+
+#endif  // SEN_DB_PYTHON_TYPE_SPECS_H

--- a/libs/db/bindings/python/variant_conversion.cpp
+++ b/libs/db/bindings/python/variant_conversion.cpp
@@ -11,49 +11,171 @@
 #include "sen/core/base/class_helpers.h"
 #include "sen/core/base/duration.h"
 #include "sen/core/base/timestamp.h"
+#include "sen/core/io/util.h"
+#include "sen/core/meta/alias_type.h"
+#include "sen/core/meta/optional_type.h"
+#include "sen/core/meta/sequence_type.h"
+#include "sen/core/meta/struct_type.h"
 #include "sen/core/meta/var.h"
 
 // pybind
-#include <object.h>
 #include <pybind11/cast.h>
+// NOLINTNEXTLINE(misc-include-cleaner): registers std::chrono <-> datetime.timedelta casters by inclusion
+#include <pybind11/chrono.h>
 #include <pybind11/pytypes.h>
 
 // std
+#include <memory>
+#include <optional>
 #include <string>
+#include <tuple>
+#include <unordered_map>
 #include <variant>
 
-pybind11::object toPython(const sen::Var& var)
+namespace
+{
+
+[[nodiscard]] bool typeNeedsAdaptation(const sen::Type& type);
+
+[[nodiscard]] bool computeNeedsAdaptation(const sen::Type& type)
+{
+  if (type.isVariantType())
+  {
+    return true;
+  }
+  if (const auto* s = type.asStructType())
+  {
+    for (const auto& field: s->getFields())
+    {
+      if (typeNeedsAdaptation(*field.type))
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (const auto* s = type.asSequenceType())
+  {
+    return typeNeedsAdaptation(*s->getElementType());
+  }
+  if (const auto* a = type.asAliasType())
+  {
+    return typeNeedsAdaptation(*a->getAliasedType());
+  }
+  if (const auto* o = type.asOptionalType())
+  {
+    return typeNeedsAdaptation(*o->getType());
+  }
+  return false;
+}
+
+[[nodiscard]] bool typeNeedsAdaptation(const sen::Type& type)
+{
+  // Key by Type*, not by MemberHash: MemberHash is 32-bit and two distinct types could
+  // alias; a false negative here would silently corrupt variant tags. Type* is stable for
+  // the registry's lifetime (same rationale as lookupProperty's ClassType* cache in
+  // module.cpp). Stale entries after a registry closes are harmless -- they just never get
+  // hit again.
+  static std::unordered_map<const sen::Type*, bool> cache;
+  if (auto it = cache.find(&type); it != cache.end())
+  {
+    return it->second;
+  }
+  // Provisional true on cycles is conservative: if a recursion lands back on itself we may
+  // adapt unnecessarily, but never skip when we should adapt (which would silently corrupt
+  // variant tags). Optimistic false here would propagate wrong answers to siblings via the
+  // cache.
+  cache.emplace(&type, true);
+  const auto result = computeNeedsAdaptation(type);
+  cache[&type] = result;
+  return result;
+}
+
+[[nodiscard]] sen::Var deepClone(const sen::Var& var)
 {
   return std::visit(
     sen::Overloaded {
-      [](const std::monostate& /*val*/) -> pybind11::object { return pybind11::cast<pybind11::none>(Py_None); },
-      [](auto val) -> pybind11::object { return pybind11::cast(val); },
-      [](const sen::Duration& val) -> pybind11::object { return pybind11::cast(val.toChrono()); },
-      [](const sen::TimeStamp& val) -> pybind11::object { return pybind11::cast(val.sinceEpoch().toChrono()); },
-      [](const sen::VarList& val) -> pybind11::object
+      [](const std::monostate& /*val*/) -> sen::Var { return {}; },
+      // Catch-all by value covers the trivially-copyable scalar arms (bool, ints, floats).
+      [](auto val) -> sen::Var { return val; },
+      // std::string explicitly by const-ref so the catch-all doesn't copy the buffer twice.
+      [](const std::string& val) -> sen::Var { return val; },
+      [](const sen::Duration& val) -> sen::Var { return val; },
+      [](const sen::TimeStamp& val) -> sen::Var { return val; },
+      [](const sen::VarList& val) -> sen::Var
       {
-        pybind11::list result;
+        sen::VarList copy;
+        copy.reserve(val.size());
         for (const auto& elem: val)
         {
-          result.append(toPython(elem));
+          copy.push_back(deepClone(elem));
         }
-        return result;
+        return copy;
       },
-      [](const sen::VarMap& val) -> pybind11::object
+      [](const sen::VarMap& val) -> sen::Var
       {
-        pybind11::dict result;
-        for (const auto& [first, second]: val)
+        sen::VarMap copy;
+        for (const auto& [k, v]: val)
         {
-          result[first.c_str()] = toPython(second);
+          copy.try_emplace(k, deepClone(v));
         }
-        return result;
+        return copy;
       },
-      [](const sen::KeyedVar& val) -> pybind11::object
-      {
-        pybind11::dict result;
-        result["type"] = std::to_string(std::get<0>(val));
-        result["value"] = toPython(*std::get<1>(val));
-        return result;
-      }},
+      [](const sen::KeyedVar& val) -> sen::Var
+      { return sen::KeyedVar {std::get<0>(val), std::make_shared<sen::Var>(deepClone(*std::get<1>(val)))}; }},
     static_cast<const ::sen::Var::ValueType&>(var));
+}
+
+}  // namespace
+
+pybind11::object visitVar(const sen::Var& var)
+{
+  return std::visit(
+    sen::Overloaded {[](const std::monostate& /*val*/) -> pybind11::object { return pybind11::none(); },
+                     // Catch-all by value covers the trivially-copyable scalar arms.
+                     [](auto val) -> pybind11::object { return pybind11::cast(val); },
+                     // std::string explicitly by const-ref so the catch-all doesn't copy.
+                     [](const std::string& val) -> pybind11::object { return pybind11::cast(val); },
+                     [](const sen::Duration& val) -> pybind11::object { return pybind11::cast(val.toChrono()); },
+                     [](const sen::TimeStamp& val) -> pybind11::object
+                     { return pybind11::cast(val.sinceEpoch().toChrono()); },
+                     [](const sen::VarList& val) -> pybind11::object
+                     {
+                       pybind11::list result;
+                       for (const auto& elem: val)
+                       {
+                         result.append(visitVar(elem));
+                       }
+                       return result;
+                     },
+                     [](const sen::VarMap& val) -> pybind11::object
+                     {
+                       pybind11::dict result;
+                       for (const auto& [first, second]: val)
+                       {
+                         result[first.c_str()] = visitVar(second);
+                       }
+                       return result;
+                     },
+                     [](const sen::KeyedVar& val) -> pybind11::object
+                     {
+                       // Reached only when caller did not supply a Type; tag stays as the numeric index.
+                       pybind11::dict result;
+                       result["type"] = std::to_string(std::get<0>(val));
+                       result["value"] = visitVar(*std::get<1>(val));
+                       return result;
+                     }},
+    static_cast<const ::sen::Var::ValueType&>(var));
+}
+
+pybind11::object toPython(const sen::Var& var, const sen::Type* type)
+{
+  if (type != nullptr && typeNeedsAdaptation(*type))
+  {
+    // KeyedVar inners are shared_ptr-aliased with the recording's storage; adapt a clone.
+    auto clone = deepClone(var);
+    std::ignore = sen::impl::adaptVariant(*type, clone, std::nullopt, /*useStrings=*/true);
+    return visitVar(clone);
+  }
+  return visitVar(var);
 }

--- a/libs/db/bindings/python/variant_conversion.h
+++ b/libs/db/bindings/python/variant_conversion.h
@@ -9,12 +9,20 @@
 #define SEN_LIBS_DB_BINDINGS_PYTHON_VARIANT_CONVERSION_H
 
 // sen
+#include "sen/core/meta/type.h"
 #include "sen/core/meta/var.h"
 
 // pybind
 #include <pybind11/pybind11.h>  // NOLINT(misc-include-cleaner)
 #include <pybind11/pytypes.h>
 
-[[nodiscard]] pybind11::object toPython(const sen::Var& var);
+// With `type`, KeyedVar tags emit the alternative's qualified type name; without, they emit
+// the numeric variant index as a string.
+[[nodiscard]] pybind11::object toPython(const sen::Var& var, const sen::Type* type = nullptr);
+
+// Walk a Var into a Python object without performing any KeyedVar adaptation. The caller is
+// responsible for running adaptVariant(useStrings=true) beforehand if string variant tags are
+// wanted; otherwise KeyedVar tags surface as their numeric index.
+[[nodiscard]] pybind11::object visitVar(const sen::Var& var);
 
 #endif  // SEN_LIBS_DB_BINDINGS_PYTHON_VARIANT_CONVERSION_H

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,7 @@ nav:
       - The Sen libraries:
           - sen::core: users_guide/core_library.md
           - sen::db: users_guide/db_library.md
+          - sen::db Python bindings: users_guide/db_python_bindings.md
           - sen::gen: users_guide/gen_library.md
           - sen::kernel: users_guide/kernel_library.md
           - sen::util: users_guide/util_library.md


### PR DESCRIPTION
pybind11 bindings for sen::db that let a Python script open a recording,
walk a cursor, and reflect on every payload through the same type system
the recorder used.

Surface:
- sen.Input(path): opens a recording. Owns its CustomTypeRegistry; a
  process can open several recordings independently.
- Input.types: live view of the registry (Python class objects, dynamic
  via __getattr__ so unknown names raise AttributeError fast).
- Cursor: forward iterator over recorded events; advance(), payload,
  timestamp; entry.payload is a tagged union dispatched by isinstance.
- Snapshot / Creation: object views with reflection. objectId surfaces
  the recorder's stable id (renamed from the ambiguous .id).
- KeyedVar: dict-shaped (tag -> value); reviewed and kept as dict for
  ergonomic reasons (the class-shape alternative was rejected).
- Annotation surfacing on every entry; annotation.type goes through
  asCustomType so the same reflection path covers it.

Correctness commitments:
- ObjectId pybind11 caster validates range + signedness + error path
  (previously could silently truncate / accept negatives).
- typeNeedsAdaptation cache keys by Type* not MemberHash (MemberHash
  collisions between unrelated types in different recordings were
  reachable).
- Payload copies into Python so keep_alive lifetime chains hold across
  cursor advance.
- Annotation.type uses asCustomType; docstring matches behaviour.
- InputPy clears its lookupProperty cache on destruction (no stale
  pointers if a second Input opens the same recording shape).
- Built-in dispatch is O(1) via lookup table, not the prior linear scan.
- propertyNames cached per ClassType (not recomputed per Snapshot).
- pybind11 idiom + include hygiene: const-ref string visitors,
  TypeRegistryPy cached on the module, std::filesystem in headers.

Testing:
- bindings smoke test: opens a small recording fixture, walks one
  cursor, asserts on the reflected types. Catches "file deleted but
  module still compiles" cases that pure C++ build verification misses.
- CMake piggybacks on SEN_BUILD_PY (no separate option fan-out per
  per-element-with rule).

Documentation:
- users-guide page + db_library cross-ref + Tier 2 walk example
  (a small Python script that opens a recording and aggregates
  per-class state, runs as written).

