### PR TITLE
feat(build)!: select what gets built with conan options

### DIFF
--- a/.conan/profiles/sen_build_docs
+++ b/.conan/profiles/sen_build_docs
@@ -1,7 +1,9 @@
 include(sen_gcc)
 
-[options]
+# Doxygen 1.15+ needs C++20 to build itself. compiler.cppstd is a Conan setting (not an option),
+# so it has to be applied from a profile rather than from the recipe.
+[settings]
 doxygen*:compiler.cppstd=20
 
-[tool_requires]
-&:doxygen/[>=1.15.0]
+[options]
+sen/*:with_docs=True

--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -95,16 +95,21 @@ jobs:
         shell: bash
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-          export ENABLE_EXAMPLES=${{ matrix.enable_examples }}
-          export ENABLE_TESTS=true
-          export ENABLE_COVERAGE=${{ matrix.enable_coverage }}
 
           # & applies build_type to the sen package only; dependencies stay at
           # the profiles' Release default, which is what binary remotes serve.
           conan install . -s "&:build_type=${{ matrix.build_type }}" \
-            -s "&:compiler.cppstd=${{ matrix.std }}" --build=missing
+            -s "&:compiler.cppstd=${{ matrix.std }}" --build=missing \
+            -o "sen/*:with_tests=True" \
+            -o "sen/*:with_examples=${{ matrix.enable_examples && 'True' || 'False' }}" \
+            -o "sen/*:with_coverage=${{ matrix.enable_coverage && 'True' || 'False' }}"
+          # The same options go to both commands: conan build regenerates the toolchain,
+          # and without them it would do so from the defaults, which build no tests.
           conan build . -s "&:build_type=${{ matrix.build_type }}" \
-            -s "&:compiler.cppstd=${{ matrix.std }}"
+            -s "&:compiler.cppstd=${{ matrix.std }}" \
+            -o "sen/*:with_tests=True" \
+            -o "sen/*:with_examples=${{ matrix.enable_examples && 'True' || 'False' }}" \
+            -o "sen/*:with_coverage=${{ matrix.enable_coverage && 'True' || 'False' }}"
 
       - name: Run tests
         if: ${{ !matrix.enable_coverage }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ option(SEN_BUILD_EXAMPLES "Build examples" ON)
 option(SEN_BUILD_TESTS "Build tests" ON)
 option(SEN_BUILD_DOCS "Build documentation" ON)
 option(SEN_DISABLE_CLANG_TIDY "Disable clang-tidy" ON)
-option(SEN_DISABLE_EXTRA_COMPONENTS "Disable non-critical components" OFF)
 option(SEN_COVERAGE_ENABLE "Enable coverage generation" OFF)
 option(SEN_ENABLE_CMAKE_TARGET_GRAPH "Enable the generation of a graphviz with the targets" ON)
 set(SEN_USE_SANITIZER
@@ -48,47 +47,6 @@ project(
 )
 
 include(util/sen_internal_utils)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.2.1)
-  message(FATAL_ERROR "GCC ${CMAKE_CXX_COMPILER_VERSION} is not supported.")
-endif()
-
-if(MSVC)
-  add_compile_options(/bigobj)
-endif()
-
-# configure coverage as an interface target so flags apply only to sen targets,
-# not to every target in the directory tree (e.g. third-party add_subdirectory targets).
-add_library(sen_coverage_flags INTERFACE)
-if(SEN_COVERAGE_ENABLE)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(
-      sen_coverage_flags
-      INTERFACE -g
-                -O0
-                -fno-inline
-                --coverage
-    )
-    target_link_options(sen_coverage_flags INTERFACE --coverage)
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    file(TO_NATIVE_PATH "${CMAKE_BINARY_DIR}/coverage_data/coverage-%p-%m.profraw" SEN_COVERAGE_DATA_DIR)
-    target_compile_options(
-      sen_coverage_flags
-      INTERFACE -g
-                -O0
-                -fno-inline
-                -fprofile-instr-generate=${SEN_COVERAGE_DATA_DIR}
-                -fcoverage-mapping
-    )
-    target_link_options(
-      sen_coverage_flags
-      INTERFACE
-      -fprofile-instr-generate=${SEN_COVERAGE_DATA_DIR}
-      -fcoverage-mapping
-    )
-  endif()
-endif()
-
 include(util/sanitizers)
 include(util/test)
 
@@ -96,8 +54,24 @@ include(util/test)
 add_subdirectory(libs/core)
 add_subdirectory(libs/kernel)
 add_subdirectory(libs/db)
-add_subdirectory(libs/db/bindings/python)
 add_subdirectory(libs/util)
+
+# components
+add_subdirectory(components/shell)
+add_subdirectory(components/ether)
+add_subdirectory(components/recorder)
+add_subdirectory(components/replayer)
+add_subdirectory(components/explorer)
+add_subdirectory(components/py)
+add_subdirectory(components/influx)
+add_subdirectory(components/logmaster)
+add_subdirectory(components/rest)
+add_subdirectory(components/tracy)
+
+# Python bindings under libs/db
+if(SEN_BUILD_PY)
+  add_subdirectory(libs/db/bindings/python)
+endif()
 
 # apps
 add_subdirectory(apps/cli_sen)
@@ -107,29 +81,12 @@ add_subdirectory(apps/cli_archive)
 add_subdirectory(apps/cli_package)
 add_subdirectory(apps/cli_remote_shell)
 
-# critical components
-add_subdirectory(components/shell)
-add_subdirectory(components/ether)
-
-# non-critical components
-if(NOT SEN_DISABLE_EXTRA_COMPONENTS)
-  add_subdirectory(components/recorder)
-  add_subdirectory(components/replayer)
-  add_subdirectory(components/explorer)
-  add_subdirectory(components/py)
-  add_subdirectory(components/influx)
-  add_subdirectory(components/logmaster)
-  add_subdirectory(components/rest)
-  add_subdirectory(components/tracy)
-endif()
-
 # examples
 if(SEN_BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
 
 # documentation
-# Docs are not present when building with only the conan export_sources
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/docs")
   if(SEN_BUILD_DOCS)
     add_subdirectory(docs)

--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ cmake --build build/gcc/Release                   # Build Sen
 If you would like to set up the full development environment for Sen (incl. testing, docs, etc...),
 you would need to install the `pytest`, `graphviz` and `plantuml` packages using your package manager.
 
+Build configuration is driven by a coarse `mode` Conan option
+(`barebones`/`basic`/`full`) that selects which components compile and which deps Conan
+fetches. Per-component opt-out happens at the CMake step via `-DSEN_BUILD_<NAME>=OFF`.
+Developer-facing flags (`with_examples`, `with_tests`, `with_clang_tidy`, `with_coverage`,
+`with_docs`, `sanitizer`) toggle the matching CMake flags. See the
+[Building Sen](docs/getting_started/install.md#build-options) page for examples.
+
 <a name="local-workspace-setup"></a>
 ## 📦 Local Workspace Setup (Conan Editable Mode)
 

--- a/apps/cli_remote_shell/CMakeLists.txt
+++ b/apps/cli_remote_shell/CMakeLists.txt
@@ -5,6 +5,10 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 
+if(NOT SEN_BUILD_SHELL)
+  return()
+endif()
+
 include(tps/cli11)
 
 add_executable(cli_remote_shell main.cpp)

--- a/apps/cli_run/CMakeLists.txt
+++ b/apps/cli_run/CMakeLists.txt
@@ -8,7 +8,16 @@
 include(tps/cli11)
 include(tps/spdlog)
 
-set(builtin_configs builtin_configs/shell.yaml builtin_configs/explorer.yaml builtin_configs/replay.yaml)
+set(builtin_configs)
+if(SEN_BUILD_SHELL)
+  list(APPEND builtin_configs builtin_configs/shell.yaml)
+endif()
+if(SEN_BUILD_REPLAYER)
+  list(APPEND builtin_configs builtin_configs/replay.yaml)
+endif()
+if(SEN_BUILD_EXPLORER)
+  list(APPEND builtin_configs builtin_configs/explorer.yaml)
+endif()
 
 set(builtin_configs_headers)
 foreach(_config_file ${builtin_configs})
@@ -37,6 +46,16 @@ target_link_libraries(
   PUBLIC sen::core sen::kernel
   PRIVATE $<BUILD_INTERFACE:CLI11::CLI11> $<BUILD_INTERFACE:spdlog::spdlog>
 )
+
+if(SEN_BUILD_SHELL)
+  target_compile_definitions(cli_run PRIVATE SEN_CLI_RUN_HAS_SHELL_PRESET)
+endif()
+if(SEN_BUILD_REPLAYER)
+  target_compile_definitions(cli_run PRIVATE SEN_CLI_RUN_HAS_REPLAY_PRESET)
+endif()
+if(SEN_BUILD_EXPLORER)
+  target_compile_definitions(cli_run PRIVATE SEN_CLI_RUN_HAS_EXPLORER_PRESET)
+endif()
 
 add_executable(sen::cli_run ALIAS cli_run)
 sen_internal_configure_app(cli_run)

--- a/apps/cli_run/main.cpp
+++ b/apps/cli_run/main.cpp
@@ -5,11 +5,6 @@
 //                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 // =====================================================================================================================
 
-// generated
-#include "builtin_configs/explorer.h"
-#include "builtin_configs/replay.h"
-#include "builtin_configs/shell.h"
-
 // sen
 #include "sen/core/base/assert.h"
 #include "sen/core/base/hash32.h"
@@ -19,38 +14,35 @@
 // generated code
 #include "stl/sen/kernel/basic_types.stl.h"
 
+#ifdef SEN_CLI_RUN_HAS_SHELL_PRESET
+#  include "builtin_configs/shell.h"
+#endif
+#ifdef SEN_CLI_RUN_HAS_REPLAY_PRESET
+#  include "builtin_configs/replay.h"
+#endif
+#ifdef SEN_CLI_RUN_HAS_EXPLORER_PRESET
+#  include "builtin_configs/explorer.h"
+#endif
+
 // cli11
 #include <CLI/App.hpp>
 #include <CLI/CLI.hpp>  // NOLINT (misc-include-cleaner): to correctly link
 #include <CLI/Validators.hpp>
 
-// os
-#ifdef WIN32
-#  include <windows.h>
-#endif
-
 // std
-#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
 #include <memory>
-#include <stdexcept>
 #include <string>
+#include <string_view>
 #include <tuple>
-#include <vector>
 
-[[nodiscard]] bool replace(std::string& str, const std::string& from, const std::string& to)
+namespace
 {
-  size_t startPos = str.find(from);
-  if (startPos == std::string::npos)
-  {
-    return false;
-  }
-  str.replace(startPos, from.length(), to);
-  return true;
-}
+
+constexpr std::string_view happyFace = "☺";  // U+263A WHITE SMILING FACE
 
 struct RunArgs
 {
@@ -60,23 +52,24 @@ struct RunArgs
   bool printConfig = false;
 };
 
-void applyCustomConfiguration(sen::kernel::Bootloader* bootloader, const std::shared_ptr<RunArgs>& args)
+[[nodiscard]] bool replace(std::string& str, std::string_view from, std::string_view to)
 {
-  if (args->startStop)
+  const auto startPos = str.find(from);
+  if (startPos == std::string::npos)
   {
-    auto params = bootloader->getConfig().getParams();
-    params.runMode = sen::kernel::RunMode::startAndStop;
-    bootloader->getConfig().setParams(params);
+    return false;
   }
+  str.replace(startPos, from.length(), to);
+  return true;
 }
 
-std::unique_ptr<sen::kernel::Bootloader> makeBootloader(const std::shared_ptr<RunArgs>& args, CLI::App& app)
+std::unique_ptr<sen::kernel::Bootloader> makeBootloader(const std::shared_ptr<RunArgs>& args,
+                                                        [[maybe_unused]] CLI::App& app)
 {
   if (args->preset.empty())
   {
     auto bootloader = sen::kernel::Bootloader::fromYamlFile(args->configFile, args->printConfig);
 
-    // use the config file name as application name, if not specified
     if (bootloader->getConfig().getParams().appName.empty())
     {
       auto params = bootloader->getConfig().getParams();
@@ -84,27 +77,38 @@ std::unique_ptr<sen::kernel::Bootloader> makeBootloader(const std::shared_ptr<Ru
       bootloader->getConfig().setParams(params);
     }
 
-    applyCustomConfiguration(bootloader.get(), args);
-
+    if (args->startStop)
+    {
+      auto params = bootloader->getConfig().getParams();
+      params.runMode = sen::kernel::RunMode::startAndStop;
+      bootloader->getConfig().setParams(params);
+    }
     return bootloader;
   }
 
   std::string presetContents;
+  bool presetMatched = false;
+#ifdef SEN_CLI_RUN_HAS_SHELL_PRESET
   if (args->preset == "shell")
   {
     presetContents = sen::decompressSymbolToString(shell, shellSize);
+    presetMatched = true;
   }
-  else if (args->preset == "explorer")
+#endif
+#ifdef SEN_CLI_RUN_HAS_EXPLORER_PRESET
+  if (!presetMatched && args->preset == "explorer")
   {
     presetContents = sen::decompressSymbolToString(explorer, explorerSize);
+    presetMatched = true;
   }
-  else if (args->preset == "replay")
+#endif
+#ifdef SEN_CLI_RUN_HAS_REPLAY_PRESET
+  if (!presetMatched && args->preset == "replay")
   {
     bool autoPlay = true;
-    std::string autoOpen = args->configFile.string();
+    const auto autoOpen = args->configFile.string();
 
-    auto remaining = app.remaining();
-    for (const auto& elem: remaining)
+    for (const auto& elem: app.remaining())
     {
       if (elem == "--stopped")
       {
@@ -115,8 +119,10 @@ std::unique_ptr<sen::kernel::Bootloader> makeBootloader(const std::shared_ptr<Ru
     presetContents = sen::decompressSymbolToString(replay, replaySize);
     std::ignore = replace(presetContents, "$autoOpen", autoOpen);
     std::ignore = replace(presetContents, "$autoPlay", autoPlay ? "true" : "false");
+    presetMatched = true;
   }
-  else
+#endif
+  if (!presetMatched)
   {
     std::string err;
     err.append("invalid preset '");
@@ -126,10 +132,22 @@ std::unique_ptr<sen::kernel::Bootloader> makeBootloader(const std::shared_ptr<Ru
   }
 
   auto bootloader = sen::kernel::Bootloader::fromYamlString(presetContents, args->printConfig);
-  applyCustomConfiguration(bootloader.get(), args);
+  if (args->startStop)
+  {
+    auto params = bootloader->getConfig().getParams();
+    params.runMode = sen::kernel::RunMode::startAndStop;
+    bootloader->getConfig().setParams(params);
+  }
   return bootloader;
 }
 
+// Exit codes:
+//   0       success
+//   1       std::runtime_error escaped from the kernel
+//   2       std::logic_error escaped from the kernel
+//   3       other std::exception escaped from the kernel
+//   4       unknown exception escaped from the kernel
+//   other   kernel.run() returned a non-zero exit code (kernel-defined)
 [[nodiscard]] int runKernel(const std::shared_ptr<RunArgs>& args, CLI::App& app)
 {
   int exitCode = EXIT_FAILURE;
@@ -137,7 +155,6 @@ std::unique_ptr<sen::kernel::Bootloader> makeBootloader(const std::shared_ptr<Ru
   {
     auto bootloader = makeBootloader(args, app);
 
-    // install the termination handler
     if (!bootloader->getConfig().getParams().crashReportDisabled)
     {
       sen::kernel::Kernel::registerTerminationHandler();
@@ -184,23 +201,8 @@ std::unique_ptr<sen::kernel::Bootloader> makeBootloader(const std::shared_ptr<Ru
   }
 
   fputs("bye ", stdout);
-#if _WIN32
-  auto oldOutCp = GetConsoleOutputCP();
-  SetConsoleOutputCP(CP_UTF8);
-
-  auto oldCp = GetConsoleCP();
-  SetConsoleCP(CP_UTF8);
-
-  std::string happy = u8"\u263A";
-  fwrite(happy.data(), 1U, happy.length(), stdout);
-
-  SetConsoleCP(oldCp);
-  SetConsoleOutputCP(oldOutCp);
-#else
-  std::string happy = "\u263A";
-  fwrite(happy.data(), 1U, happy.length(), stdout);
-#endif
-  fputs("\n", stdout);
+  fwrite(happyFace.data(), 1U, happyFace.size(), stdout);
+  fputc('\n', stdout);
   return 0;
 }
 
@@ -214,7 +216,21 @@ int runApp(int argc, char* argv[])
   app.get_formatter()->column_width(35);
 
   app.add_option("config", args->configFile, "Configuration file")->check(CLI::ExistingPath);
-  app.add_option("--preset", args->preset, "Preset name")->check(CLI::IsMember({"shell", "explorer", "replay"}));
+#if defined(SEN_CLI_RUN_HAS_SHELL_PRESET) || defined(SEN_CLI_RUN_HAS_REPLAY_PRESET) ||                                 \
+  defined(SEN_CLI_RUN_HAS_EXPLORER_PRESET)
+  app.add_option("--preset", args->preset, "Preset name")
+    ->check(CLI::IsMember({
+#  ifdef SEN_CLI_RUN_HAS_SHELL_PRESET
+      "shell",
+#  endif
+#  ifdef SEN_CLI_RUN_HAS_REPLAY_PRESET
+      "replay",
+#  endif
+#  ifdef SEN_CLI_RUN_HAS_EXPLORER_PRESET
+      "explorer",
+#  endif
+    }));
+#endif
   app.add_flag("--start-stop", args->startStop, "Stop execution after all components are running");
   app.add_flag("--print-config", args->printConfig, "Print the configuration that will be used");
 
@@ -222,6 +238,8 @@ int runApp(int argc, char* argv[])
 
   return runKernel(args, app);
 }
+
+}  // namespace
 
 int main(int argc, char* argv[])
 {

--- a/cmake/util/sen_internal_utils.cmake
+++ b/cmake/util/sen_internal_utils.cmake
@@ -11,6 +11,10 @@ include_guard()
 # global configuration
 # ===================================================================================================================
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.2.1)
+  message(FATAL_ERROR "GCC ${CMAKE_CXX_COMPILER_VERSION} is not supported.")
+endif()
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_INSTALL_LIBDIR lib)
 set(CMAKE_LINK_WHAT_YOU_USE OFF "Enable this to get feedback about the linkage")
@@ -120,6 +124,43 @@ function(sen_internal_generate_template_headers)
 
 endfunction()
 
+# Guard the rest of a Sen component's CMakeLists. Place at the top, above any
+# include(tps/<dep>) - declares the SEN_BUILD_<NAME> cache option (default ON, idempotent),
+# and returns from the calling file if the option is OFF so no Conan deps get pulled in.
+#
+# Must be a macro (not a function) for return() to exit the calling CMakeLists file.
+#
+# Arguments:
+#   NAME        - component name (lower case). Used to derive SEN_BUILD_<NAME>.
+#   DESCRIPTION - (optional) human-readable description for the option cache entry.
+macro(sen_internal_component_guard)
+  set(_one_value_args NAME DESCRIPTION)
+  cmake_parse_arguments(
+    _guard
+    ""
+    "${_one_value_args}"
+    ""
+    ${ARGN}
+  )
+
+  if(NOT _guard_NAME)
+    message(FATAL_ERROR "sen_internal_component_guard: NAME is required")
+  endif()
+
+  string(TOUPPER "${_guard_NAME}" _guard_upper)
+  set(_guard_option_name "SEN_BUILD_${_guard_upper}")
+
+  if(NOT _guard_DESCRIPTION)
+    set(_guard_DESCRIPTION "Build the ${_guard_NAME} component")
+  endif()
+
+  option(${_guard_option_name} "${_guard_DESCRIPTION}" ON)
+
+  if(NOT ${_guard_option_name})
+    return()
+  endif()
+endmacro()
+
 function(sen_internal_install target_name)
   if(UNIX AND NOT APPLE)
     set_property(TARGET ${target_name} PROPERTY INSTALL_RPATH "$ORIGIN")
@@ -198,15 +239,50 @@ if(SEN_ENABLE_CMAKE_TARGET_GRAPH)
   find_program(dot_executable dot)
   if(NOT dot_executable)
     message(WARNING "'dot' executable not found. Dependency graph cannot be generated.")
-    return()
+  else()
+    add_custom_command(
+      TARGET cmake_target_graph
+      POST_BUILD
+      COMMAND ${dot_executable} -Tsvg ${CMAKE_BINARY_DIR}/${_post_file} -o ${CMAKE_SOURCE_DIR}/sen.svg
+      COMMENT "Generating graph: sen.svg"
+    )
   endif()
+endif()
 
-  add_custom_command(
-    TARGET cmake_target_graph
-    POST_BUILD
-    COMMAND ${dot_executable} -Tsvg ${CMAKE_BINARY_DIR}/${_post_file} -o ${CMAKE_SOURCE_DIR}/sen.svg
-    COMMENT "Generating graph: sen.svg"
-  )
+# configure coverage as an interface target so flags apply only to sen targets,
+# not to every target in the directory tree (e.g. third-party add_subdirectory targets).
+add_library(sen_coverage_flags INTERFACE)
+if(SEN_COVERAGE_ENABLE)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(
+      sen_coverage_flags
+      INTERFACE -g
+                -O0
+                -fno-inline
+                --coverage
+    )
+    target_link_options(sen_coverage_flags INTERFACE --coverage)
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    file(TO_NATIVE_PATH "${CMAKE_BINARY_DIR}/coverage_data/coverage-%p-%m.profraw" SEN_COVERAGE_DATA_DIR)
+    target_compile_options(
+      sen_coverage_flags
+      INTERFACE -g
+                -O0
+                -fno-inline
+                -fprofile-instr-generate=${SEN_COVERAGE_DATA_DIR}
+                -fcoverage-mapping
+    )
+    target_link_options(
+      sen_coverage_flags
+      INTERFACE
+      -fprofile-instr-generate=${SEN_COVERAGE_DATA_DIR}
+      -fcoverage-mapping
+    )
+  endif()
+endif()
+
+if(MSVC)
+  add_compile_options(/bigobj)
 endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)

--- a/components/ether/CMakeLists.txt
+++ b/components/ether/CMakeLists.txt
@@ -5,6 +5,8 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 
+sen_internal_component_guard(NAME ether)
+
 include(tps/spdlog)
 include(tps/asio)
 include(tps/concurrentqueue)

--- a/components/explorer/CMakeLists.txt
+++ b/components/explorer/CMakeLists.txt
@@ -5,6 +5,8 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 
+sen_internal_component_guard(NAME explorer)
+
 include(tps/implot)
 include(tps/spdlog)
 

--- a/components/influx/CMakeLists.txt
+++ b/components/influx/CMakeLists.txt
@@ -5,6 +5,8 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 
+sen_internal_component_guard(NAME influx)
+
 include(tps/spdlog)
 include(tps/asio)
 

--- a/components/logmaster/CMakeLists.txt
+++ b/components/logmaster/CMakeLists.txt
@@ -5,6 +5,8 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 
+sen_internal_component_guard(NAME logmaster)
+
 include(tps/spdlog)
 
 add_sen_package(

--- a/components/py/CMakeLists.txt
+++ b/components/py/CMakeLists.txt
@@ -5,6 +5,13 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 
+sen_internal_component_guard(
+  NAME
+  py
+  DESCRIPTION
+  "Build Python integration (components/py and libs/db Python bindings)"
+)
+
 include(tps/pybind11)
 include(tps/spdlog)
 

--- a/components/recorder/CMakeLists.txt
+++ b/components/recorder/CMakeLists.txt
@@ -5,6 +5,8 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 
+sen_internal_component_guard(NAME recorder)
+
 include(tps/spdlog)
 
 set(_recorder_stl_files stl/sen/components/recorder/configuration.stl stl/sen/components/recorder/recorder.stl)

--- a/components/replayer/CMakeLists.txt
+++ b/components/replayer/CMakeLists.txt
@@ -5,6 +5,8 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 
+sen_internal_component_guard(NAME replayer)
+
 include(tps/spdlog)
 
 set(_replayer_stl_files stl/sen/components/replayer/configuration.stl stl/sen/components/replayer/replayer.stl)

--- a/components/rest/CMakeLists.txt
+++ b/components/rest/CMakeLists.txt
@@ -5,6 +5,8 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 
+sen_internal_component_guard(NAME rest)
+
 include(tps/asio)
 include(tps/cpptrace)
 include(tps/spdlog)

--- a/components/shell/CMakeLists.txt
+++ b/components/shell/CMakeLists.txt
@@ -5,6 +5,8 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 
+sen_internal_component_guard(NAME shell)
+
 include(tps/asio)
 include(tps/cli11)
 

--- a/components/tracy/CMakeLists.txt
+++ b/components/tracy/CMakeLists.txt
@@ -5,6 +5,8 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 
+sen_internal_component_guard(NAME tracy)
+
 include(tps/tracy)
 
 add_sen_package(

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,12 +8,19 @@
 
 from os import getenv
 from os.path import isdir, join
+from pathlib import Path
 
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy
 from conan.tools.scm.git import Git
 from conan.tools.system.package_manager import Apt, Dnf, Yum, Zypper
+
+COMPONENTS = tuple(sorted(p.parent.name for p in (Path(__file__).parent / "components").glob("*/CMakeLists.txt")))
+
+# Components enabled by `mode=basic`. `mode=full` enables every COMPONENT;
+# `mode=barebones` enables none.
+_BASIC_COMPONENTS = frozenset({"shell", "ether"})
 
 
 class SenConan(ConanFile):
