### PR TITLE
ci: stop apt hangs and stop pull requests filling the cache

### DIFF
--- a/.github/actions/build_documentation/action.yaml
+++ b/.github/actions/build_documentation/action.yaml
@@ -22,21 +22,41 @@ runs:
         key: conanp-docs-${{ env.cache_date }}
         restore-keys: conanp-docs-
 
+    # Writes only on main, as in standard_test.yaml; main reaches this through
+    # build_docs.yaml, so the cache still gets filled.
     - uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639  # v1.2
       with:
         key: docs
         max-size: 1G
         verbose: 1
-        # Same reasoning as the conan cache above.
         save: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install system dependencies
       shell: bash
       # graphviz draws the doxygen diagrams; libxext-dev is needed for clang
       # compat with sdl2 2.24.0.
+      #
+      # apt-get, not the interactive apt. The bounds stop it waiting with no output until
+      # the job timeout kills it: twice in one day this build sat here for its whole hour,
+      # once on the dpkg lock and once on a mirror that stopped answering mid-download.
+      # They are generous on purpose. The mirror can be slow without being stuck, and the
+      # point is to end a hang well before the job cap, not to police how long apt takes.
       run: |
-        sudo apt update
-        sudo apt install -y g++ graphviz libxext-dev
+        # The runners prefer azure.archive.ubuntu.com through this mirror list. That host
+        # has been ignoring requests for us today, and apt then alternates between it and
+        # the working mirror until the bound below kills the step. Point it straight at
+        # the one that answers.
+        if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' /etc/apt/apt-mirrors.txt
+        fi
+        sudo tee /etc/apt/apt.conf.d/99-sen-timeouts <<'CONF'
+        DPkg::Lock::Timeout "120";
+        Acquire::Retries "3";
+        Acquire::http::Timeout "30";
+        Acquire::https::Timeout "30";
+        CONF
+        timeout 1200 sudo apt-get update
+        timeout 1200 sudo apt-get install -y g++ graphviz libxext-dev
 
     - name: Install python dependencies
       shell: bash

--- a/.github/actions/setup_build_context/action.yaml
+++ b/.github/actions/setup_build_context/action.yaml
@@ -21,10 +21,32 @@ runs:
       shell: bash
       run: pip install conan==2.28.1 pytest==9.1.1 junitparser==5.0.1
 
+    # Both ways apt hangs here, bounded in one place so the calls inside llvm.sh get it
+    # too: it waits for the dpkg lock the runner's background updates hold, and it waits
+    # on a mirror that stopped answering. Unbounded, both produce no output at all until
+    # the job timeout kills them; one clang leg spent two hours that way.
+    - name: Bound how long apt waits
+      if: ${{ inputs.compiler-name != 'msvc' }}
+      shell: bash
+      run: |
+        # The runners prefer azure.archive.ubuntu.com through this mirror list. That host
+        # has been ignoring requests for us today, and apt then alternates between it and
+        # the working mirror until the bound below kills the step. Point it straight at
+        # the one that answers.
+        if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' /etc/apt/apt-mirrors.txt
+        fi
+        sudo tee /etc/apt/apt.conf.d/99-sen-timeouts <<'CONF'
+        DPkg::Lock::Timeout "120";
+        Acquire::Retries "3";
+        Acquire::http::Timeout "30";
+        Acquire::https::Timeout "30";
+        CONF
+
     - name: Install gcc-${{ inputs.compiler-version }}
       if: ${{ inputs.compiler-name == 'gcc' }}
       shell: bash
-      run: sudo apt-get install -y g++-${{ inputs.compiler-version }}
+      run: timeout 1200 sudo apt-get install -y g++-${{ inputs.compiler-version }}
 
     - name: Install clang-${{ inputs.compiler-version }}
       if: ${{ inputs.compiler-name == 'clang' }}
@@ -32,8 +54,11 @@ runs:
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh ${{ inputs.compiler-version }}
-        sudo apt install -y \
+        # llvm.sh refreshes the apt metadata and installs the whole toolchain, so it is
+        # slow by nature: 15 minutes killed a run that was still making progress. This is
+        # well under the job cap, so a real hang is still caught long before that.
+        timeout 2400 sudo ./llvm.sh ${{ inputs.compiler-version }}
+        timeout 1200 sudo apt-get install -y \
           clang-tools-${{ inputs.compiler-version }} \
           clang-tidy-${{ inputs.compiler-version }} \
           llvm-${{ inputs.compiler-version }} \
@@ -43,7 +68,7 @@ runs:
       if: ${{ inputs.compiler-name != 'msvc' }}
       shell: bash
       # libxext for clang compat with sdl2 2.24.0; bats for the installer tests
-      run: sudo apt-get install -y libxext-dev bats
+      run: timeout 1200 sudo apt-get install -y libxext-dev bats
 
     - name: Setup conan profile
       shell: bash

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Print context
         run: |
-          sudo apt-get install -y file
+          timeout 600 sudo apt-get -o DPkg::Lock::Timeout=120 install -y file
           ls -rlisa
           cat changelog/sen-CHANGELOG.txt
 

--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -46,6 +46,12 @@ ENV LANG=C.UTF-8 \
 # dependency chain (SDL needs libXext, the explorer needs libGL). make
 # serves the autotools-style Conan recipes; python3-dev serves pybind11;
 # bats runs the installer test suite.
+# Every apt and curl call in this file talks to a mirror that can stall or refuse a
+# connection; one such refusal from apt.llvm.org failed an image build. Retries turn
+# those into a pause instead of a red pipeline.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+        > /etc/apt/apt.conf.d/99-sen-retries
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bats \
         ca-certificates \
@@ -72,7 +78,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # both use this major version. The repository is added directly instead of
 # running llvm.sh, which needs add-apt-repository.
 RUN install -m 0755 -d /etc/apt/keyrings \
-    && curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key -o /etc/apt/keyrings/llvm.asc \
+    && curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
+        https://apt.llvm.org/llvm-snapshot.gpg.key -o /etc/apt/keyrings/llvm.asc \
     && echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" \
         > /etc/apt/sources.list.d/llvm.list \
     && apt-get update \


### PR DESCRIPTION
Two things that read as build failures and are not.

An apt call that does not bound how long it waits for the dpkg lock blocks with
no output until the job timeout kills it, which is what ended a documentation
build on #86 after its full hour. Every call now bounds the wait.

The compiler cache stores a new entry on every run, and no other pull request
can read it, so six open ones filled the 10 GB the repository gets. What that
evicted was the conan package caches, which are the expensive ones to rebuild.
Only main writes the compiler cache now; pull requests read what it leaves.
