### PR TITLE
fix(cmake): find python for pybind11 without the removed module

### DIFF
--- a/cmake/tps/pybind11.cmake
+++ b/cmake/tps/pybind11.cmake
@@ -7,11 +7,14 @@
 
 include_guard()
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.27.0")
-  cmake_policy(SET CMP0148 OLD)
-endif()
-
-# search for Python3 so that pybind11 does not do it on its own and possibly creates a version mismatch
+# Find Python here so that pybind11 does not do it on its own and possibly
+# creates a version mismatch.
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+
+# Left to itself, pybind11 looks for Python through FindPythonLibs, which CMake
+# 3.27 deprecated (CMP0148) and will remove. PYBIND11_FINDPYTHON sends it to
+# FindPython instead, and the hint keeps it on the interpreter found above.
+set(PYBIND11_FINDPYTHON ON)
+set(Python_EXECUTABLE "${Python3_EXECUTABLE}")
 
 find_package(pybind11 REQUIRED)


### PR DESCRIPTION
pybind11 looks for Python through FindPythonLibs unless told otherwise, and CMake
3.27 deprecated that module; pinning CMP0148 to OLD only delays the break and
warns twice on every configure. PYBIND11_FINDPYTHON sends it to FindPython, and
the hint keeps it on the interpreter this project already found.