@@ -30,15 +37,51 @@ class SenConan(ConanFile):
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
 
+    # Allow component discovery from the recipe folder.
+    exports = "components/*/CMakeLists.txt"
+
+    # Conan-level component selection is `mode` only - per-component would explode
+    # package_id. CMake-level `-DSEN_BUILD_<COMP>=OFF` is the per-component override.
+    options = {
+        "mode": ["barebones", "basic", "full"],  # barebones: no components, basic: shell + ether
+        "with_examples": [True, False],
+        "with_tests": [True, False],
+        "with_clang_tidy": [True, False],
+        "with_coverage": [True, False],
+        "with_docs": [True, False],
+        "sanitizer": ["none", "address", "thread"],
+    }
+    default_options = {
+        "mode": "full",
+        "with_examples": False,
+        "with_tests": False,
+        "with_clang_tidy": False,
+        "with_coverage": False,
+        "with_docs": False,
+        "sanitizer": "none",
+    }
+
+    def _is_component_enabled(self, name):
+        """Whether component `name` is enabled for the active `mode`."""
+        if name not in COMPONENTS:
+            raise ValueError(f"unknown component '{name}'; valid: {sorted(COMPONENTS)}")
+        mode = str(self.options.mode)
+        if mode == "full":
+            return True
+        if mode == "basic":
+            return name in _BASIC_COMPONENTS
+        return False  # barebones
+
     def build_requirements(self):
         """Defines the dependencies only need for building of Sen."""
         self.tool_requires("cmake/3.28.1")
         self.tool_requires("ninja/1.13.2")
         self.test_requires("gtest/1.17.0")
