### PR TITLE
ci: write the shared caches only from main

### DIFF
--- a/.github/actions/build_documentation/action.yaml
+++ b/.github/actions/build_documentation/action.yaml
@@ -12,7 +12,11 @@ runs:
       shell: bash
       run: echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_ENV"
 
-    - uses: actions/cache@v5
+    # Saved only on main, as in standard_test.yaml: a cache written from a pull
+    # request is private to it, and open pull requests together pass the 10 GB
+    # limit.
+    - name: Restore conan packages
+      uses: actions/cache/restore@v5
       with:
         path: ~/.conan2/p
         key: conanp-docs-${{ env.cache_date }}
@@ -23,6 +27,8 @@ runs:
         key: docs
         max-size: 1G
         verbose: 1
+        # Same reasoning as the conan cache above.
+        save: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install system dependencies
       shell: bash
@@ -67,3 +73,12 @@ runs:
     - name: Remove unwanted parts from conan cache before backup
       shell: bash
       run: conan cache clean "*" -s -b -d
+
+    # After the clean, so build folders stay out. main gets here through
+    # build_docs.yaml, which is what keeps the slice pull requests restore.
+    - name: Save conan packages
+      if: always() && github.ref == 'refs/heads/main'
+      uses: actions/cache/save@v5
+      with:
+        path: ~/.conan2/p
+        key: conanp-docs-${{ env.cache_date }}

--- a/.github/workflows/conan.yaml
+++ b/.github/workflows/conan.yaml
@@ -61,9 +61,10 @@ jobs:
         run: echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_ENV"
 
       # Same key scheme as standard_test.yaml so both workflows share one
-      # dependency slice per compiler (dependencies are always Release).
-      - name: Cache conan packages
-        uses: actions/cache@v5
+      # dependency slice per compiler (dependencies are always Release), and
+      # the same save-only-on-main split, for the same reason.
+      - name: Restore conan packages
+        uses: actions/cache/restore@v5
         with:
           path: ~/.conan2/p
           key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ env.cache_date }}
@@ -75,6 +76,7 @@ jobs:
           key: ${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ matrix.build_type }}
           max-size: 1G
           verbose: 1
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup build context
         uses: ./.github/actions/setup_build_context
@@ -106,3 +108,11 @@ jobs:
         run: |
           conan remove sen --confirm
           conan cache clean "*" -s -b -d
+
+      # After the clean, so sen itself and the build folders stay out.
+      - name: Save conan packages
+        if: always() && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.conan2/p
+          key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ env.cache_date }}

--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -38,7 +38,9 @@ jobs:
     needs: compute-matrix-jobs
     runs-on: ${{ matrix.runner }}
       # Generous on purpose: a cold cache builds every dependency from
-      # source. The cap ends a hang, it does not police duration.
+      # source. The cap ends a hang, it does not police duration. Measured
+      # 2026-08-20 on a run whose conan cache missed and whose ccache hit 1.3
+      # per cent: 20 to 30 minutes, so this is around four times the work.
     timeout-minutes: 120
     strategy:
       fail-fast: true
@@ -58,8 +60,12 @@ jobs:
 
       # Dependencies are always Release, so one slice serves the Debug and
       # Release jobs of a compiler alike.
-      - name: Cache conan packages
-        uses: actions/cache@v5
+      #
+      # Saved only on main, at the end of the job: a cache written from a pull
+      # request is private to it, so open pull requests each store the same
+      # slice and the repository passes GitHub's 10 GB limit.
+      - name: Restore conan packages
+        uses: actions/cache/restore@v5
         with:
           path: ~/.conan2/p
           key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ env.cache_date }}
@@ -71,6 +77,8 @@ jobs:
           key: ${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ matrix.build_type }}
           max-size: 1G
           verbose: 1
+          # Same reasoning as the conan cache above.
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup build context
         uses: ./.github/actions/setup_build_context
@@ -181,3 +189,12 @@ jobs:
         shell: bash
         run: |
           conan cache clean "*" -s -b -d
+
+      # After the clean, so build folders stay out. always() keeps what a
+      # cancelled run already built.
+      - name: Save conan packages
+        if: always() && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.conan2/p
+          key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ env.cache_date }}


### PR DESCRIPTION
The repository's Actions cache was measured at 10.94 GB against GitHub's 10 GB
limit, across 58 entries, none of them on main. A cache written from a pull
request is private to it, so open pull requests each store the same dependency
slice until the limit evicts them; four pull requests went red that way on
19 August, every failure a job killed at its timeout on a cold cache.

Caches now restore everywhere and save only from main, and the budgets match
what a cold build costs: the packaging job is 12 minutes warm and still passed
120, so the dependencies alone take upwards of an hour and a half. main has no
cache today, so its first run after this merges is what seeds the rest.