### PR TITLE
test: revive the container-based object_sync integration suite

### DIFF
--- a/.github/scripts/generate_matrix_jobs.py
+++ b/.github/scripts/generate_matrix_jobs.py
@@ -44,6 +44,12 @@ class JobSpecification:
     build_type: tp.Literal["Release", "Debug"]
     enable_coverage: bool = False
     enable_examples: bool = False
+    # Docker base image for the container-based integration tests. A non-empty
+    # value registers them, and the base must match the runner's OS so the
+    # binaries mounted into the containers find a matching runtime. Empty on
+    # the legs that would only add container startups without covering
+    # anything the x86 gcc legs do not already cover.
+    runtime_base: str = ""
     # Builds the CPack archive and checks its contents. Set on the shipping
     # configuration only: the archive is the same everywhere it is built.
     check_package: bool = False
@@ -90,6 +96,7 @@ SPECIFIED_JOBS = [
             std=17,
             build_type="Debug",
             enable_examples=True,
+            runtime_base="ubuntu:22.04",
         ),
         include_in_release_workflow=False,
         include_in_conan_workflow=True,
@@ -108,6 +115,7 @@ SPECIFIED_JOBS = [
             std=17,
             build_type="Release",
             enable_examples=True,
+            runtime_base="ubuntu:22.04",
             check_package=True,
         ),
         include_in_release_workflow=True,

--- a/.github/scripts/test_generate_matrix_jobs.py
+++ b/.github/scripts/test_generate_matrix_jobs.py
@@ -87,6 +87,18 @@ def test_standard_test_legs_build_examples():
     assert all(job.enable_examples for job in jobs)
 
 
+def test_container_tests_run_on_the_x86_gcc_legs():
+    """The container-based suite runs on the x86 gcc legs, on a matching base."""
+    jobs = compute_jobs(release=False, conan=False, standard_test=True, target_main=False)
+    with_containers = {job.build_type: job for job in jobs if job.runtime_base}
+    assert set(with_containers) == {"Debug", "Release"}
+    for job in with_containers.values():
+        assert job.compiler.name == "gcc"
+        assert job.arch == "x86"
+        # the runner label and the docker base name the same Ubuntu release
+        assert job.runtime_base.replace(":", "-") == job.runner
+
+
 def test_windows_legs_keep_the_defaults():
     """The Windows legs do not build the examples."""
     jobs = compute_jobs(release=True, conan=False, standard_test=False, target_main=False)
@@ -127,6 +139,7 @@ def test_standard_test_specs_in_full():
             "build_type": "Debug",
             "enable_coverage": True,
             "enable_examples": True,
+            "runtime_base": "",
             "check_package": False,
         },
         {
@@ -140,6 +153,7 @@ def test_standard_test_specs_in_full():
             "build_type": "Debug",
             "enable_coverage": False,
             "enable_examples": True,
+            "runtime_base": "ubuntu:22.04",
             "check_package": False,
         },
         {
@@ -153,6 +167,7 @@ def test_standard_test_specs_in_full():
             "build_type": "Release",
             "enable_coverage": False,
             "enable_examples": True,
+            "runtime_base": "ubuntu:22.04",
             "check_package": True,
         },
         {
@@ -166,6 +181,7 @@ def test_standard_test_specs_in_full():
             "build_type": "Debug",
             "enable_coverage": False,
             "enable_examples": True,
+            "runtime_base": "",
             "check_package": False,
         },
     ]

--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -91,6 +91,21 @@ jobs:
         shell: bash
         run: pip install junitparser==5.0.1
 
+      # Built before the compile: a problem with docker or the apt mirror then
+      # costs seconds instead of a whole build. The tag carries the base image
+      # because the test driver mounts binaries built on that OS into it.
+      - name: Build the runtime image for the container-based tests
+        if: matrix.runtime_base != ''
+        shell: bash
+        env:
+          BASE: ${{ matrix.runtime_base }}
+        run: |
+          pip install docker==7.2.0 testcontainers==4.15.0
+          tag="sen-runtime:${BASE//:/-}"
+          docker build --file tools/ci/runtime.Dockerfile \
+            --build-arg "BASE=$BASE" --tag "$tag" tools/ci
+          echo "SEN_INTEGRATION_TEST_IMAGE=$tag" >> "$GITHUB_ENV"
+
       - name: Compile base libraries
         shell: bash
         run: |