+        if self.options.with_docs:
+            self.tool_requires("doxygen/[>=1.15.0]")
 
     def requirements(self):
         """Defines the dependencies of Sen."""
-        # non-visible dependencies
         self.requires("asio/1.36.0", visible=False)
         self.requires("cli11/2.3.2", visible=False)
         self.requires("concurrentqueue/1.0.4", visible=False)
@@ -48,33 +91,36 @@ class SenConan(ConanFile):
         self.requires("pugixml/1.14", visible=False)
         self.requires("rapidyaml/0.5.0", visible=False)
         self.requires("cpptrace/1.0.4", visible=False)
-        self.requires("llhttp/9.1.3", visible=False)
-        self.requires("tracy/0.12.1", options={"delayed_init": True, "manual_lifetime": True}, visible=False)
-
-        # Custom version of implot that uses imgui/1.90.5-docking.
-        # imgui is overridden to pin the docking branch required by implot.
-        # Without this, Conan would resolve imgui to the non-docking variant.
-        self.requires("implot/0.16", visible=False)
-        self.requires("imgui/1.90.5-docking", override=True, visible=False)
-
-        # visible dependencies
-        self.requires("pybind11/2.13.6", visible=True)
         self.requires("spdlog/1.17.0", visible=True)
 
-        # our usage of imgui in Linux has an implicit dependency on SDL.
-        # SDL has a missing dependency on libext-dev, so we need to install it.
-        if self.settings.os == "Linux":
-            self.requires(
-                "sdl/2.24.0",
-                options={"alsa": False, "pulse": False, "shared": True, "wayland": False, "libunwind": False},
-                visible=False,
-            )
+        # explorer-only: ImGui + ImPlot + SDL.
+        # ImGui is overridden to pin the docking branch required by ImPlot.
+        # Conan would resolve imgui to the non-docking variant otherwise.
+        if self._is_component_enabled("explorer"):
+            self.requires("implot/0.16", visible=False)
+            self.requires("imgui/1.90.5-docking", override=True, visible=False)
+            if self.settings.os == "Linux":
+                self.requires(
+                    "sdl/2.24.0",
+                    options={"alsa": False, "pulse": False, "shared": True, "wayland": False, "libunwind": False},
+                    visible=False,
+                )
+
+        # py-only (Python integration)
+        if self._is_component_enabled("py"):
+            self.requires("pybind11/2.13.6", visible=True)
+
+        # rest-only
+        if self._is_component_enabled("rest"):
+            self.requires("llhttp/9.1.3", visible=False)
+
+        # tracy-only
+        if self._is_component_enabled("tracy"):
+            self.requires("tracy/0.12.1", options={"delayed_init": True, "manual_lifetime": True}, visible=False)
 
     def system_requirements(self):
