### PR TITLE
chore: fix all clang-tidy findings in the existing code

### DIFF
--- a/apps/cli_package/init_package.cpp
+++ b/apps/cli_package/init_package.cpp
@@ -23,6 +23,7 @@
 #include <inja/json.hpp>
 
 // std
+#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <iostream>

--- a/components/ether/src/ether_transport.cpp
+++ b/components/ether/src/ether_transport.cpp
@@ -36,9 +36,7 @@
 
 // std
 #include <algorithm>
-#include <atomic>
 #include <chrono>
-#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>

--- a/components/ether/src/tcp_beam_tracker.cpp
+++ b/components/ether/src/tcp_beam_tracker.cpp
@@ -35,7 +35,6 @@
 #include <stdexcept>
 #include <string>
 #include <system_error>
-#include <tuple>
 #include <utility>
 #include <vector>
 

--- a/components/rest/src/component.cpp
+++ b/components/rest/src/component.cpp
@@ -8,7 +8,6 @@
 #include "component.h"
 
 // component
-#include "base_router.h"
 #include "http_server.h"
 #include "sen_router.h"
 #include "utils.h"
@@ -34,7 +33,6 @@
 #include <asio/ip/tcp.hpp>
 
 // std
-#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/components/rest/src/http_server.cpp
+++ b/components/rest/src/http_server.cpp
@@ -16,19 +16,14 @@
 #include <asio/error_code.hpp>
 #include <asio/ip/tcp.hpp>
 #include <asio/socket_base.hpp>
-#include <asio/system_error.hpp>
-#include <asio/thread_pool.hpp>
 
 // sen
 #include "sen/core/base/assert.h"
 
 // std
 #include <chrono>
-#include <cstdint>
-#include <functional>
 #include <memory>
 #include <system_error>
-#include <thread>
 #include <tuple>
 #include <utility>
 

--- a/components/rest/src/http_session.cpp
+++ b/components/rest/src/http_session.cpp
@@ -25,7 +25,6 @@
 #include <asio/io_context.hpp>
 #include <asio/ip/tcp.hpp>
 #include <asio/post.hpp>
-#include <asio/thread_pool.hpp>
 
 // std
 #include <cstddef>

--- a/components/rest/src/notification_loop.cpp
+++ b/components/rest/src/notification_loop.cpp
@@ -8,7 +8,6 @@
 #include "notification_loop.h"
 
 // component
-#include "client_session.h"
 #include "http_session.h"
 #include "notifications.h"
 #include "utils.h"

--- a/components/rest/src/sen_router.cpp
+++ b/components/rest/src/sen_router.cpp
@@ -15,7 +15,6 @@
 #include "json_response.h"
 #include "jwt.h"
 #include "locators.h"
-#include "notification_loop.h"
 #include "object_interests_manager.h"
 #include "response_adapter.h"
 #include "types.h"
@@ -40,7 +39,6 @@
 #include "sen/kernel/type_specs_utils.h"
 
 // asio
-#include <asio/buffer.hpp>
 #include <asio/ip/tcp.hpp>
 #include <asio/write.hpp>  // NOLINT(misc-include-cleaner)
 
@@ -57,6 +55,7 @@
 #include <unordered_map>
 #include <utility>
 #include <variant>
+#include <vector>
 
 // json
 #include "nlohmann/json.hpp"

--- a/components/rest/test/rest_e2e_fixture.cpp
+++ b/components/rest/test/rest_e2e_fixture.cpp
@@ -15,7 +15,6 @@
 #include <asio/connect.hpp>  // NOLINT(misc-include-cleaner)
 #include <asio/error.hpp>
 #include <asio/error_code.hpp>
-#include <asio/io_context.hpp>
 #include <asio/ip/tcp.hpp>
 #include <asio/system_error.hpp>
 #include <asio/write.hpp>  // NOLINT(misc-include-cleaner)