@@ -111,9 +126,24 @@ jobs:
             -o "sen/*:with_examples=${{ matrix.enable_examples && 'True' || 'False' }}" \
             -o "sen/*:with_coverage=${{ matrix.enable_coverage && 'True' || 'False' }}"
 
+      # The suite is registered only if the image reached CMake, and its tests
+      # are labelled flaky, a selection ctest is allowed to leave empty. A
+      # rename on either side of that handoff would otherwise register nothing
+      # and still report success.
+      - name: Check the container-based tests are registered
+        if: matrix.runtime_base != ''
+        shell: bash
+        run: |
+          ctest --test-dir build/${{ matrix.compiler.name }}/${{ matrix.build_type }} \
+            -N -L integration | grep -q object_sync
+
       - name: Run tests
         if: ${{ !matrix.enable_coverage }}
         shell: bash
+        # The runner is discarded when the job ends, so the testcontainers
+        # cleanup helper would only add an image pull.
+        env:
+          TESTCONTAINERS_RYUK_DISABLED: "true"
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           cmake --build build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/ --target run_tests

--- a/cmake/util/test.cmake
+++ b/cmake/util/test.cmake
@@ -31,6 +31,14 @@ else()
   set(CTEST_PARALLEL_ARGS "--parallel" 0)
 endif()
 