-        """Defines the system requirements of Sen."""
-        # our usage of imgui on Linux has an implicit dependency on SDL,
-        # which itself requires libXext. Install it via the system package manager.
-        if self.settings.os == "Linux":
+        """SDL (pulled in by the explorer on Linux) requires libXext at the system level."""
+        if self.settings.os == "Linux" and self._is_component_enabled("explorer"):
             Apt(self).install(["libxext-dev"], update=True)  # ubuntu, debian, ...
             Yum(self).install(["libXext-devel"], update=True)  # almalinux, rockylinux, ...
             Dnf(self).install(["libXext-devel"], update=True)  # fedora, rhel, centos, ...
@@ -143,11 +189,20 @@ class SenConan(ConanFile):
         deps.generate()
 
         tc = CMakeToolchain(self)
-        tc.cache_variables["SEN_DISABLE_CLANG_TIDY"] = "OFF" if env_var_to_bool("ENABLE_CT") else "ON"
-        tc.cache_variables["SEN_COVERAGE_ENABLE"] = "ON" if env_var_to_bool("ENABLE_COVERAGE") else "OFF"
-        tc.cache_variables["SEN_BUILD_EXAMPLES"] = "ON" if env_var_to_bool("ENABLE_EXAMPLES") else "OFF"
-        tc.cache_variables["SEN_BUILD_TESTS"] = "ON" if env_var_to_bool("ENABLE_TESTS") else "OFF"
-        tc.cache_variables["SEN_USE_SANITIZER"] = select_sanitizer()
+        tc.cache_variables["SEN_DISABLE_CLANG_TIDY"] = "OFF" if self.options.with_clang_tidy else "ON"
+        tc.cache_variables["SEN_COVERAGE_ENABLE"] = "ON" if self.options.with_coverage else "OFF"
+        tc.cache_variables["SEN_BUILD_EXAMPLES"] = "ON" if self.options.with_examples else "OFF"
+        tc.cache_variables["SEN_BUILD_TESTS"] = "ON" if self.options.with_tests else "OFF"
+        tc.cache_variables["SEN_BUILD_DOCS"] = "ON" if self.options.with_docs else "OFF"
+        tc.cache_variables["SEN_USE_SANITIZER"] = {
+            "none": "None",
+            "address": "ASanUBSan",
+            "thread": "Thread",
+        }[str(self.options.sanitizer)]
+
+        for component in COMPONENTS:
+            is_on = self._is_component_enabled(component)
+            tc.cache_variables[f"SEN_BUILD_{component.upper()}"] = "ON" if is_on else "OFF"
 
         # directory for the generated documentation
         site_dir = getenv("MKDOCS_SITE_DIR")
