### PR TITLE
ci: publish the test report on the run page

### DIFF
--- a/.github/scripts/test_report.py
+++ b/.github/scripts/test_report.py
@@ -1,0 +1,78 @@
+# === test_report.py ===================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Renders the ctest JUnit report as a job summary.
+
+A report with no tests in it is an error: a build configured without tests
+runs the suite, finds nothing and would otherwise pass.
+"""
+
+import sys
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+class EmptyReport(Exception):
+    """Raised when the report holds no test cases."""
+
+
+def read_report(path: Path) -> tuple[int, int, int, list[str]]:
+    """Returns totals and the names of the failed cases."""
+    cases = ElementTree.parse(path).getroot().iter("testcase")
+
+    total = 0
+    failed: list[str] = []
+    skipped = 0
+    for case in cases:
+        total += 1
+        if case.find("skipped") is not None:
+            skipped += 1
+        elif case.find("failure") is not None or case.find("error") is not None:
+            failed.append(f"{case.get('classname', '')}.{case.get('name', '?')}".lstrip("."))
+
+    if total == 0:
+        raise EmptyReport(f"{path} holds no test cases")
+
+    return total, skipped, total - skipped - len(failed), failed
+
+
+def render(total: int, skipped: int, passed: int, failed: list[str]) -> str:
+    """Returns the markdown for the job summary."""
+    lines = [
+        "### Tests",
+        "",
+        "| Total | Passed | Failed | Skipped |",
+        "| ----: | -----: | -----: | ------: |",
+        f"| {total} | {passed} | {len(failed)} | {skipped} |",
+    ]
+    if failed:
+        lines += ["", "Failed:", ""] + [f"- `{name}`" for name in failed]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    """Prints the summary for the report named on the command line."""
+    if len(sys.argv) != 2:
+        print("usage: test_report.py <ctestReport.xml>", file=sys.stderr)
+        return 2
+
+    path = Path(sys.argv[1])
+    if not path.is_file():
+        print(f"no test report at {path}", file=sys.stderr)
+        return 1
+
+    try:
+        total, skipped, passed, failed = read_report(path)
+    except EmptyReport as empty:
+        print(empty, file=sys.stderr)
+        return 1
+
+    print(render(total, skipped, passed, failed), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_test_report.py
+++ b/.github/scripts/test_test_report.py
@@ -1,0 +1,54 @@
+# === test_test_report.py ==============================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Pins the counting and the empty-report failure."""
+
+import pytest
+from test_report import EmptyReport, main, read_report
+
+REPORT = """<?xml version="1.0"?>
+<testsuite name="sen" tests="4">
+  <testcase classname="core" name="passes"/>
+  <testcase classname="core" name="fails"><failure message="boom"/></testcase>
+  <testcase classname="kernel" name="errors"><error message="boom"/></testcase>
+  <testcase classname="kernel" name="skipped"><skipped/></testcase>
+</testsuite>
+"""
+
+
+def write(tmp_path, body):
+    """Writes a report and returns its path."""
+    path = tmp_path / "ctestReport.xml"
+    path.write_text(body)
+    return path
+
+
+def test_counts_each_outcome(tmp_path):
+    """Failures and errors both count as failed; skips are their own column."""
+    total, skipped, passed, failed = read_report(write(tmp_path, REPORT))
+    assert (total, skipped, passed) == (4, 1, 1)
+    assert failed == ["core.fails", "kernel.errors"]
+
+
+def test_a_report_without_tests_is_an_error(tmp_path):
+    """A build configured without tests produces this, and it must not pass."""
+    with pytest.raises(EmptyReport):
+        read_report(write(tmp_path, '<?xml version="1.0"?>\n<testsuite name="sen" tests="0"/>\n'))
+
+
+def test_a_missing_report_fails(tmp_path, monkeypatch):
+    """The suite never ran, so there is nothing to report on."""
+    monkeypatch.setattr("sys.argv", ["test_report.py", str(tmp_path / "absent.xml")])
+    assert main() == 1
+
+
+def test_summary_lists_the_failed_cases(tmp_path, monkeypatch, capsys):
+    """The names are what a reader needs; the counts alone do not identify them."""
+    monkeypatch.setattr("sys.argv", ["test_report.py", str(write(tmp_path, REPORT))])
+    assert main() == 0
+    out = capsys.readouterr().out
+    assert "| 4 | 1 | 2 | 1 |" in out
+    assert "- `core.fails`" in out

--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -159,6 +159,15 @@ jobs:
           cmake --build build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/ \
             --target generate-coverage-report
 
+      # Runs even when the build failed: that is when the report is worth reading.
+      - name: Publish the test report
+        if: always()
+        shell: bash
+        run: |
+          python .github/scripts/test_report.py \
+            "build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/ctestReport.xml" \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Publish the coverage report
         if: matrix.enable_coverage
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4


### PR DESCRIPTION
Every leg already produces a merged junit report and then throws it away, so the
only way to see what ran was to read the log. The run page now carries the counts
and the names of the failures, and a report with no tests in it fails the step:
a build configured without tests runs the suite, finds nothing and would
otherwise pass.