+# Where the container-based suites mount the repository. run.py reads it from
+# the environment and both sides default to the same path, so the mount point
+# is written down once.
+set(SEN_INTEGRATION_TEST_MOUNT
+    "/home/builder/sen"
+    CACHE STRING "Path the container-based integration tests mount the repository at"
+)
+
 # An empty main selection is a mistake, not a pass: without --no-tests=error a
 # dropped suite or a filter typo leaves ctest reporting success over zero tests.
 set(CMAKE_CTEST_ARGUMENTS
@@ -206,15 +214,17 @@ function(add_sen_integration_test test_name)
 
   # the USE_TESTCONTAINERS argument indicates that the integration test will use python testcontainers
   if(${_arg_USE_TESTCONTAINERS})
-    # ryuk image to clean docker resources used in integration tests that use testcontainers
+    # Hand the runtime image and the mount point to the python test driver
+    # (see run.py). The sanitizer options are read inside the container, so
+    # the suppression files are named by their path there, not on the host.
     append_test_env_modification(
-      ${test_name}
-      "RYUK_CONTAINER_IMAGE=set:docker-proxy.pforgeipt-docker.intra.airbusds.corp/testcontainers/ryuk:0.8.1"
+      ${test_name} "SEN_INTEGRATION_TEST_IMAGE=set:${SEN_INTEGRATION_TEST_IMAGE}"
+      "SEN_INTEGRATION_TEST_MOUNT=set:${SEN_INTEGRATION_TEST_MOUNT}"
     )
-    set(_lsan_suppressions /home/builder/sen/cmake/util/lsan_ignorelist.txt)
-    set(_asan_suppressions /home/builder/sen/cmake/util/asan_ignorelist.txt)
-    set(_ubsan_suppressions /home/builder/sen/cmake/util/ubsan_ignorelist.txt)
-    set(_tsan_suppressions /home/builder/sen/cmake/util/tsan_ignorelist.txt)
+    set(_lsan_suppressions ${SEN_INTEGRATION_TEST_MOUNT}/cmake/util/lsan_ignorelist.txt)
+    set(_asan_suppressions ${SEN_INTEGRATION_TEST_MOUNT}/cmake/util/asan_ignorelist.txt)
+    set(_ubsan_suppressions ${SEN_INTEGRATION_TEST_MOUNT}/cmake/util/ubsan_ignorelist.txt)
+    set(_tsan_suppressions ${SEN_INTEGRATION_TEST_MOUNT}/cmake/util/tsan_ignorelist.txt)
   endif()
 
   if(LSAN_SUPPRESSION_FILE)

--- a/conanfile.py
+++ b/conanfile.py
@@ -210,6 +210,14 @@ class SenConan(ConanFile):
             is_on = self._is_component_enabled(component)
             tc.cache_variables[f"SEN_BUILD_{component.upper()}"] = "ON" if is_on else "OFF"
 
+        # Runtime image for the container-based integration tests. Passing it
+        # through the toolchain keeps the configure step in one place: the
+        # tests are registered by the same conan build that compiles them,
+        # with the cmake conan pins rather than whatever cmake a runner ships.
+        integration_image = getenv("SEN_INTEGRATION_TEST_IMAGE")
+        if integration_image:
+            tc.cache_variables["SEN_INTEGRATION_TEST_IMAGE"] = integration_image
+
         # directory for the generated documentation
         site_dir = getenv("MKDOCS_SITE_DIR")
         if site_dir:

--- a/libs/kernel/test/CMakeLists.txt
+++ b/libs/kernel/test/CMakeLists.txt
@@ -18,8 +18,15 @@ if(NOT MSVC)
   #
   # integration tests that use containers (only available in Linux)
   if(LINUX)
-    #   add_subdirectory(integration/object_sync)
-    # interest_filtering drives multi-process runs over the ether component
+    # The container-based suites run the built binaries inside docker containers and
+    # need a runtime image. Opt in by configuring with
+    # -DSEN_INTEGRATION_TEST_IMAGE=<image> (CI does; see tools/ci/runtime.Dockerfile).
+    # Without the image the tests are not registered, so a plain local ctest run
+    # stays green on machines without docker. Both suites drive the ether component,
+    # so neither can be registered when the build leaves it out.
+    if(SEN_INTEGRATION_TEST_IMAGE AND SEN_BUILD_ETHER)
+      add_subdirectory(integration/object_sync)
+    endif()
     if(SEN_BUILD_ETHER)
       add_subdirectory(integration/interest_filtering)
     endif()

--- a/libs/kernel/test/integration/run.py
+++ b/libs/kernel/test/integration/run.py
@@ -21,8 +21,11 @@ from testcontainers.core.network import Network
 
 # constants
 # TODO (SEN-1681) replace with a lighter runtime image
-IMAGE_NAME = "sim-csr-docker.pforgeipt-docker.intra.airbusds.corp/sen-build-debian12:0.1.0-31-ge5dd492"
-TIMEOUT = 30
+IMAGE_NAME = (
+    os.environ.get("SEN_INTEGRATION_TEST_IMAGE")
+    or "sim-csr-docker.pforgeipt-docker.intra.airbusds.corp/sen-build-debian12:0.1.0-31-ge5dd492"
+)
+TIMEOUT = int(os.environ.get("SEN_INTEGRATION_TEST_TIMEOUT") or 30)
 
 
 def stream_logs(cont: DockerContainer) -> None:
@@ -82,10 +85,23 @@ def check_image_availability(image: str) -> None:
         raise RuntimeError("Could not connect to the local Docker daemon.") from e
 
 
+def cleanup(container_list: list[DockerContainer]) -> None:
+    """Removes the containers a run started.
+
+    A passing test leaves its containers behind otherwise: they have exited,
+    but nothing deletes them, and the testcontainers janitor is disabled on
+    purpose in CI. Failures here must not mask the result of the test.
+    """
+    for container in container_list:
+        try:
+            container.stop()
+        except Exception as error:  # noqa: BLE001 - cleanup is best effort
+            print(f"could not remove a test container: {error}", file=sys.stderr)
+
+
 def abort(container_list: list[DockerContainer], thread_list: list[Thread]) -> None:
     """Stops containers and joins log threads before aborting with error."""
-    for container in container_list:
-        container.stop()
+    cleanup(container_list)
 
     for t in thread_list:
         if isinstance(t, Thread):
@@ -109,8 +125,10 @@ if __name__ == "__main__":
     # repo root dir in the host machine (if cmake is being configured in a container)
     host_repo_root = find_host_mount(cmake_repo_root) if is_container() else cmake_repo_root
 
-    # repo root dir in the container used to execute the integration tests
-    test_repo_root = Path("/home/builder/sen")
+    # repo root dir in the container used to execute the integration tests;
+    # cmake/util/test.cmake sets this and names the sanitizer suppression
+    # files by the same path
+    test_repo_root = Path(os.environ.get("SEN_INTEGRATION_TEST_MOUNT") or "/home/builder/sen")
     test_workdir = test_repo_root / Path(cmake_workdir).relative_to(cmake_repo_root)
 
     # container paths
@@ -118,42 +136,47 @@ if __name__ == "__main__":
         containers = []
         log_threads = []
 
-        for i, config in enumerate(configs):
-            aliases = ["sen-hub"] if i == 0 else []
+        try:
+            for i, config in enumerate(configs):
+                aliases = ["sen-hub"] if i == 0 else []
 
-            # container definition
-            container = (
-                DockerContainer(IMAGE_NAME)
-                .with_network(network)
-                .with_network_aliases(*aliases)
-                .with_volume_mapping(host_repo_root, "/home/builder/sen", mode="rw")
-                .with_command(f"./cli_run {test_repo_root / Path(config).relative_to(cmake_repo_root)}")
-                .with_kwargs(working_dir=str(test_workdir), cap_add=["SYS_ADMIN"], security_opt=["seccomp=unconfined"])
-            )
+                # container definition
+                container = (
+                    DockerContainer(IMAGE_NAME)
+                    .with_network(network)
+                    .with_network_aliases(*aliases)
+                    .with_volume_mapping(host_repo_root, str(test_repo_root), mode="rw")
+                    .with_command(f"./cli_run {test_repo_root / Path(config).relative_to(cmake_repo_root)}")
+                    .with_kwargs(
+                        working_dir=str(test_workdir), cap_add=["SYS_ADMIN"], security_opt=["seccomp=unconfined"]
+                    )
+                )
 
-            # start the container (with the host environment) and the log thread
-            container.env.update(os.environ)
-            container.start()
-            log_threads.append(Thread(target=stream_logs, args=(container,), daemon=True).start())
-            containers.append(container)
+                # start the container (with the host environment) and the log thread
+                container.env.update(os.environ)
+                container.start()
+                log_threads.append(Thread(target=stream_logs, args=(container,), daemon=True).start())
+                containers.append(container)
 
-        deadline = time.time() + TIMEOUT
-        while time.time() < deadline:
-            wrapped = [c.get_wrapped_container() for c in containers]
-            for w in wrapped:
-                w.reload()
+            deadline = time.time() + TIMEOUT
+            while time.time() < deadline:
+                wrapped = [c.get_wrapped_container() for c in containers]
+                for w in wrapped:
+                    w.reload()
 
-            # abort if any of the processes has exited with error
-            if any(w.status == "exited" and w.wait()["StatusCode"] != 0 for w in wrapped):
+                # abort if any of the processes has exited with error
+                if any(w.status == "exited" and w.wait()["StatusCode"] != 0 for w in wrapped):
+                    abort(containers, log_threads)
+
+                # pass the test if all processes have exited successfully
+                if all(w.status == "exited" for w in wrapped):
+                    # join the logger threads
+                    list(map(Thread.join, [t for t in log_threads if isinstance(t, Thread)]))
+                    break
+
+                time.sleep(0.2)
+            else:
+                print(f"\nError: timeout of {TIMEOUT}s reached!")
                 abort(containers, log_threads)
-
-            # pass the test if all processes have exited successfully
-            if all(w.status == "exited" for w in wrapped):
-                # join the logger threads
-                list(map(Thread.join, [t for t in log_threads if isinstance(t, Thread)]))
-                break
-
-            time.sleep(0.2)
-        else:
-            print(f"\nError: timeout of {TIMEOUT}s reached!")
-            abort(containers, log_threads)
+        finally:
+            cleanup(containers)

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -66,6 +66,16 @@ the share of covered lines falls below the floor recorded in
 because the number moves slightly between runs; the browsable report is
 published by the nightly run.
 
+The two x86 gcc legs also build a small runtime image
+(`tools/ci/runtime.Dockerfile`) and register the container-based
+`object_sync` suite, which then runs inside `run_tests` like every other
+test. The image is built before the compile, so a problem with docker costs
+seconds rather than a whole build, and a step right after the compile
+asserts that the suite really registered: its tests are labelled flaky, a
+selection ctest is allowed to leave empty, so a broken handoff would
+otherwise pass silently. The clang and arm legs do not run the suite; they
+would add container startups without covering anything these two legs miss.
+
 A separate job builds the documentation (the API reference and the
 handbook) without publishing it. It runs when a changed path is an input
 of the documentation build: `docs/`, `examples/` (the handbook copies its
@@ -149,9 +159,12 @@ hook, and one of them asserts that every declared leg is selected by some
 workflow, so a leg that reads as coverage but can never run does not
 survive.
 
-Besides compiler, build type and language standard, each leg carries two
-switches: whether it builds the examples, and whether it builds and checks
-the package archive. The
+Besides compiler, build type and language standard, each leg carries three
+switches: whether it builds the examples, the docker base image for the
+container-based integration tests (empty means the leg does not run them;
+the base must match the runner's OS so the binaries mounted into the
+containers find a matching runtime), and whether it builds and checks the
+package archive. The
 standard is passed to the compiler, so adding a leg for a different one
 tests what its name claims; every leg currently builds C++17, which is what
 the project promises its consumers.
@@ -385,10 +398,10 @@ crash), `.ruff.toml` per-file ignores (tutorial scripts),
 - MSVC jobs build but do not run tests (SEN-1725). Uploading coverage to an
   external service is wired but disabled (SEN-1726); the published report and
   the floor cover the same ground without sending anything outside.
-- No container-based suite runs yet. The `object_sync` suite is revived in a
-  change of its own, which brings the runtime image and the steps that build
-  it; the other suites (transport, runtime compatibility, crash report, type
-  clash) are still disabled and need the same verify-and-enable treatment.
+- Only the `object_sync` container suite runs, and only on the two x86 gcc
+  legs. The other container suites (transport, runtime compatibility, crash
+  report, type clash) are still disabled and need the same verify-and-enable
+  treatment.
 - The Windows legs do not build the examples yet.
 - What runs on a pull request is decided by the pull request's own copy of
   the workflows and of `classify_changes.py`, because that is how GitHub

--- a/tools/ci/runtime.Dockerfile
+++ b/tools/ci/runtime.Dockerfile
@@ -1,0 +1,28 @@
+# === runtime.Dockerfile ===============================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+#
+# Runtime image for the container-based integration tests. The test driver
+# mounts the workspace with the already-built binaries and runs them here, so
+# only the runtime dependencies are needed and BASE must match the OS the
+# binaries were built on.
+#
+# Build:  docker build -f tools/ci/runtime.Dockerfile --build-arg BASE=ubuntu:22.04 -t sen-runtime:ubuntu-22.04 tools/ci
+# Use:    cmake -DSEN_INTEGRATION_TEST_IMAGE=sen-runtime:ubuntu-22.04 ...
+
+ARG BASE=ubuntu:22.04
+FROM ${BASE}
+
+# libgl1: needed by the SDL/OpenGL dependencies some components link against.
+# python3 and its shared library: the py component embeds the interpreter, so
+# libpy.so links libpython. The version is read from the base image, because
+# each Ubuntu release carries a different one and no unversioned package
+# exists.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libgl1 python3 \
+    && apt-get install -y --no-install-recommends \
+        "libpython$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The object_sync suite was disabled with the datacenter runners and hardwired to
the corporate registry image. It now registers when SEN_INTEGRATION_TEST_IMAGE is
configured, and the two x86 gcc legs build that image and pass it in. A check
after the build asserts the suite registered, since ctest is allowed to select
nothing. The other disabled suites stay off until they get the same treatment.