--- a/components/shell/src/terminal_lib/posix_terminal.cpp
+++ b/components/shell/src/terminal_lib/posix_terminal.cpp
@@ -21,7 +21,6 @@
 #include <stdio.h>  // NOLINT
 #include <sys/ioctl.h>
 #include <sys/select.h>
-#include <sys/types.h>
 #include <sys/uio.h>
 #include <termios.h>
 #include <unistd.h>

--- a/components/shell/src/terminal_lib/remote_terminal_client.cpp
+++ b/components/shell/src/terminal_lib/remote_terminal_client.cpp
@@ -169,6 +169,7 @@ void RemoteTerminalClient::run(const std::string& host, const std::string& port)
 
     // connect
     asio::error_code ec;
+    // NOLINTNEXTLINE(misc-include-cleaner): asio/connect.hpp is included; the check cannot map the symbol
     asio::connect(socket, results, ec);
 
     if (!ec)

--- a/components/shell/src/terminal_lib/remote_terminal_server.cpp
+++ b/components/shell/src/terminal_lib/remote_terminal_server.cpp
@@ -21,6 +21,7 @@
 #include "stl/remote_shell.stl.h"
 
 // asio
+
 #include <asio/buffer.hpp>
 #include <asio/error_code.hpp>
 #include <asio/ip/tcp.hpp>
@@ -29,6 +30,7 @@
 #include <asio/write.hpp>  // NOLINT(misc-include-cleaner)
 
 // std
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -182,6 +184,7 @@ void RemoteTerminal::sendMsg(T&& msg)
   }
 
   asio::error_code ec;
+  // NOLINTNEXTLINE(misc-include-cleaner): asio/write.hpp is included; the check cannot map the symbol
   asio::write(socket_, asio::buffer(outBuffer_), ec);
 
   if (ec)

--- a/libs/core/include/sen/core/base/iterator_adapters.h
+++ b/libs/core/include/sen/core/base/iterator_adapters.h
@@ -98,8 +98,14 @@ public:
   {
   }
 
-  IteratorType begin() const noexcept(std::is_nothrow_copy_constructible_v<IteratorType>) { return beginIterator_; }
-  IteratorType end() const noexcept(std::is_nothrow_copy_constructible_v<IteratorType>) { return endIterator_; }
+  [[nodiscard]] IteratorType begin() const noexcept(std::is_nothrow_copy_constructible_v<IteratorType>)
+  {
+    return beginIterator_;
+  }
+  [[nodiscard]] IteratorType end() const noexcept(std::is_nothrow_copy_constructible_v<IteratorType>)
+  {
+    return endIterator_;
+  }
 
 private:
   LockType<MutexType> lock_;

--- a/libs/core/include/sen/core/base/result.h
+++ b/libs/core/include/sen/core/base/result.h
@@ -270,6 +270,9 @@ public:  // access
   /// Extracts the value of the correct result, or
   /// terminates the program with a given error message.
   template <typename U = T>
