### PR TITLE
ci: generate the release changelog on main as well

### DIFF
--- a/.github/scripts/create_changelog.py
+++ b/.github/scripts/create_changelog.py
@@ -1,0 +1,174 @@
+# === create_changelog.py ==============================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Builds the release changelog from the conventional commit messages.
+
+The commit range starts at the merge base with the previous release branch;
+without one, every commit reachable from HEAD is included. The output is
+the body of the draft GitHub release.
+"""
+
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+# One entry per type that .gitlint accepts, so every commit that can land has a
+# section to land in. test_create_changelog.py checks the two lists still match.
+TYPE_MAP = {
+    "feat": "✨ Features",
+    "fix": "🐛 Bug Fixes",
+    "build": "🏗️ Build System",
+    "ci": "👷 Continuous Integration",
+    "docs": "📚 Documentation",
+    "refactor": "🔨 Refactor",
+    "perf": "🚀 Performance",
+    "test": "🚨 Tests",
+    "revert": "⏪ Reverts",
+    "chore": "📦 Chores",
+}
+
+# Subjects that do not parse, and those whose type has no section, still belong in
+# the notes: dropping them silently is how a release ships with commits nobody listed.
+UNPARSED_SECTION = "🧾 Other"
+
+TITLE_PATTERN = re.compile(r"^(?P<type>\w+)(?:[(\[](?P<scope>[^)\]]+)[)\]])?(?P<breaking>!)?: (?P<subject>.+)")
+
+COMMIT_SEPARATOR = "---END---"
+
+
+def contains_head(branch: str) -> bool:
+    """Says whether the branch already contains the commit being released."""
+    return (
+        subprocess.run(
+            ["git", "merge-base", "--is-ancestor", "HEAD", branch],
+            capture_output=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def get_last_release_branch() -> str | None:
+    """Returns the most recent release branch that does not contain the commit being released."""
+    try:
+        raw_branches = (
+            subprocess.check_output(
+                ["git", "branch", "-a", "--list", "*release/*.*.x"],
+                stderr=subprocess.STDOUT,
+            )
+            .decode("utf-8")
+            .split()
+        )
+    except subprocess.CalledProcessError:
+        return None
+
+    version_pattern = re.compile(r"release/(\d+)\.(\d+)\.x")
+    found_versions = []
+    for branch in raw_branches:
+        # The name git printed, remotes/origin/ prefix included: a release runs on a checkout that
+        # has no local branches, so the shortened name is not a reference it can resolve.
+        name = branch.strip("* ")
+        match = version_pattern.search(name)
+        if not match:
+            continue
+
+        # A release runs on a tag, so HEAD is detached and the release line being built has no name
+        # to compare against. Skipping the lines that already contain HEAD leaves the previous one,
+        # which is the one to list the changes against.
+        if contains_head(name):
+            continue
+
+        major, minor = map(int, match.groups())
+        found_versions.append(((major, minor), name))
+
+    if not found_versions:
+        return None
+
+    found_versions.sort(key=lambda entry: entry[0], reverse=True)
+    return found_versions[0][1]
+
+
+def get_commit_range() -> str:
+    """Returns the revision range of the commits that belong in the changelog."""
+    release_branch = get_last_release_branch()
+    if not release_branch:
+        return "HEAD"
+
+    try:
+        merge_base = subprocess.check_output(["git", "merge-base", release_branch, "HEAD"]).decode("utf-8").strip()
+    except subprocess.CalledProcessError:
+        return "HEAD"
+
+    return f"{merge_base}..HEAD"
+
+
+def get_commits() -> list[str]:
+    """Returns the raw commit messages in the changelog range."""
+    log_format = f"%s%n%b%n{COMMIT_SEPARATOR}"
+    try:
+        raw_log = subprocess.check_output(
+            ["git", "log", get_commit_range(), f"--format={log_format}"],
+            stderr=subprocess.STDOUT,
+        ).decode("utf-8")
+    except subprocess.CalledProcessError:
+        return []
+
+    return raw_log.split(f"{COMMIT_SEPARATOR}\n")
+
+
+def build_changelog(commits: list[str]) -> str:
+    """Groups the commit messages by type and renders the changelog text."""
+    groups: defaultdict[str, list[str]] = defaultdict(list)
+    breaking_changes: list[tuple[str, str]] = []
+
+    for raw_message in commits:
+        if not raw_message.strip():
+            continue
+
+        lines = raw_message.strip().split("\n")
+        title = lines[0]
+        body = "\n".join(lines[1:])
+
+        match = TITLE_PATTERN.match(title)
+        if "BREAKING CHANGE" in body or (match and match.group("breaking")):
+            if "BREAKING CHANGE:" in body:
+                # The whole footer, to the next blank line: taking one line drops the
+                # rest of a description that was wrapped to fit the message.
+                footer = body.split("BREAKING CHANGE:")[1].strip()
+                description = " ".join(footer.split("\n\n")[0].split())
+            else:
+                description = "<No specific breaking change description provided.>"
+            breaking_changes.append((title, description))
+
+        commit_type = match.group("type") if match else ""
+        groups[commit_type if commit_type in TYPE_MAP else UNPARSED_SECTION].append(title)
+
+    sections = ["## 📝 Change Log\n"]
+    if breaking_changes:
+        sections.append("### 💥 BREAKING CHANGES")
+        for title, description in breaking_changes:
+            sections.append(f"- **{title}**")
+            sections.append(f"  > {description}")
+        sections.append("")
+
+    for commit_type, section_title in list(TYPE_MAP.items()) + [(UNPARSED_SECTION, UNPARSED_SECTION)]:
+        if commit_type in groups:
+            sections.append(f"### {section_title}")
+            sections.extend(f"- {message}" for message in groups[commit_type])
+            sections.append("")
+
+    return "\n".join(sections)
+
+
+def main() -> int:
+    """Prints the changelog for the current checkout."""
+    print(build_changelog(get_commits()))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_create_changelog.py
+++ b/.github/scripts/test_create_changelog.py
@@ -1,0 +1,130 @@
+# === test_create_changelog.py =========================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Pins the grouping and breaking-change extraction of the changelog."""
+
+import configparser
+import subprocess
+from pathlib import Path
+
+from create_changelog import TYPE_MAP, build_changelog, get_commit_range, get_last_release_branch
+
+GITLINT_FILE = Path(__file__).resolve().parents[2] / ".gitlint"
+
+
+def git(repo: Path, *args: str) -> None:
+    """Runs a git command in the test repository."""
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+def commit(repo: Path, subject: str) -> None:
+    """Adds one commit to the test repository."""
+    (repo / "file.txt").write_text(subject)
+    git(repo, "add", "file.txt")
+    git(repo, "-c", "commit.gpgsign=false", "commit", "-qm", subject)
+
+
+def test_commits_are_grouped_by_type():
+    """Each conventional type gets its own section, in TYPE_MAP order."""
+    text = build_changelog(["fix: repair the flux\n\n", "feat: add the flux\n\n", "feat: tune the flux\n\n"])
+    features = text.index("### ✨ Features")
+    fixes = text.index("### 🐛 Bug Fixes")
+    assert features < fixes
+    assert "- feat: add the flux" in text
+    assert "- feat: tune the flux" in text
+    assert "- fix: repair the flux" in text
+
+
+def test_breaking_marker_in_title_is_reported():
+    """A `!` after the type lands in the breaking-changes section."""
+    text = build_changelog(["feat!: drop the old api\n\n"])
+    assert "### 💥 BREAKING CHANGES" in text
+    assert "- **feat!: drop the old api**" in text
+
+
+def test_breaking_change_footer_supplies_the_description():
+    """A BREAKING CHANGE footer is quoted under the entry."""
+    text = build_changelog(["fix: change defaults\nBREAKING CHANGE: defaults are now strict\n"])
+    assert "  > defaults are now strict" in text
+
+
+def test_a_wrapped_breaking_description_is_kept_whole():
+    """Messages wrap at 80 columns, so the description is usually more than one line."""
+    text = build_changelog(
+        [
+            "feat!: retire the env interface\nBREAKING CHANGE: the first sentence.\nAnd the rest of it.\n\n"
+            "Not the body paragraph after the blank line.\n"
+        ]
+    )
+    assert "  > the first sentence. And the rest of it." in text
+    assert "Not the body paragraph" not in text.split("### ")[1]
+
+
+def test_scoped_and_unknown_titles():
+    """Scoped titles group under their type; unparsed ones are listed, not dropped."""
+    text = build_changelog(["chore[deps]: bump urllib3\n\n", "merge remote tracking branch\n\n"])
+    assert "- chore[deps]: bump urllib3" in text
+    assert "- merge remote tracking branch" in text
+
+
+def test_empty_input_renders_the_header_only():
+    """No commits still renders a valid, header-only changelog."""
+    assert build_changelog([]).startswith("## 📝 Change Log")
+
+
+def test_scoped_subjects_are_grouped_like_any_other():
+    """This repository writes scopes in parentheses, which gitlint enforces."""
+    text = build_changelog(["feat(installer): add the installer\n\n", "fix(core,kernel): repair the flux\n\n"])
+    assert "- feat(installer): add the installer" in text
+    assert "- fix(core,kernel): repair the flux" in text
+
+
+def test_scoped_breaking_marker_is_reported():
+    """A scope must not hide the ! marker; that is the commit people need to see."""
+    text = build_changelog(["feat(gen)!: drop the old options\n\n"])
+    assert "### 💥 BREAKING CHANGES" in text
+    assert "- **feat(gen)!: drop the old options**" in text
+
+
+def test_unparsed_subjects_are_listed_rather_than_dropped():
+    """A subject that does not parse still belongs in the notes."""
+    text = build_changelog(["Merge branch 'main' into topic\n\n"])
+    assert "Merge branch 'main' into topic" in text
+
+
+def test_every_type_gitlint_accepts_has_a_section():
+    """A type that can be committed but has no section here would be dropped from the notes."""
+    config = configparser.ConfigParser()
+    config.read(GITLINT_FILE)
+    accepted = config["contrib-title-conventional-commits"]["types"].split(",")
+    assert sorted(accepted) == sorted(TYPE_MAP)
+
+
+def test_the_previous_release_line_is_chosen_from_a_detached_head(tmp_path, monkeypatch):
+    """A release runs on a tag, so the line being released has no branch name to compare against."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "main")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    commit(repo, "feat: the 0.5 work")
+    git(repo, "branch", "release/0.5.x")
+    commit(repo, "feat: the 0.6 work")
+    git(repo, "branch", "release/0.6.x")
+    git(repo, "checkout", "-q", "--detach", "release/0.6.x")
+    monkeypatch.chdir(repo)
+
+    # Not release/0.6.x: that is the line being released, and its merge base with HEAD is HEAD,
+    # which would leave the release with an empty changelog.
+    assert get_last_release_branch() == "release/0.5.x"
+    assert get_commit_range() != "HEAD"
+
+
+def test_a_type_without_a_section_is_listed_rather_than_dropped():
+    """The sections are driven by TYPE_MAP, so an unmapped type has to fall back to Other."""
+    text = build_changelog(["wip: half of a thing\n\n"])
+    assert "### 🧾 Other" in text
+    assert "- wip: half of a thing" in text

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -37,6 +37,27 @@ jobs:
       - id: compute-jobs
         run: python .github/scripts/generate_matrix_jobs.py --release
 
+  generate_changelog:
+    name: "Generate changelog"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute changelog
+        run: python .github/scripts/create_changelog.py > ${{ github.workspace }}-CHANGELOG.txt
+
+      - name: Archive the generated changelog
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: changelog
+          # The release body comes from this file; an empty artifact would ship
+          # a release with no notes.
+          if-no-files-found: error
+          path: ${{ github.workspace }}-CHANGELOG.txt
+
   create_release_with_artifacts:
     name: "Build Job: ${{ matrix.compiler.name }}-${{ matrix.compiler.version }} C++${{ matrix.std }} [${{ matrix.build_type }}]"
     needs: compute-matrix-jobs
@@ -86,7 +107,9 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write
-    needs: create_release_with_artifacts
+    needs:
+      - create_release_with_artifacts
+      - generate_changelog
     steps:
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
@@ -95,6 +118,7 @@ jobs:
         run: |
           sudo apt-get install -y file
           ls -rlisa
+          cat changelog/sen-CHANGELOG.txt
 
       # The installer verifies what it downloads against this file, and treats
       # its absence as "verification skipped". Without it every install is
@@ -117,6 +141,7 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         if: github.ref_type == 'tag'
         with:
+          body_path: changelog/sen-CHANGELOG.txt
           files: |
             release-*/*
             SHA256SUMS


### PR DESCRIPTION
The changelog script and workflow job exist only on the release branches, so the
next release branch cut from main would lose its changelog. This brings them to
main with tests, and fixes two faults in that copy: build and revert commits were
dropped from the notes, and the range never started at the previous release.