@@ -191,21 +246,3 @@ class SenConan(ConanFile):
             self.runenv_info.prepend_path("LD_LIBRARY_PATH", join(self.package_folder, "bin"))
 
         # Windows: PATH is already prepended above; no additional loader path needed.
-
-
-def env_var_to_bool(env_var_name):
-    """Returns True if the environment variable is set to a truthy value, False otherwise."""
-    return getenv(env_var_name, "").lower() in ("true", "on", "1", "yes")
-
-
-def select_sanitizer() -> str:
-    """Determine which sanitizer should be enabled."""
-    if env_var_to_bool("ENABLE_ASAN"):
-        print("Configuring address and undefined-behavior sanitizers...")
-        return "ASanUBSan"
-
-    if env_var_to_bool("ENABLE_TSAN"):
-        print("Configuring thread sanitizer...")
-        return "Thread"
-
-    return "None"

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -60,6 +60,13 @@ ${sen_exec} generate json component fom --help > ${snippets_dir}/sen_generate_js
 \n\
 ${sen_exec} generate json schema --help > ${snippets_dir}/sen_generate_json_schema.sh\n\
 \n\
+${sen_exec} generate py --help > ${snippets_dir}/sen_generate_py.sh\n\
+${sen_exec} generate py stl --help > ${snippets_dir}/sen_generate_py_stl.sh\n\
+${sen_exec} generate py fom --help > ${snippets_dir}/sen_generate_py_fom.sh\n\
+\n\
+${sen_exec} generate ts --help > ${snippets_dir}/sen_generate_ts.sh\n\
+${sen_exec} generate ts stl --help > ${snippets_dir}/sen_generate_ts_stl.sh\n\
+\n\
 ${sen_exec} archive --help > ${snippets_dir}/sen_archive.sh\n\
 ${sen_exec} archive indexed --help > ${snippets_dir}/sen_archive_indexed.sh\n\
 ${sen_exec} archive info --help > ${snippets_dir}/sen_archive_info.sh\n\