+  // resultExpect terminates the program when the state is wrong, so the std::get
+  // below cannot actually throw.
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   [[nodiscard]] const impl::NonVoidT<U>& expect(std::string_view errorMsg = {}) const noexcept
   {
     impl::resultExpect(isOk(), errorMsg);

--- a/libs/core/include/sen/core/base/uuid.h
+++ b/libs/core/include/sen/core/base/uuid.h
@@ -141,24 +141,24 @@ inline Uuid::Uuid(Span<const uint8_t> bytes) noexcept
 constexpr uint32_t Uuid::getHash32() const noexcept
 {
   uint64_t h = getHash();
-  return static_cast<uint32_t>(h ^ (h >> 32));
+  return static_cast<uint32_t>(h ^ (h >> 32U));
 }
 
 constexpr UuidVariant Uuid::getVariant() const noexcept
 {
-  auto b = static_cast<uint8_t>(lo_ >> 56);
+  auto b = static_cast<uint8_t>(lo_ >> 56U);
 
-  if ((b & 0x80) == 0)
+  if ((b & 0x80U) == 0U)
   {
     return UuidVariant::ncs;
   }
 
-  if ((b & 0xC0) == 0x80)
+  if ((b & 0xC0U) == 0x80U)
   {
     return UuidVariant::rfc;
   }
 
-  if ((b & 0xE0) == 0xC0)
+  if ((b & 0xE0U) == 0xC0U)
   {
     return UuidVariant::microsoft;
   }
@@ -168,7 +168,7 @@ constexpr UuidVariant Uuid::getVariant() const noexcept
 
 constexpr UuidVersion Uuid::getVersion() const noexcept
 {
-  uint8_t v = static_cast<uint8_t>(hi_ >> 12) & 0xF;
+  uint8_t v = static_cast<uint8_t>(hi_ >> 12U) & 0xFU;
 
   switch (v)
   {

--- a/libs/core/include/sen/core/meta/native_types.h
+++ b/libs/core/include/sen/core/meta/native_types.h
@@ -121,6 +121,11 @@ public:
 
 /// @cond
 
+// The generated get() functions are noexcept although the first call constructs a
+// static instance, which can throw only on allocation failure; terminating then is
+// intended, so the escape warning is waived for this block.
+// NOLINTBEGIN(bugprone-exception-escape)
+
 // integral numbers
 SEN_INTEGRAL_TYPE(UInt8Type, uint8_t, u8, "8 bit unsigned integer", readUInt8, writeUInt8);
 SEN_INTEGRAL_TYPE(Int16Type, int16_t, i16, "16 bit signed integer", readInt16, writeInt16);
@@ -137,6 +142,8 @@ SEN_REAL_TYPE(Float64Type, float64_t, f64, "64 bit floating point number", readF
 // other native types
 SEN_BUILTIN_NATIVE_TYPE(BoolType, bool, "bool", "classic boolean", readBool, writeBool, true);
 SEN_BUILTIN_NATIVE_TYPE(StringType, std::string, "string", "unbounded string", readString, writeString, false);
+
+// NOLINTEND(bugprone-exception-escape)
 
 /// @endcond
 

--- a/libs/core/include/sen/core/meta/quantity_type.h
+++ b/libs/core/include/sen/core/meta/quantity_type.h
@@ -94,7 +94,7 @@ public:
   [[nodiscard]] std::optional<const Unit*> getUnit() const noexcept;
 
   /// Gets the unit of the measurement, failing if no unit was there.
-  [[nodiscard]] const Unit& getUnit(sen::Unit::EnsureTag) const;
+  [[nodiscard]] const Unit& getUnit(sen::Unit::EnsureTag /*ensure*/) const;
 
   /// The maximum value, if any.
   [[nodiscard]] std::optional<float64_t> getMaxValue() const noexcept;

--- a/libs/core/include/sen/core/meta/type.h
+++ b/libs/core/include/sen/core/meta/type.h
@@ -228,7 +228,7 @@ public:
     return std::get<RawPtrType>(type_);
   }
 
-  const SenTypeType* type() const
+  [[nodiscard]] const SenTypeType* type() const
   {
     if (std::holds_alternative<ManagedPtrType>(type_))
     {

--- a/libs/core/include/sen/core/meta/var.h
+++ b/libs/core/include/sen/core/meta/var.h
@@ -243,7 +243,7 @@ private:
   [[nodiscard]] bool isEqual(const Var& rhs) const noexcept;
 
 private:
-  ValueType value_ {};
+  ValueType value_;
 };
 
 template <typename T>

--- a/libs/core/include/sen/core/obj/detail/event_buffer.h
+++ b/libs/core/include/sen/core/obj/detail/event_buffer.h
@@ -156,7 +156,7 @@ private:
     CallbackEntry(ConnId id, CallbackStorageType callback): id_(id), callback_(std::move(callback)) {}
 
     [[nodiscard]] ConnId getConnectionId() const noexcept { return id_; }
-    const CallbackStorageType& getCallback() const noexcept { return callback_; }
+    [[nodiscard]] const CallbackStorageType& getCallback() const noexcept { return callback_; }
 
   private:
     ConnId id_;

--- a/libs/core/include/sen/core/obj/object_list.h
+++ b/libs/core/include/sen/core/obj/object_list.h
@@ -44,12 +44,17 @@ public:  // types
   using TypedObjectList = std::list<T*>;
   using UntypedObjectList = std::list<std::shared_ptr<Object>>;
 
+  // Plain aggregate carrying the four range endpoints; the member functions are only
+  // range-for sugar over them, so the public members are the point of the type.
+  // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
   struct Iterators
   {
     typename TypedObjectList::iterator typedBegin;
     typename TypedObjectList::iterator typedEnd;
     typename UntypedObjectList::iterator untypedBegin;
     typename UntypedObjectList::iterator untypedEnd;
+
+    // NOLINTEND(misc-non-private-member-variables-in-classes)
 
     /// Range-for support iterates over typed objects.
     [[nodiscard]] typename TypedObjectList::iterator begin() const { return typedBegin; }

--- a/libs/core/src/base/assert.cpp
+++ b/libs/core/src/base/assert.cpp
@@ -13,7 +13,9 @@
 #include "sen/core/base/source_location.h"
 
 // cpptrace
-#include "cpptrace/cpptrace.hpp"
+#include "cpptrace/basic.hpp"
+#include "cpptrace/exceptions.hpp"
+#include "cpptrace/utils.hpp"
 
 // std
 #include <csignal>

--- a/libs/core/src/base/hash32.cpp
+++ b/libs/core/src/base/hash32.cpp
@@ -53,7 +53,6 @@ constexpr uint64_t adlerMod = 65521;
 // Compression
 uchar* stbOutPtr;
 FILE* stbOutFile;
-uint stbOutBytes;
 unsigned int stbRunningAdler;
 
 #define STB_IN2(x)          ((i[x] << 8) + i[(x) + 1])                                      // NOLINT
@@ -310,11 +309,7 @@ unsigned int stbMatchLen(uchar* m1, uchar* m2, uint maxlen)  // NOLINT
   return i;
 }
 
-void stbWriteFunc(unsigned char v)
-{
-  fputc(v, stbOutFile);
-  ++stbOutBytes;
-}
+void stbWriteFunc(unsigned char v) { fputc(v, stbOutFile); }
 
 void stbOut2(uint v)
 {

--- a/libs/core/src/base/uuid.cpp
+++ b/libs/core/src/base/uuid.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <ostream>
 #include <string>
+#include <string_view>
 
 // --------------------------------------------------------------------------------------------------------------------------
 // UUID format https://tools.ietf.org/html/rfc4122

--- a/libs/core/src/meta/alias_type.cpp
+++ b/libs/core/src/meta/alias_type.cpp
@@ -11,12 +11,10 @@
 #include "utils.h"
 
 // sen
-#include "sen/core/base/assert.h"
 #include "sen/core/meta/custom_type.h"
 #include "sen/core/meta/type.h"
 
 // std
-#include <memory>
 #include <string_view>
 #include <tuple>
 #include <utility>

--- a/libs/core/src/meta/class_type.cpp
+++ b/libs/core/src/meta/class_type.cpp
@@ -22,6 +22,7 @@
 #include "sen/core/meta/method.h"
 #include "sen/core/meta/property.h"
 #include "sen/core/meta/type.h"
+#include "sen/core/obj/native_object.h"
 
 // std
 #include <algorithm>

--- a/libs/core/src/meta/enum_type.cpp
+++ b/libs/core/src/meta/enum_type.cpp
@@ -20,7 +20,6 @@
 // std
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -52,6 +51,9 @@ EnumType::EnumType(EnumSpec spec, Private notUsable): CustomType(impl::hash<Enum
   }
 }
 
+// The handle is built from a valid spec and always holds an alternative, so the
+// std::get inside the dereference cannot actually throw.
+// NOLINTNEXTLINE(bugprone-exception-escape)
 const IntegralType& EnumType::getStorageType() const noexcept { return *spec_.storageType; }
 
 Span<const Enumerator> EnumType::getEnums() const noexcept { return makeConstSpan(spec_.enums); }

--- a/libs/core/src/meta/optional_type.cpp
+++ b/libs/core/src/meta/optional_type.cpp
@@ -11,12 +11,10 @@
 #include "utils.h"
 
 // sen
-#include "sen/core/base/assert.h"
 #include "sen/core/meta/custom_type.h"
 #include "sen/core/meta/type.h"
 
 // std
-#include <memory>
 #include <string_view>
 #include <tuple>
 #include <utility>

--- a/libs/core/src/meta/quantity_type.cpp
+++ b/libs/core/src/meta/quantity_type.cpp
@@ -22,7 +22,6 @@
 
 // std
 #include <limits>
-#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>

--- a/libs/core/src/meta/sequence_type.cpp
+++ b/libs/core/src/meta/sequence_type.cpp
@@ -11,13 +11,11 @@
 #include "utils.h"
 
 // sen
-#include "sen/core/base/assert.h"
 #include "sen/core/meta/custom_type.h"
 #include "sen/core/meta/type.h"
 
 // std
 #include <cstddef>
-#include <memory>
 #include <optional>
 #include <string_view>
 #include <tuple>

--- a/libs/core/src/meta/struct_type.cpp
+++ b/libs/core/src/meta/struct_type.cpp
@@ -18,7 +18,6 @@
 
 // std
 #include <cstddef>
-#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>

--- a/libs/core/src/meta/time_types.cpp
+++ b/libs/core/src/meta/time_types.cpp
@@ -16,7 +16,6 @@
 #include "sen/core/meta/type.h"
 
 // std
-#include <memory>
 #include <optional>
 #include <ostream>
 

--- a/libs/core/src/meta/variant_type.cpp
+++ b/libs/core/src/meta/variant_type.cpp
@@ -19,7 +19,6 @@
 // std
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <string_view>
 #include <tuple>

--- a/libs/core/test/lang/parser_test.cpp
+++ b/libs/core/test/lang/parser_test.cpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <tuple>
 #include <variant>
 #include <vector>
 

--- a/libs/core/test/meta/alias_type_test.cpp
+++ b/libs/core/test/meta/alias_type_test.cpp
@@ -17,7 +17,6 @@
 
 // std
 #include <exception>
-#include <memory>
 #include <tuple>
 #include <vector>
 

--- a/libs/core/test/meta/variant_traits_test.cpp
+++ b/libs/core/test/meta/variant_traits_test.cpp
@@ -27,6 +27,7 @@
 // std
 #include <array>
 #include <cstdint>
+#include <stdexcept>
 #include <tuple>
 #include <variant>
 #include <vector>

--- a/libs/db/src/util.cpp
+++ b/libs/db/src/util.cpp
@@ -19,6 +19,7 @@
 #include "sen/core/meta/type.h"
 
 // spdlog
+#include <spdlog/logger.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 // lz4
@@ -28,9 +29,10 @@
 // NOLINTNEXTLINE(hicpp-deprecated-headers,modernize-deprecated-headers)
 #include "stdio.h"  // fwrite_unlocked is not part of <stdio>
 
-// std
-#include <spdlog/logger.h>
+// generated
+#include "stl/sen/kernel/basic_types.stl.h"
 
+// std
 #include <cerrno>
 #include <cstddef>
 #include <cstdint>

--- a/libs/db/test/creation_test.cpp
+++ b/libs/db/test/creation_test.cpp
@@ -13,7 +13,6 @@
 #include "sen/kernel/component.h"
 #include "sen/kernel/component_api.h"
 #include "sen/kernel/test_kernel.h"
-#include "stl/sen/db/basic_types.stl.h"
 
 // google test
 #include <gtest/gtest.h>

--- a/libs/db/test/output_test.cpp
+++ b/libs/db/test/output_test.cpp
@@ -14,12 +14,14 @@
 #include "sen/db/input.h"
 #include "sen/db/output.h"
 #include "sen/kernel/test_kernel.h"
+#include "stl/sen/db/basic_types.stl.h"
 #include "stl/sen/kernel/basic_types.stl.h"
 
 // google test
 #include <gtest/gtest.h>
 
 // std
+#include <filesystem>
 #include <utility>
 
 namespace sen::db::test

--- a/libs/db/test/property_change_test.cpp
+++ b/libs/db/test/property_change_test.cpp
@@ -21,7 +21,6 @@
 #include <gtest/gtest.h>
 
 // std
-#include <memory>
 #include <utility>
 #include <variant>
 

--- a/libs/kernel/include/sen/kernel/kernel_config.h
+++ b/libs/kernel/include/sen/kernel/kernel_config.h
@@ -119,7 +119,7 @@ private:
   std::vector<ComponentToLoad> componentsToLoad_;
   std::vector<PipelineToLoad> pipelinesToLoad_;
   KernelParams params_ {};
-  std::filesystem::path path_ {};
+  std::filesystem::path path_;
 };
 
 }  // namespace sen::kernel

--- a/libs/kernel/src/bus/bus.cpp
+++ b/libs/kernel/src/bus/bus.cpp
@@ -27,7 +27,6 @@
 #include "sen/core/meta/type.h"
 #include "sen/core/meta/type_registry.h"
 #include "sen/core/obj/interest.h"
-#include "sen/core/obj/object.h"
 #include "sen/core/obj/object_provider.h"
 #include "sen/kernel/transport.h"
 #include "sen/kernel/type_specs_utils.h"
@@ -40,11 +39,9 @@
 
 // std
 #include <algorithm>
-#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <string>
 #include <string_view>

--- a/libs/kernel/src/bus/remote_participant.cpp
+++ b/libs/kernel/src/bus/remote_participant.cpp
@@ -12,7 +12,6 @@
 
 // bus
 #include "bus/bus.h"
-#include "bus/containers.h"
 #include "bus/generic_remote_object.h"
 #include "bus/local_participant.h"
 #include "bus/remote_interest_manager.h"

--- a/libs/kernel/src/crash_reporter.cpp
+++ b/libs/kernel/src/crash_reporter.cpp
@@ -34,7 +34,7 @@
 
 // cpptrace
 #include "cpptrace/basic.hpp"
-#include "cpptrace/cpptrace.hpp"
+#include "cpptrace/exceptions.hpp"
 
 // linux
 #ifdef __linux__

--- a/libs/kernel/src/posix/posix_api.cpp
+++ b/libs/kernel/src/posix/posix_api.cpp
@@ -38,10 +38,12 @@ int NativePosixAPI::dlclose(void* handle) noexcept { return ::dlclose(handle); }
 
 void* NativePosixAPI::dlsym(void* handle, const char* name) noexcept { return ::dlsym(handle, name); }
 
+// NOLINTNEXTLINE(misc-include-cleaner): pthread.h is included; the check cannot map the type
 int NativePosixAPI::pthread_attr_destroy(pthread_attr_t* attr) noexcept { return ::pthread_attr_destroy(attr); }
 
 int NativePosixAPI::pthread_attr_init(pthread_attr_t* attr) noexcept { return ::pthread_attr_init(attr); }
 
+// NOLINTNEXTLINE(misc-include-cleaner): pthread.h is included; the check cannot map the type
 int NativePosixAPI::pthread_create(pthread_t* pthread,
                                    const pthread_attr_t* attr,
                                    void* (*startRoutine)(void*),  // NOSONAR
@@ -64,6 +66,7 @@ int NativePosixAPI::pthread_attr_setstacksize(pthread_attr_t* attr, std::size_t 
   return ::pthread_attr_setstacksize(attr, stackSize);
 }
 
+// NOLINTNEXTLINE(misc-include-cleaner): pthread.h and sched.h are included; the check cannot map the type
 int NativePosixAPI::pthread_attr_setschedparam(pthread_attr_t* attr, const sched_param* param) noexcept
 {
   return ::pthread_attr_setschedparam(attr, param);

--- a/libs/kernel/src/posix/thread_impl.cpp
+++ b/libs/kernel/src/posix/thread_impl.cpp
@@ -147,7 +147,7 @@ Result<void, ThreadCreateErr> ThreadImpl::configurePriority() noexcept
     return Err(ThreadCreateErr::internalOsError);
   }
 
-  sched_param sched {};
+  sched_param sched {};  // NOLINT(misc-include-cleaner): sched.h is included; the check cannot map the type
 
   if (config_.priority == Priority::lowest)
   {

--- a/libs/kernel/src/runner.cpp
+++ b/libs/kernel/src/runner.cpp
@@ -41,7 +41,6 @@
 // std
 #include <algorithm>
 #include <chrono>
-#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <functional>
@@ -709,7 +708,10 @@ void Runner::realTimeExecLoop(std::function<void()>&& workFunction, bool logOver
       if (wakeUpTime - time64 > halfPeriod)
       {
         time64 += period;
-        goto doSleep;  // NOLINT(hicpp-avoid-goto)
+        // Re-enter the sleep phase without running the frame. This is the hot
+        // scheduling loop; turning the jump into a nested loop is a change to
+        // the timing path, not a lint fix, so the check is waived here.
+        goto doSleep;  // NOLINT(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
       }
     }
 

--- a/libs/kernel/src/wall_clock.cpp
+++ b/libs/kernel/src/wall_clock.cpp
@@ -11,13 +11,14 @@
 #include "stl/sen/kernel/basic_types.stl.h"
 
 // kernel
-#include "kernel_impl.h"
+// Only the x86 branch below uses this, so a run on another architecture sees no use for it.
+#include "kernel_impl.h"  // NOLINT(misc-include-cleaner)
 
 // spdlog
 #include <spdlog/logger.h>  // NOLINT(misc-include-cleaner)
 
 // std
-#include <cstdint>
+#include <cstdint>  // NOLINT(misc-include-cleaner): same as kernel_impl.h above
 #include <cstdlib>
 #include <cstring>
 

--- a/libs/kernel/src/wall_clock.h
+++ b/libs/kernel/src/wall_clock.h
@@ -186,7 +186,7 @@ SEN_ALWAYS_INLINE int64_t WallClock::readTimeStampCounterRegistry() noexcept
   return static_cast<int64_t>((rdx << 32U) + rax);
 #elif defined __arm64 || defined __aarch64__
   int64_t tsc;
-  asm volatile("mrs %0, cntvct_el0" : "=r"(tsc));
+  asm volatile("mrs %0, cntvct_el0" : "=r"(tsc));  // NOLINT(hicpp-no-assembler)
   return tsc;
 #else
   return rdsysns();

--- a/libs/util/include/sen/util/dr/algorithms.h
+++ b/libs/util/include/sen/util/dr/algorithms.h
@@ -145,7 +145,7 @@ struct Situation
   bool isFrozen = false;
 
   /// TimeStamp of the instant when the situation is computed.
-  sen::TimeStamp timeStamp {};
+  sen::TimeStamp timeStamp;
 
   ///  Position in ECEF.
   Location worldLocation {};
@@ -175,7 +175,7 @@ struct GeodeticSituation
   bool isFrozen = false;
 
   /// TimeStamp of the instant when the situation is computed.
-  sen::TimeStamp timeStamp {};
+  sen::TimeStamp timeStamp;
 
   /// World Location in Geodetic (Latitude, Longitude, Altitude).
   GeodeticWorldLocation worldLocation {};


### PR DESCRIPTION
The new nightly clang-tidy job runs over the whole tree; this clears every
finding its first full run reported, so the job is green from night one.
Where a check is wrong or the code is deliberate, the waiver is written
next to the code together with its reason.