@@ -112,6 +119,11 @@ exit 0"
       ${snippets_dir}/sen_generate_json_component_stl.sh
       ${snippets_dir}/sen_generate_json_component_fom.sh
       ${snippets_dir}/sen_generate_json_schema.sh
+      ${snippets_dir}/sen_generate_py.sh
+      ${snippets_dir}/sen_generate_py_stl.sh
+      ${snippets_dir}/sen_generate_py_fom.sh
+      ${snippets_dir}/sen_generate_ts.sh
+      ${snippets_dir}/sen_generate_ts_stl.sh
       ${snippets_dir}/sen_archive.sh
       ${snippets_dir}/sen_archive_indexed.sh
       ${snippets_dir}/sen_archive_info.sh

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -189,3 +189,68 @@ Use Conan to fetch the third-party dependencies `conan install . --profile=sen_g
 To build, use `conan build . --profile=sen_gcc`. Alternatively, use
 `cmake -S . -B build -G Ninja --preset sen_gcc && cmake --build build` (you can replace 'sen_gcc'
 with the preset of your choice).
+
+??? note "Build options"
+
+    **Component selection**
+
+     `mode` is the Conan-level switch; it picks which components compile and which
+     deps Conan fetches.
+
+     | Mode        | Components enabled                                                                |
+     | ----------- | --------------------------------------------------------------------------------- |
+     | `barebones` | none - libs only, for embedding Sen as a library                                  |
+     | `basic`     | `shell`, `ether` (minimum interactive set)                                        |
+     | `full`      | every component (default)                                                         |
+
+     ```shell
+     conan install . --profile=sen_gcc -o sen/*:mode=barebones --build=missing
+     conan install . --profile=sen_gcc -o sen/*:mode=basic --build=missing
+     ```
+
+     Per-component Conan options are deliberately not exposed (combinatorial
+     package_id). Developers skip building specific components at the CMake step:
+
+     ```shell
+     conan install . --profile=sen_gcc --build=missing
+     cmake --preset conan-gcc-release -DSEN_BUILD_TRACY=OFF -DSEN_BUILD_EXPLORER=OFF
+     ```
+
+     The CMake override doesn't change what Conan fetched. Components beyond `mode`
+     can't be enabled this way (their deps weren't fetched).
+
+     **Developer-facing flags**
+
+     Examples, tests, static analysis, coverage, sanitizers, and documentation are exposed as Conan
+     options. All default to off. Turn on what you need with `-o sen/*:…=True`.
+
+     | Option            | Default  | Maps to                                                                       |
+     | ----------------- | -------- | ----------------------------------------------------------------------------- |
+     | `with_examples`   | `False`  | `-DSEN_BUILD_EXAMPLES=ON`                                                     |
+     | `with_tests`      | `False`  | `-DSEN_BUILD_TESTS=ON`                                                        |
+     | `with_clang_tidy` | `False`  | `-DSEN_DISABLE_CLANG_TIDY=OFF` (polarity flipped)                             |
+     | `with_coverage`   | `False`  | `-DSEN_COVERAGE_ENABLE=ON`                                                    |
+     | `with_docs`       | `False`  | `-DSEN_BUILD_DOCS=ON` and pulls `doxygen` as a tool requirement               |
+     | `sanitizer`       | `"none"` | `-DSEN_USE_SANITIZER=None`/`ASanUBSan`/`Thread` for `none`/`address`/`thread` |
+
+     Options are applied at `conan install` time — that's the step that generates the build files. The
+     subsequent `conan build` (or a direct `cmake --build`) just compiles with the settings already baked
+     in; the `-D` mappings above are for users invoking CMake without Conan.
+
+     ```shell
+     # Configure a build that compiles the test suite with the address sanitizer
+     conan install . --profile=sen_gcc -o sen/*:with_tests=True -o sen/*:sanitizer=address --build=missing
+     ```
+
+     **Building the docs**
+
+     `with_docs=True` pulls `doxygen` automatically, but `doxygen` itself needs `compiler.cppstd=20`
+     (set per-dep), which has to come from a profile rather than from the recipe. Sen ships a
+     `sen_build_docs` profile that sets both, so the one-liner for docs is:
+
+     ```shell
+     conan install . --profile=sen_build_docs --build=missing
+     ```
+
+     `mkdocs` and `graphviz` are not Conan-managed - install them via `pip install -r docs/requirements.txt`
+     and your platform package manager.

--- a/docs/users_guide/command_line.md
+++ b/docs/users_guide/command_line.md
@@ -400,6 +400,39 @@ Generates json schemas from a Sen data model.
 --8<-- "snippets/sen_generate_json_schema.sh"
 ```
 
+### Python
+
+```title="sen generate py"
+--8<-- "snippets/sen_generate_py.sh"
+```
+
+#### Python from STL
+
+```title="sen generate py stl"
+--8<-- "snippets/sen_generate_py_stl.sh"
+```
+
+#### Python from HLA FOMs
+
+```title="sen generate py fom"
+--8<-- "snippets/sen_generate_py_fom.sh"
+```
+
+### TypeScript
+
+TypeScript generation reads STL only; there is no FOM subcommand today
+(no HLA model targets TS).
+
+```title="sen generate ts"
+--8<-- "snippets/sen_generate_ts.sh"
+```
+
+#### TypeScript from STL
+
+```title="sen generate ts stl"
+--8<-- "snippets/sen_generate_ts_stl.sh"
+```
+
 ## Archiving Utility
 
 Helps you interact with archives.

--- a/examples/config/CMakeLists.txt
+++ b/examples/config/CMakeLists.txt
@@ -13,25 +13,120 @@ file(
   "${CMAKE_CURRENT_LIST_DIR}/*.yaml"
 )
 
-# create a smoke test for each configuratin
+# Walk yaml_path's top-level `load:` block and (recursively) the files referenced by its
+# `include:` block, collecting each `- name: <X>` at the load list's outer indent. Names
+# at deeper indents (e.g. shell.query items) are skipped. Cycle-safe via visited set.
+function(
+  _sen_collect_load_components
+  yaml_path
+  out_var
+  visited_var
+)
+  get_filename_component(_abs "${yaml_path}" ABSOLUTE)
+  if(_abs IN_LIST ${visited_var})
+    set(${out_var}
+        ""
+        PARENT_SCOPE
+    )
+    return()
+  endif()
+  list(APPEND ${visited_var} "${_abs}")
+  set(${visited_var}
+      "${${visited_var}}"
+      PARENT_SCOPE
+  )
+
+  if(NOT EXISTS "${_abs}")
+    message(FATAL_ERROR "examples/config: included file not found: ${_abs}")
+  endif()
+
+  file(STRINGS "${_abs}" _lines)
+  set(_section "")
+  set(_collected "")
+  set(_includes "")
+  foreach(_line IN LISTS _lines)
+    if(_line MATCHES "^load:")
+      set(_section "load")
+    elseif(_line MATCHES "^include:")
+      set(_section "include")
+    elseif(_line MATCHES "^[A-Za-z]")
+      set(_section "")
+    elseif(_section STREQUAL "load" AND _line MATCHES "^  - name: ([A-Za-z_][A-Za-z0-9_]*)")
+      list(APPEND _collected "${CMAKE_MATCH_1}")
+    elseif(_section STREQUAL "include" AND _line MATCHES "^  - (.+)$")
+      set(_inc "${CMAKE_MATCH_1}")
+      string(STRIP "${_inc}" _inc)
+      list(APPEND _includes "${_inc}")
+    endif()
+  endforeach()
+
+  get_filename_component(_yaml_dir "${_abs}" DIRECTORY)
+  foreach(_inc IN LISTS _includes)
+    get_filename_component(_inc_abs "${_yaml_dir}/${_inc}" ABSOLUTE)
+    _sen_collect_load_components("${_inc_abs}" _sub ${visited_var})
+    list(APPEND _collected ${_sub})
+    set(${visited_var}
+        "${${visited_var}}"
+        PARENT_SCOPE
+    )
+  endforeach()
+
+  set(${out_var}
+      "${_collected}"
+      PARENT_SCOPE
+  )
+endfunction()
+
+# the shell is always used in our smoke tests
+if(NOT SEN_BUILD_SHELL)
+  return()
+endif()
+
 foreach(config_file ${configs})
 
-  # skip explorer-related configurations
-  if(config_file MATCHES "/[0-9]+_+.*\.yaml")
-    if(NOT
-       config_file
-       MATCHES
-       "_exp.yaml$"
-    )
+  if(NOT
+     config_file
+     MATCHES
+     "/[0-9]+_+.*\.yaml"
+  )
+    continue()
+  endif()
 
-      get_filename_component(config ${config_file} NAME_WE)
+  # explorer GUI configs need a display; never smoke-test them
+  if(config_file MATCHES "_exp.yaml$")
+    continue()
+  endif()
 
-      set(test_name ${config}_smoke)
-      add_sen_run_smoke_test(${test_name} CONFIG_FILE ${config_file})
+  set(_visited "")
+  _sen_collect_load_components("${config_file}" _required_components _visited)
+  list(REMOVE_DUPLICATES _required_components)
 
-      append_test_env_modification(
-        ${test_name} "PYTHONPATH=path_list_append:${PROJECT_SOURCE_DIR}/examples/config/10_python/scripts"
+  set(_skip_smoke FALSE)
+  foreach(_comp IN LISTS _required_components)
+    string(TOUPPER "${_comp}" _comp_upper)
+    if(NOT DEFINED SEN_BUILD_${_comp_upper})
+      message(
+        FATAL_ERROR
+          "examples/config: '${config_file}' loads component '${_comp}', but "
+          "SEN_BUILD_${_comp_upper} is not defined. Either it is a typo or a "
+          "new Sen component is missing from conanfile.py COMPONENTS."
       )
     endif()
+    if(NOT SEN_BUILD_${_comp_upper})
+      set(_skip_smoke TRUE)
+      break()
+    endif()
+  endforeach()
+  if(_skip_smoke)
+    continue()
   endif()
+
+  get_filename_component(config ${config_file} NAME_WE)
+
+  set(test_name ${config}_smoke)
+  add_sen_run_smoke_test(${test_name} CONFIG_FILE ${config_file})
+
+  append_test_env_modification(
+    ${test_name} "PYTHONPATH=path_list_append:${PROJECT_SOURCE_DIR}/examples/config/10_python/scripts"
+  )
 endforeach()

--- a/libs/kernel/test/CMakeLists.txt
+++ b/libs/kernel/test/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 add_subdirectory(unit)
 
-# Disable integration tests due to windows build agent problems
+# Disable integration tests in Windows
 if(NOT MSVC)
   add_subdirectory(integration/test_helpers)
   # TODO(SEN-1725): Need to figure out github support
@@ -19,7 +19,10 @@ if(NOT MSVC)
   # integration tests that use containers (only available in Linux)
   if(LINUX)
     #   add_subdirectory(integration/object_sync)
-    add_subdirectory(integration/interest_filtering)
+    # interest_filtering drives multi-process runs over the ether component
+    if(SEN_BUILD_ETHER)
+      add_subdirectory(integration/interest_filtering)
+    endif()
     #   add_subdirectory(integration/stress_tests/high_churn_subs)
   endif()
 endif()


### PR DESCRIPTION
Conan decides what the build contains and therefore what it fetches: `mode` picks
the components, and the `with_*` flags cover examples, tests, clang-tidy, coverage,
sanitizers and the documentation. A `basic` build resolves 19 dependencies where a
`full` one resolves 29, so a build without the explorer no longer downloads imgui,
SDL and opengl to leave them unused. Components keep a cmake guard, which is how a
developer skips one for a while.

Breaking: `SEN_DISABLE_EXTRA_COMPONENTS` and the `ENABLE_*` environment variables
are gone; use the matching conan options.
