### PR TITLE
feat(ether): add network exclusion handling

### DIFF
--- a/components/ether/CMakeLists.txt
+++ b/components/ether/CMakeLists.txt
@@ -45,19 +45,34 @@ add_sen_package(
           src/process_handler.cpp
           src/output_queue.h
           src/shared_buffer_sequence.h
+          src/network_exclusion.h
+          src/network_exclusion.cpp
   STL_FILES stl/discovery.stl stl/runtime.stl stl/configuration.stl
   PRIVATE_DEPS
     sen::kernel
     asio::asio
     spdlog::spdlog
     concurrentqueue::concurrentqueue
+  TEST_TARGET ether_for_testing
   IS_COMPONENT
 )
 
 sen_enable_static_analysis(ether)
+
+if(WIN32)
+  target_link_libraries(ether PRIVATE ole32 oleaut32 wbemuuid)
+  if(TARGET ether_for_testing)
+    target_link_libraries(ether_for_testing PRIVATE ole32 oleaut32 wbemuuid)
+  endif()
+endif()
 
 set_target_properties(ether PROPERTIES FOLDER "components/ether")
 
 sen_internal_install(ether)
 
 install(FILES ${PROJECT_SOURCE_DIR}/schemas/ether.json DESTINATION schemas)
+
+# tests
+if(SEN_BUILD_TESTS)
+  add_subdirectory(test)
+endif()

--- a/components/ether/src/bus_handler.cpp
+++ b/components/ether/src/bus_handler.cpp
@@ -8,6 +8,7 @@
 #include "bus_handler.h"
 
 // component
+#include "network_exclusion.h"
 #include "shared_buffer_sequence.h"
 #include "stats.h"
 #include "util.h"
@@ -80,27 +81,37 @@ uint8_t computeByte(const ByteRange& byteRange, uint8_t hash)
 asio::ip::address computeMulticastAddress(uint32_t sessionId,
                                           uint32_t busId,
                                           uint16_t discoveryPort,
-                                          const MulticastRange& ranges)
+                                          const MulticastRange& range,
+                                          const MulticastExclusions& exclusions)
 {
   const auto hash = hashCombine(busHashSeed, sessionId, busId, discoveryPort);
   const auto hashBytes = reinterpret_cast<const uint8_t*>(&hash);  // NOLINT
 
-  const uint8_t byte0 = computeByte(ranges[0], hashBytes[0]);  // NOLINT
-  const uint8_t byte1 = computeByte(ranges[1], hashBytes[1]);  // NOLINT
-  const uint8_t byte2 = computeByte(ranges[2], hashBytes[2]);  // NOLINT
-  const uint8_t byte3 = computeByte(ranges[3], hashBytes[3]);  // NOLINT
+  const uint8_t byte0 = computeByte(range[0], hashBytes[0]);  // NOLINT
+  const uint8_t byte1 = computeByte(range[1], hashBytes[1]);  // NOLINT
+  const uint8_t byte2 = computeByte(range[2], hashBytes[2]);  // NOLINT
+  const uint8_t byte3 = computeByte(range[3], hashBytes[3]);  // NOLINT
 
   // NOLINTNEXTLINE
   asio::ip::address_v4::bytes_type bytes = {byte0, byte1, byte2, byte3};
 
   for (std::size_t i = 0; i < bytes.size(); ++i)
   {
-    bytes[i] = clamp(bytes[i], ranges[i]);  // NOLINT
+    bytes[i] = clamp(bytes[i], range[i]);  // NOLINT
   }
 
-  const auto address = asio::ip::address_v4(bytes);
-  SEN_ENSURE(address.is_multicast());
-  return address;
+  const auto address = getUsableMulticastAddress(asio::ip::address_v4(bytes), range, exclusions);
+
+  // component.cpp rejects a range with no usable address before the component starts, so this
+  // normally cannot fire. It stays because that check is skipped when multicast is disabled, and
+  // because it is per-bus rather than over the whole range.
+  if (!address)
+  {
+    throwRuntimeError("multicast address range has no usable addresses after applying exclusions");
+  }
+
+  SEN_ENSURE(address->is_multicast());
+  return *address;
 }
 
 }  // namespace
@@ -118,10 +129,11 @@ std::shared_ptr<BusHandler> BusHandler::make(uint32_t sessionId,
                                              asio::io_context& io,
                                              const Configuration& config,
                                              sen::kernel::Tracer& tracer,
-                                             TransportCounters& counters)
+                                             TransportCounters& counters,
+                                             const MulticastExclusions& exclusions)
 {
   return std::shared_ptr<BusHandler>(
-    new BusHandler(sessionId, busId, name, procId, listener, discoveryPort, io, config, tracer, counters));
+    new BusHandler(sessionId, busId, name, procId, listener, discoveryPort, io, config, tracer, counters, exclusions));
 }
 
 BusHandler::BusHandler(uint32_t sessionId,
@@ -133,7 +145,8 @@ BusHandler::BusHandler(uint32_t sessionId,
                        asio::io_context& io,
                        const Configuration& config,
                        sen::kernel::Tracer& tracer,
-                       TransportCounters& counters)
+                       TransportCounters& counters,
+                       const MulticastExclusions& exclusions)
   : busId_(busId)
   , procId_(procId)
   , name_(std::move(name))
@@ -146,7 +159,8 @@ BusHandler::BusHandler(uint32_t sessionId,
   , io_(io)
   , counters_(counters)
 {
-  const auto group = computeMulticastAddress(sessionId, busId.get(), discoveryPort, config.busConfig.multicastRange);
+  const auto group =
+    computeMulticastAddress(sessionId, busId.get(), discoveryPort, config.busConfig.multicastRange, exclusions);
 
   // configure the tracing
   outQueue_.configureTracing(name + "bus.udp.out", &tracer);

--- a/components/ether/src/bus_handler.h
+++ b/components/ether/src/bus_handler.h
@@ -8,6 +8,7 @@
 #ifndef SEN_COMPONENTS_ETHER_SRC_BUS_HANDLER_H
 #define SEN_COMPONENTS_ETHER_SRC_BUS_HANDLER_H
 
+#include "network_exclusion.h"
 #include "stats.h"
 #include "util.h"
 
@@ -38,7 +39,8 @@ public:
                                                         asio::io_context& io,
                                                         const Configuration& config,
                                                         sen::kernel::Tracer& tracer,
-                                                        TransportCounters& counters);
+                                                        TransportCounters& counters,
+                                                        const MulticastExclusions& exclusions);
 
   ~BusHandler();
 
@@ -63,7 +65,8 @@ private:
              asio::io_context& io,
              const Configuration& config,
              sen::kernel::Tracer& tracer,
-             TransportCounters& counters);
+             TransportCounters& counters,
+             const MulticastExclusions& exclusions);
 
 private:
   void readMessage();

--- a/components/ether/src/component.cpp
+++ b/components/ether/src/component.cpp
@@ -8,6 +8,7 @@
 // component
 #include "discovery.h"
 #include "ether_transport.h"
+#include "network_exclusion.h"
 #include "tcp_discovery_hub.h"
 #include "util.h"
 
@@ -95,6 +96,22 @@ public:
       return result;
     }
 
+    auto exclusionsResult = makeNetworkExclusions(config_);
+    if (exclusionsResult.isError())
+    {
+      return Err(kernel::ExecError {kernel::ErrorCategory::expectationsNotMet, std::move(exclusionsResult).getError()});
+    }
+    exclusions_ = std::move(exclusionsResult).getValue();
+
+    if (!config_.busConfig.multicastDisabled &&
+        !hasUsableMulticastAddress(config_.busConfig.multicastRange, exclusions_.multicast))
+    {
+      return Err(kernel::ExecError {
+        kernel::ErrorCategory::expectationsNotMet,
+        "multicast address range has no usable addresses after applying exclusions",
+      });
+    }
+
     discovery_ = DiscoverySystem::make(config_, io_);
 
     // run the discovery hub if needed
@@ -106,7 +123,9 @@ public:
     const auto& appName = api.getAppName();
     api.installTransportFactory(
       [this, appName](const auto& session, std::unique_ptr<sen::kernel::Tracer> tracer)
-      { return std::make_unique<EtherTransport>(config_, session, appName, discovery_, std::move(tracer)); },
+      {
+        return std::make_unique<EtherTransport>(config_, session, appName, discovery_, std::move(tracer), exclusions_);
+      },
       etherProtocolVersion);
     return done();
   }
@@ -275,6 +294,7 @@ private:
   std::shared_ptr<DiscoverySystem> discovery_;
   std::unique_ptr<TcpDiscoveryHub> discoveryHub_;
   Configuration config_ {};
+  NetworkExclusions exclusions_;
 };
 
 }  // namespace sen::components::ether

--- a/components/ether/src/ether_transport.cpp
+++ b/components/ether/src/ether_transport.cpp
@@ -10,6 +10,7 @@
 // component
 #include "bus_handler.h"
 #include "discovery.h"
+#include "network_exclusion.h"
 #include "process_handler.h"
 #include "stats.h"
 #include "util.h"
@@ -132,7 +133,8 @@ EtherTransport::EtherTransport(const Configuration& config,
                                std::string_view sessionName,
                                std::string_view appName,
                                std::shared_ptr<DiscoverySystem> discovery,
-                               std::unique_ptr<sen::kernel::Tracer> tracer)
+                               std::unique_ptr<sen::kernel::Tracer> tracer,
+                               const NetworkExclusions& exclusions)
   : kernel::Transport(sessionName)
   , config_(config)
   , sessionId_(crc32(sessionName))
@@ -140,6 +142,7 @@ EtherTransport::EtherTransport(const Configuration& config,
   , discovery_(std::move(discovery))
   , logger_(getLogger())
   , tracer_(std::move(tracer))
+  , exclusions_(exclusions)
 {
   ownInfo_.appName = appName;
 }
@@ -459,8 +462,8 @@ void EtherTransport::localParticipantJoinedBus(ObjectOwnerId participant, kernel
       port = std::get<MulticastDiscovery>(config_.discovery).port;
     }
 
-    auto handler =
-      BusHandler::make(sessionId_, bus, busName, procId, listener_, port, *io_, config_, *tracer_, counters_);
+    auto handler = BusHandler::make(
+      sessionId_, bus, busName, procId, listener_, port, *io_, config_, *tracer_, counters_, exclusions_.multicast);
     handler->startReading();
 
     auto [itr, done] = busMap_.try_emplace(bus, std::move(handler));

--- a/components/ether/src/ether_transport.h
+++ b/components/ether/src/ether_transport.h
@@ -11,6 +11,7 @@
 // component
 #include "bus_handler.h"
 #include "discovery.h"
+#include "network_exclusion.h"
 #include "process_handler.h"
 #include "stats.h"
 #include "util.h"
@@ -42,7 +43,8 @@ public:
                  std::string_view sessionName,
                  std::string_view appName,
                  std::shared_ptr<DiscoverySystem> discovery,
-                 std::unique_ptr<sen::kernel::Tracer> tracer);
+                 std::unique_ptr<sen::kernel::Tracer> tracer,
+                 const NetworkExclusions& exclusions);
   ~EtherTransport() override;
 
 public:
@@ -125,6 +127,7 @@ private:
   std::unique_ptr<sen::kernel::Tracer> tracer_;
   std::mutex ioMutex_;
   TransportCounters counters_;
+  const NetworkExclusions& exclusions_;
 
   // timers
   std::unordered_map<TimerId, TimerData> timers_;

--- a/components/ether/src/network_exclusion.cpp
+++ b/components/ether/src/network_exclusion.cpp
@@ -1,0 +1,639 @@
+// === network_exclusion.cpp ===========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#include "network_exclusion.h"
+
+#include "util.h"
+
+// sen
+#include "sen/core/base/checked_conversions.h"
+#include "sen/core/base/result.h"
+
+// asio
+#include <asio/error_code.hpp>
+#include <asio/ip/address_v4.hpp>
+
+// generated code
+#include "stl/configuration.stl.h"
+
+#ifdef _WIN32
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  ifndef _WIN32_DCOM
+#    define _WIN32_DCOM
+#  endif
+#  include <Wbemidl.h>
+#  include <comdef.h>
+#endif
+
+// std
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace sen::components::ether
+{
+
+namespace
+{
+
+constexpr uint16_t lastWellKnownPort = 1023;
+constexpr uint16_t lastPort = std::numeric_limits<uint16_t>::max();
+
+// RFC 2365 reserves these addresses in each scoped zone
+constexpr std::string_view organizationLocalReservedMin = "239.195.255.0";
+constexpr std::string_view organizationLocalReservedMax = "239.195.255.255";
+constexpr std::string_view localScopeReservedMin = "239.255.255.0";
+constexpr std::string_view localScopeReservedMax = "239.255.255.255";
+
+[[nodiscard]] Result<asio::ip::address_v4, std::string> parseAddress(std::string_view address)
+{
+  asio::error_code error;
+  const auto result = asio::ip::make_address_v4(std::string(address), error);
+  if (error)
+  {
+    return Err(std::string("invalid multicast exclusion address '") + std::string(address) + "'");
+  }
+  return Ok(result);
+}
+
+[[nodiscard]] Result<void, std::string> addMulticastRange(MulticastExclusions& exclusions,
+                                                          std::string_view min,
+                                                          std::string_view max)
+{
+  const auto minResult = parseAddress(min);
+  if (minResult.isError())
+  {
+    return Err(minResult.getError());
+  }
+  const auto maxResult = parseAddress(max);
+  if (maxResult.isError())
+  {
+    return Err(maxResult.getError());
+  }
+
+  const auto& minAddress = minResult.getValue();
+  const auto& maxAddress = maxResult.getValue();
+  if (minAddress.to_uint() > maxAddress.to_uint())
+  {
+    return Err(std::string("invalid multicast exclusion range (min > max)"));
+  }
+  if ((minAddress.to_uint() >> 24U) != 239U || (maxAddress.to_uint() >> 24U) != 239U)
+  {
+    return Err(std::string("multicast exclusion ranges must stay inside 239.0.0.0/8"));
+  }
+  exclusions.add(minAddress.to_uint(), maxAddress.to_uint());
+  return Ok();
+}
+
+[[nodiscard]] uint64_t multicastSpaceSize(const MulticastRange& range)
+{
+  uint64_t result = 1;
+  for (const auto& byteRange: range)
+  {
+    const auto min = sen::std_util::checkedConversion<uint64_t>(byteRange.min);
+    const auto max = sen::std_util::checkedConversion<uint64_t>(byteRange.max);
+    result *= max - min + 1U;
+  }
+  return result;
+}
+
+[[nodiscard]] uint32_t nextMulticastAddress(uint32_t currentAddress, const MulticastRange& range)
+{
+  auto bytes = asio::ip::make_address_v4(currentAddress).to_bytes();
+  for (int index = bytes.size() - 1; index >= 0; --index)
+  {
+    auto& byte = bytes.at(index);
+    const auto& byteRange = range.at(index);
+
+    if (byte < byteRange.max)
+    {
+      ++byte;
+      return asio::ip::address_v4(bytes).to_uint();
+    }
+    byte = byteRange.min;
+  }
+  return asio::ip::address_v4(bytes).to_uint();
+}
+
+#ifdef __linux__
+[[nodiscard]] Result<uint16_t, std::string> parsePort(std::string_view text)
+{
+  std::istringstream input {std::string(text)};
+  uint32_t value = 0;
+  input >> value;
+  if (!input || !input.eof() || value > lastPort)
+  {
+    return Err(std::string("invalid port '") + std::string(text) + "'");
+  }
+
+  return Ok(sen::std_util::checkedConversion<uint16_t>(value));
+}
+
+[[nodiscard]] Result<void, std::string> parsePortRanges(std::string_view text, OsPortExclusions& exclusions)
+{
+  std::size_t begin = 0;
+  while (begin < text.size())
+  {
+    const auto end = text.find(',', begin);
+    const auto token = text.substr(begin, end == std::string_view::npos ? text.size() - begin : end - begin);
+    if (token.empty())
+    {
+      return Err(std::string("empty port range"));
+    }
+
+    const auto separator = token.find('-');
+    const auto minResult = parsePort(token.substr(0, separator));
+    if (minResult.isError())
+    {
+      return Err(minResult.getError());
+    }
+
+    const auto maxResult = separator == std::string_view::npos ? minResult : parsePort(token.substr(separator + 1));
+    if (maxResult.isError())
+    {
+      return Err(maxResult.getError());
+    }
+    if (minResult.getValue() > maxResult.getValue())
+    {
+      return Err(std::string("invalid port exclusion range (min > max)"));
+    }
+
+    exclusions.add(minResult.getValue(), maxResult.getValue());
+    if (end == std::string_view::npos)
+    {
+      break;
+    }
+    begin = end + 1;
+  }
+  return Ok();
+}
+
+#endif
+
+#ifdef _WIN32
+/// COM interface pointer used for the Windows WMI port range queries
+template <typename Interface>
+class WmiComInterfacePtr
+{
+public:
+  WmiComInterfacePtr() = default;
+  ~WmiComInterfacePtr() { reset(nullptr); }
+
+  WmiComInterfacePtr(const WmiComInterfacePtr&) = delete;
+  WmiComInterfacePtr& operator=(const WmiComInterfacePtr&) = delete;
+
+  Interface* get() const noexcept { return ptr_; }
+  Interface* operator->() const noexcept { return ptr_; }
+
+  void reset(Interface* ptr) noexcept
+  {
+    if (ptr_ != nullptr)
+    {
+      ptr_->Release();
+    }
+    ptr_ = ptr;
+  }
+
+private:
+  Interface* ptr_ = nullptr;
+};
+
+/// COM initialization state for the Windows WMI port range queries
+class WmiComInitialization
+{
+public:
+  explicit WmiComInitialization(bool uninitialize) noexcept: uninitialize_(uninitialize) {}
+  ~WmiComInitialization()
+  {
+    if (uninitialize_)
+    {
+      CoUninitialize();
+    }
+  }
+
+  WmiComInitialization(const WmiComInitialization&) = delete;
+  WmiComInitialization& operator=(const WmiComInitialization&) = delete;
+  WmiComInitialization(WmiComInitialization&& other) noexcept: uninitialize_(std::exchange(other.uninitialize_, false))
+  {
+  }
+  WmiComInitialization& operator=(WmiComInitialization&& other) noexcept
+  {
+    if (this != &other)
+    {
+      if (uninitialize_)
+      {
+        CoUninitialize();
+      }
+      uninitialize_ = std::exchange(other.uninitialize_, false);
+    }
+    return *this;
+  }
+
+private:
+  bool uninitialize_ = false;
+};
+
+/// WMI property value returned through the COM VARIANT type
+class WmiVariantValue
+{
+public:
+  WmiVariantValue() { VariantInit(&value_); }
+  ~WmiVariantValue() { VariantClear(&value_); }
+
+  WmiVariantValue(const WmiVariantValue&) = delete;
+  WmiVariantValue& operator=(const WmiVariantValue&) = delete;
+
+  VARIANT* put() noexcept { return &value_; }
+  const VARIANT& get() const noexcept { return value_; }
+
+private:
+  VARIANT value_ {};
+};
+
+[[nodiscard]] std::string wmiNameToString(std::wstring_view text) { return std::string(text.begin(), text.end()); }
+
+[[nodiscard]] std::string hresultToString(HRESULT result)
+{
+  std::ostringstream output;
+  output << "0x" << std::hex << static_cast<unsigned long>(result);
+  return output.str();
+}
+
+[[nodiscard]] std::string variantTypeToString(VARTYPE type)
+{
+  std::ostringstream output;
+  output << static_cast<uint32_t>(type) << " (0x" << std::hex << static_cast<uint32_t>(type) << ")";
+  return output.str();
+}
+
+[[nodiscard]] Result<WmiComInitialization, std::string> initializeWmiCom()
+{
+  // WMI queries require COM to be initialized in the current thread
+  const auto initResult = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  const bool shouldUninitialize = SUCCEEDED(initResult);
+  if (FAILED(initResult) && initResult != RPC_E_CHANGED_MODE)
+  {
+    return Err(std::string("could not initialize COM: ") + hresultToString(initResult));
+  }
+
+  const auto securityResult = CoInitializeSecurity(
+    nullptr, -1, nullptr, nullptr, RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_IMP_LEVEL_IMPERSONATE, nullptr, EOAC_NONE, nullptr);
+  if (FAILED(securityResult) && securityResult != RPC_E_TOO_LATE)
+  {
+    if (shouldUninitialize)
+    {
+      CoUninitialize();
+    }
+    return Err(std::string("could not initialize COM security: ") + hresultToString(securityResult));
+  }
+
+  return Ok(WmiComInitialization(shouldUninitialize));
+}
+
+[[nodiscard]] Result<std::optional<uint32_t>, std::string> wmiValueToOptionalUint32(VARIANT* value)
+{
+  if (value == nullptr)
+  {
+    return Err(std::string("null WMI value"));
+  }
+  if (value->vt == VT_EMPTY || value->vt == VT_NULL)
+  {
+    return Ok(std::optional<uint32_t> {});
+  }
+
+  WmiVariantValue converted;
+  const auto convertResult = VariantChangeType(converted.put(), value, 0, VT_UI4);
+  if (FAILED(convertResult))
+  {
+    return Err(std::string("could not convert WMI value type ") + variantTypeToString(value->vt) + ": " +
+               hresultToString(convertResult));
+  }
+
+  return Ok(std::optional<uint32_t> {converted.get().ulVal});
+}
+
+[[nodiscard]] Result<std::optional<uint32_t>, std::string> readOptionalWmiUint32Property(IWbemClassObject* object,
+                                                                                         const wchar_t* propertyName,
+                                                                                         std::wstring_view className)
+{
+  WmiVariantValue value;
+  const auto result = object->Get(propertyName, 0, value.put(), nullptr, nullptr);
+  if (FAILED(result))
+  {
+    return Err(std::string("could not read WMI property '") + wmiNameToString(propertyName) + "' from " +
+               wmiNameToString(className) + ": " + hresultToString(result));
+  }
+
+  auto numericResult = wmiValueToOptionalUint32(value.put());
+  if (numericResult.isError())
+  {
+    return Err(std::string("invalid WMI property '") + wmiNameToString(propertyName) + "' from " +
+               wmiNameToString(className) + ": " + numericResult.getError());
+  }
+
+  return numericResult;
+}
+
+[[nodiscard]] Result<void, std::string> addDynamicPortRangeFromWmiClass(IWbemServices* service,
+                                                                        std::wstring_view className,
+                                                                        OsPortExclusions& exclusions,
+                                                                        bool allowMissingClass)
+{
+  std::wstring query = L"SELECT DynamicPortRangeStartPort, DynamicPortRangeNumberOfPorts FROM ";
+  query.append(className.data(), className.size());
+  IEnumWbemClassObject* enumeratorRaw = nullptr;
+  const auto queryResult = service->ExecQuery(_bstr_t(L"WQL"),
+                                              _bstr_t(query.c_str()),
+                                              WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
+                                              nullptr,
+                                              &enumeratorRaw);
+  if (FAILED(queryResult))
+  {
+    if (allowMissingClass && queryResult == WBEM_E_INVALID_CLASS)
+    {
+      return Ok();
+    }
+    return Err(std::string("could not query WMI class ") + wmiNameToString(className) + ": " +
+               hresultToString(queryResult));
+  }
+  WmiComInterfacePtr<IEnumWbemClassObject> enumerator;
+  enumerator.reset(enumeratorRaw);
+
+  bool foundRange = false;
+  while (true)
+  {
+    IWbemClassObject* objectRaw = nullptr;
+    ULONG objectCount = 0;
+    const auto nextResult = enumerator->Next(WBEM_INFINITE, 1, &objectRaw, &objectCount);
+    if (FAILED(nextResult))
+    {
+      return Err(std::string("could not read WMI query result from ") + wmiNameToString(className) + ": " +
+                 hresultToString(nextResult));
+    }
+    if (objectCount == 0)
+    {
+      break;
+    }
+    WmiComInterfacePtr<IWbemClassObject> object;
+    object.reset(objectRaw);
+
+    const auto startResult = readOptionalWmiUint32Property(object.get(), L"DynamicPortRangeStartPort", className);
+    if (startResult.isError())
+    {
+      return Err(startResult.getError());
+    }
+    const auto countResult = readOptionalWmiUint32Property(object.get(), L"DynamicPortRangeNumberOfPorts", className);
+    if (countResult.isError())
+    {
+      return Err(countResult.getError());
+    }
+
+    const auto& start = startResult.getValue();
+    const auto& count = countResult.getValue();
+    if (!start && !count)
+    {
+      continue;
+    }
+    if (!start || !count)
+    {
+      return Err(std::string("Windows dynamic port range is incomplete in ") + wmiNameToString(className));
+    }
+
+    if (*count == 0U)
+    {
+      continue;
+    }
+
+    if (*start == 0U || *start > lastPort || *count > lastPort || *count > (lastPort - *start + 1U))
+    {
+      return Err(std::string("invalid Windows dynamic port range reported by ") + wmiNameToString(className));
+    }
+
+    const auto max = *start + *count - 1U;
+    exclusions.add(sen::std_util::checkedConversion<uint16_t>(*start), sen::std_util::checkedConversion<uint16_t>(max));
+    foundRange = true;
+  }
+
+  if (!foundRange)
+  {
+    if (allowMissingClass)
+    {
+      return Ok();
+    }
+    return Err(std::string("WMI class ") + wmiNameToString(className) + " did not report a dynamic port range");
+  }
+
+  return Ok();
+}
+
+#endif
+
+[[nodiscard]] Result<OsPortExclusions, std::string> probeOsPortExclusions()
+{
+  OsPortExclusions result;
+#ifdef __linux__
+  const std::filesystem::path ephemeralPortsPath = "/proc/sys/net/ipv4/ip_local_port_range";
+  const std::filesystem::path reservedPortsPath = "/proc/sys/net/ipv4/ip_local_reserved_ports";
+
+  std::ifstream ephemeralInput(ephemeralPortsPath);
+  if (!ephemeralInput)
+  {
+    return Err(std::string("could not read OS ephemeral port range from '") + ephemeralPortsPath.string() + "'");
+  }
+
+  uint32_t ephemeralMin = 0;
+  uint32_t ephemeralMax = 0;
+  ephemeralInput >> ephemeralMin;
+  if (!ephemeralInput)
+  {
+    return Err(std::string("invalid OS ephemeral port range in '") + ephemeralPortsPath.string() + "'");
+  }
+  ephemeralInput >> ephemeralMax;
+  if (!ephemeralInput || ephemeralMin > lastPort || ephemeralMax > lastPort || ephemeralMin > ephemeralMax)
+  {
+    return Err(std::string("invalid OS ephemeral port range in '") + ephemeralPortsPath.string() + "'");
+  }
+
+  result.add(sen::std_util::checkedConversion<uint16_t>(ephemeralMin),
+             sen::std_util::checkedConversion<uint16_t>(ephemeralMax));
+
+  std::ifstream reservedInput(reservedPortsPath);
+  if (!reservedInput)
+  {
+    return Err(std::string("could not read OS reserved port ranges from '") + reservedPortsPath.string() + "'");
+  }
+
+  std::string configuredRanges;
+  std::getline(reservedInput, configuredRanges);
+  if (!reservedInput && !reservedInput.eof())
+  {
+    return Err(std::string("could not read OS reserved port ranges from '") + reservedPortsPath.string() + "'");
+  }
+
+  const auto parseResult = parsePortRanges(configuredRanges, result);
+  if (parseResult.isError())
+  {
+    return Err(std::string("invalid OS reserved port ranges in '") + reservedPortsPath.string() +
+               "': " + parseResult.getError());
+  }
+#endif
+#ifdef _WIN32
+  auto comResult = initializeWmiCom();
+  if (comResult.isError())
+  {
+    return Err(comResult.getError());
+  }
+  auto WmiComInitialization = std::move(comResult).getValue();
+
+  IWbemLocator* locatorRaw = nullptr;
+  const auto locatorResult = CoCreateInstance(
+    CLSID_WbemLocator, nullptr, CLSCTX_INPROC_SERVER, IID_IWbemLocator, reinterpret_cast<void**>(&locatorRaw));
+  if (FAILED(locatorResult))
+  {
+    return Err(std::string("could not create WMI locator: ") + hresultToString(locatorResult));
+  }
+  WmiComInterfacePtr<IWbemLocator> locator;
+  locator.reset(locatorRaw);
+
+  // MSFT_Net*Setting classes are exposed through ROOT\StandardCimv2
+  IWbemServices* serviceRaw = nullptr;
+  const auto connectResult = locator->ConnectServer(
+    _bstr_t(L"ROOT\\StandardCimv2"), nullptr, nullptr, nullptr, 0, nullptr, nullptr, &serviceRaw);
+  if (FAILED(connectResult))
+  {
+    return Err(std::string("could not connect to WMI namespace ROOT\\StandardCimv2: ") +
+               hresultToString(connectResult));
+  }
+  WmiComInterfacePtr<IWbemServices> service;
+  service.reset(serviceRaw);
+
+  const auto proxyResult = CoSetProxyBlanket(service.get(),
+                                             RPC_C_AUTHN_WINNT,
+                                             RPC_C_AUTHZ_NONE,
+                                             nullptr,
+                                             RPC_C_AUTHN_LEVEL_CALL,
+                                             RPC_C_IMP_LEVEL_IMPERSONATE,
+                                             nullptr,
+                                             EOAC_NONE);
+  if (FAILED(proxyResult))
+  {
+    return Err(std::string("could not configure WMI proxy security: ") + hresultToString(proxyResult));
+  }
+
+  // read the Windows dynamic port ranges
+  auto tcpResult = addDynamicPortRangeFromWmiClass(service.get(), L"MSFT_NetTCPSetting", result, false);
+  if (tcpResult.isError())
+  {
+    return Err(std::string("could not read Windows TCP dynamic port range: ") + tcpResult.getError());
+  }
+  auto udpResult = addDynamicPortRangeFromWmiClass(service.get(), L"MSFT_NetUDPSetting", result, true);
+  if (udpResult.isError())
+  {
+    return Err(std::string("could not read Windows UDP dynamic port range: ") + udpResult.getError());
+  }
+#endif
+  return Ok(std::move(result));
+}
+
+}  // namespace
+
+Result<NetworkExclusions, std::string> makeNetworkExclusions(const Configuration& config)
+{
+  NetworkExclusions result;
+
+  if (auto addResult = addMulticastRange(result.multicast, organizationLocalReservedMin, organizationLocalReservedMax);
+      addResult.isError())
+  {
+    return Err(addResult.getError());
+  }
+  if (auto addResult = addMulticastRange(result.multicast, localScopeReservedMin, localScopeReservedMax);
+      addResult.isError())
+  {
+    return Err(addResult.getError());
+  }
+
+  for (const auto& configuredRange: config.busConfig.multicastExclusions)
+  {
+    const auto addResult = addMulticastRange(result.multicast, configuredRange.min, configuredRange.max);
+    if (addResult.isError())
+    {
+      return Err(addResult.getError());
+    }
+  }
+
+  result.ports.builtIn.add(0, lastWellKnownPort);
+  for (const auto& range: config.portExclusions)
+  {
+    if (range.min > range.max)
+    {
+      return Err(std::string("invalid port exclusion range (min > max)"));
+    }
+    result.ports.configured.add(range.min, range.max);
+  }
+
+  // A failed probe is not a reason to refuse to start. It fails where the OS will not say which
+  // ports it reserves -- a hardened container without /proc/sys/net/ipv4/ip_local_port_range, or
+  // Windows without WMI -- and the set it produces only narrows the choice of pinned ports, which
+  // are opt-in. Starting with an empty set risks a collision the OS would have warned about;
+  // refusing to start denies the whole component over an advisory list.
+  auto osResult = probeOsPortExclusions();
+  if (osResult.isError())
+  {
+    getLogger()->warn(
+      "could not read the OS port exclusions ({}); continuing without them, so a "
+      "pinned port may collide with one the OS has reserved",
+      osResult.getError());
+  }
+  else
+  {
+    result.ports.os = std::move(osResult).getValue();
+  }
+
+  return Ok(std::move(result));
+}
+
+bool hasUsableMulticastAddress(const MulticastRange& range, const MulticastExclusions& exclusions)
+{
+  asio::ip::address_v4::bytes_type bytes {};
+  for (std::size_t index = 0; index < bytes.size(); ++index)
+  {
+    bytes.at(index) = range.at(index).min;
+  }
+
+  return getUsableMulticastAddress(asio::ip::address_v4(bytes), range, exclusions).has_value();
+}
+
+[[nodiscard]] std::optional<asio::ip::address_v4> getUsableMulticastAddress(asio::ip::address_v4 candidate,
+                                                                            const MulticastRange& range,
+                                                                            const MulticastExclusions& exclusions)
+{
+  const auto address =
+    exclusions.nextUsable(candidate.to_uint(),
+                          multicastSpaceSize(range),
+                          [&range](uint32_t address) { return nextMulticastAddress(address, range); });
+
+  if (!address)
+  {
+    return std::nullopt;
+  }
+
+  return asio::ip::make_address_v4(*address);
+}
+
+}  // namespace sen::components::ether

--- a/components/ether/src/network_exclusion.h
+++ b/components/ether/src/network_exclusion.h
@@ -1,0 +1,154 @@
+// === network_exclusion.h =============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#ifndef SEN_COMPONENTS_ETHER_SRC_NETWORK_EXCLUSION_H
+#define SEN_COMPONENTS_ETHER_SRC_NETWORK_EXCLUSION_H
+
+// sen
+#include "sen/core/base/assert.h"
+#include "sen/core/base/result.h"
+
+// generated code
+#include "stl/configuration.stl.h"
+
+// asio
+#include <asio/ip/address_v4.hpp>
+
+// std
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace sen::components::ether
+{
+
+/// Stores sorted and non-overlapping exclusion ranges.
+/// Tag keeps different exclusion types separate
+template <typename Value, typename Tag>
+class ExclusionSet
+{
+public:
+  /// Exclusion range
+  struct Range
+  {
+    Value min;
+    Value max;
+  };
+
+public:
+  /// Adds a range and merges overlapping or adjacent ranges.
+  void add(Value min, Value max)
+  {
+    SEN_ASSERT(min <= max);
+
+    auto position = std::lower_bound(
+      ranges_.begin(), ranges_.end(), min, [](const Range& range, Value value) { return hasGap(range.max, value); });
+
+    while (position != ranges_.end() && !hasGap(max, position->min))
+    {
+      min = std::min(min, position->min);
+      max = std::max(max, position->max);
+      position = ranges_.erase(position);
+    }
+
+    ranges_.insert(position, {min, max});
+  }
+
+  /// Returns true if the value is excluded
+  [[nodiscard]] bool isExcluded(Value value) const noexcept
+  {
+    const auto itr = std::upper_bound(
+      ranges_.begin(), ranges_.end(), value, [](Value candidate, const Range& range) { return candidate < range.min; });
+    return itr != ranges_.begin() && value <= std::prev(itr)->max;
+  }
+
+  /// Finds the first non-excluded value in a finite candidate sequence.
+  template <typename Next>
+  [[nodiscard]] std::optional<Value> nextUsable(Value start, uint64_t candidateCount, Next&& next) const
+  {
+    Value candidate = start;
+    for (uint64_t attempt = 0; attempt < candidateCount; ++attempt)
+    {
+      if (!isExcluded(candidate))
+      {
+        return candidate;
+      }
+      candidate = next(candidate);
+    }
+    return std::nullopt;
+  }
+
+  /// Returns the sorted exclusion ranges
+  [[nodiscard]] const std::vector<Range>& ranges() const noexcept { return ranges_; }
+
+private:
+  /// Returns true if there is a gap between two ranges
+  [[nodiscard]] static bool hasGap(Value leftMax, Value rightMin) noexcept
+  {
+    if (leftMax >= rightMin)
+    {
+      return false;
+    }
+
+    auto nextValue = leftMax + 1;
+
+    return nextValue < rightMin;
+  }
+
+private:
+  std::vector<Range> ranges_;
+};
+
+struct MulticastExclusionTag;
+struct BuiltInPortExclusionTag;
+struct ConfiguredPortExclusionTag;
+struct OsPortExclusionTag;
+
+/// Excluded multicast addresses
+using MulticastExclusions = ExclusionSet<uint32_t, MulticastExclusionTag>;
+/// Built-in port exclusions
+using BuiltInPortExclusions = ExclusionSet<uint16_t, BuiltInPortExclusionTag>;
+/// User configured port exclusions
+using ConfiguredPortExclusions = ExclusionSet<uint16_t, ConfiguredPortExclusionTag>;
+/// Port exclusions reported by the operating system
+using OsPortExclusions = ExclusionSet<uint16_t, OsPortExclusionTag>;
+
+/// Keeps port exclusions separated by their source
+struct PortExclusionSources
+{
+  BuiltInPortExclusions builtIn;
+  ConfiguredPortExclusions configured;
+  OsPortExclusions os;
+};
+
+/// Network exclusions used by ether.
+/// Multicast address exclusions and port exclusions are independent.
+struct NetworkExclusions
+{
+  MulticastExclusions multicast;
+  PortExclusionSources ports;
+};
+
+/// Builds multicast and port exclusions.
+/// Returns an error for invalid input.
+[[nodiscard]] Result<NetworkExclusions, std::string> makeNetworkExclusions(const Configuration& config);
+
+/// Returns true if the multicast range has a usable address.
+[[nodiscard]] bool hasUsableMulticastAddress(const MulticastRange& range, const MulticastExclusions& exclusions);
+
+/// Finds the first usable multicast address, starting at candidate.
+/// Returns nullopt if all addresses are excluded.
+[[nodiscard]] std::optional<asio::ip::address_v4> getUsableMulticastAddress(asio::ip::address_v4 candidate,
+                                                                            const MulticastRange& range,
+                                                                            const MulticastExclusions& exclusions);
+
+}  // namespace sen::components::ether
+
+#endif  // SEN_COMPONENTS_ETHER_SRC_NETWORK_EXCLUSION_H

--- a/components/ether/stl/configuration.stl
+++ b/components/ether/stl/configuration.stl
@@ -60,6 +60,24 @@ struct ByteRange
 // Range of values of a IPv4 multicast address
 array<ByteRange, 4> MulticastRange;
 
+// Inclusive IPv4 multicast address range
+struct MulticastAddressRange
+{
+  min : string,
+  max : string
+}
+
+sequence<MulticastAddressRange> MulticastAddressExclusions;
+
+// Inclusive port range
+struct PortRange
+{
+  min : u16,
+  max : u16
+}
+
+sequence<PortRange> PortExclusions;
+
 // Remember to set these to the same value in all related Sen instances
 struct BusConfig
 {
@@ -67,6 +85,9 @@ struct BusConfig
   // [239], [192-195], [0-255], [0-255]
   // Remember to keep a range wide enough for avoiding collisions if you have many buses.
   multicastRange : MulticastRange,
+
+  // Address ranges that must not be allocated
+  multicastExclusions : MulticastAddressExclusions,
 
   // Defaults to 50985
   // Change this in case you have limited control over the infrastructure.
@@ -87,6 +108,7 @@ struct Configuration
   processUdpOutQueue : QueueConfig,            // Queue for communicating with processes over UDP
   processTcpOutQueue : QueueConfig,            // Queue for communicating with processes over TCP
   busConfig          : BusConfig,              // Bus transport configuration
+  portExclusions     : PortExclusions,         // Port ranges that this process must not use
   runDiscoveryHub    : MaybeDiscoveryHubPort,  // If present, run the TCP discovery hub on this port
   networkDevice      : MaybeDeviceName         // If present, the network device to use
 }

--- a/components/ether/test/CMakeLists.txt
+++ b/components/ether/test/CMakeLists.txt
@@ -1,0 +1,25 @@
+# === CMakeLists.txt ===================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+
+add_sen_unit_test_suite(
+  ether_test
+  network_exclusion_test.cpp
+  LINK_DEPS
+  sen::core
+  asio::asio
+  ether_for_testing
+)
+
+target_include_directories(ether_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+
+if(WIN32)
+  target_link_libraries(ether_test PRIVATE ole32 oleaut32 wbemuuid)
+endif()
+
+set_target_properties(
+  ether_test PROPERTIES FOLDER "test" RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin"
+)

--- a/components/ether/test/network_exclusion_test.cpp
+++ b/components/ether/test/network_exclusion_test.cpp
@@ -1,0 +1,268 @@
+// === network_exclusion_test.cpp ======================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#include "network_exclusion.h"
+
+// gtest
+#include <gtest/gtest.h>
+
+// asio
+#include <asio/ip/address_v4.hpp>
+
+// generated code
+#include "stl/configuration.stl.h"
+
+// std
+#include <cstdint>
+#include <string>
+
+namespace sen::components::ether
+{
+
+namespace
+{
+
+[[nodiscard]] MulticastRange makeRange(uint8_t byte1Min,
+                                       uint8_t byte1Max,
+                                       uint8_t byte2Min,
+                                       uint8_t byte2Max,
+                                       uint8_t byte3Min,
+                                       uint8_t byte3Max)
+{
+  return {
+    ByteRange {239, 239},
+    ByteRange {byte1Min, byte1Max},
+    ByteRange {byte2Min, byte2Max},
+    ByteRange {byte3Min, byte3Max},
+  };
+}
+
+}  // namespace
+
+/// @test
+/// Merges overlapping and adjacent ranges.
+/// @requirements(SEN-909)
+TEST(NetworkExclusion, MergesRanges)
+{
+  ConfiguredPortExclusions exclusions;
+  exclusions.add(20, 30);
+  exclusions.add(10, 15);
+  exclusions.add(16, 19);
+  exclusions.add(25, 40);
+
+  ASSERT_EQ(exclusions.ranges().size(), 1U);
+  EXPECT_EQ(exclusions.ranges().front().min, 10);
+  EXPECT_EQ(exclusions.ranges().front().max, 40);
+
+  ConfiguredPortExclusions upperLimitExclusions;
+  upperLimitExclusions.add(65534, 65535);
+  upperLimitExclusions.add(65533, 65533);
+
+  ASSERT_EQ(upperLimitExclusions.ranges().size(), 1U);
+  EXPECT_EQ(upperLimitExclusions.ranges().front().min, 65533);
+  EXPECT_EQ(upperLimitExclusions.ranges().front().max, 65535);
+}
+
+/// @test
+/// Keeps separate ranges sorted.
+/// @requirements(SEN-909)
+TEST(NetworkExclusion, KeepsRangesSeparate)
+{
+  ConfiguredPortExclusions exclusions;
+  exclusions.add(30, 40);
+  exclusions.add(10, 20);
+  exclusions.add(50, 60);
+
+  ASSERT_EQ(exclusions.ranges().size(), 3U);
+  EXPECT_EQ(exclusions.ranges().at(0).min, 10);
+  EXPECT_EQ(exclusions.ranges().at(1).min, 30);
+  EXPECT_EQ(exclusions.ranges().at(2).min, 50);
+  EXPECT_TRUE(exclusions.isExcluded(35));
+  EXPECT_FALSE(exclusions.isExcluded(45));
+}
+
+/// @test
+/// Finds the next value that is not excluded.
+/// @requirements(SEN-909)
+TEST(NetworkExclusion, FindsNextValue)
+{
+  ConfiguredPortExclusions exclusions;
+  exclusions.add(10, 12);
+
+  const auto result = exclusions.nextUsable(
+    10, 4, [](uint16_t value) { return value == 12 ? static_cast<uint16_t>(9) : static_cast<uint16_t>(value + 1); });
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, 9);
+}
+
+/// @test
+/// Returns no value when every candidate is excluded.
+/// @requirements(SEN-909)
+TEST(NetworkExclusion, ReturnsNoValueWhenExhausted)
+{
+  ConfiguredPortExclusions exclusions;
+  exclusions.add(10, 12);
+
+  const auto result = exclusions.nextUsable(
+    10, 3, [](uint16_t value) { return value == 12 ? static_cast<uint16_t>(10) : static_cast<uint16_t>(value + 1); });
+
+  EXPECT_FALSE(result.has_value());
+}
+
+/// @test
+/// Loads built-in and configured exclusions.
+/// @requirements(SEN-909)
+TEST(NetworkExclusion, LoadsExclusions)
+{
+  Configuration config {};
+  config.busConfig.multicastExclusions.push_back({"239.200.0.1", "239.200.0.10"});
+  config.portExclusions.push_back({4000, 4010});
+
+  const auto result = makeNetworkExclusions(config);
+
+  ASSERT_TRUE(result.isOk());
+  const auto& exclusions = result.getValue();
+  EXPECT_TRUE(exclusions.multicast.isExcluded(asio::ip::make_address_v4("239.195.255.1").to_uint()));
+  EXPECT_TRUE(exclusions.multicast.isExcluded(asio::ip::make_address_v4("239.255.255.250").to_uint()));
+  EXPECT_TRUE(exclusions.multicast.isExcluded(asio::ip::make_address_v4("239.200.0.5").to_uint()));
+  EXPECT_TRUE(exclusions.ports.builtIn.isExcluded(443));
+  EXPECT_TRUE(exclusions.ports.configured.isExcluded(4005));
+}
+
+/// @test
+/// Loads port ranges reported by the operating system.
+/// @requirements(SEN-909)
+TEST(NetworkExclusion, LoadsOsPortExclusions)
+{
+  Configuration config {};
+
+  const auto result = makeNetworkExclusions(config);
+
+  ASSERT_TRUE(result.isOk());
+  const auto& osRanges = result.getValue().ports.os.ranges();
+  ASSERT_FALSE(osRanges.empty());
+
+  for (const auto& range: osRanges)
+  {
+    EXPECT_LE(range.min, range.max);
+    EXPECT_GT(range.min, 0);
+    EXPECT_TRUE(result.getValue().ports.os.isExcluded(range.min));
+    EXPECT_TRUE(result.getValue().ports.os.isExcluded(range.max));
+  }
+}
+
+/// @test
+/// Rejects invalid multicast exclusion ranges.
+/// @requirements(SEN-909)
+TEST(NetworkExclusion, RejectsInvalidMulticastRanges)
+{
+  {
+    Configuration config {};
+    config.busConfig.multicastExclusions.push_back({"238.0.0.0", "238.0.0.255"});
+
+    const auto result = makeNetworkExclusions(config);
+
+    ASSERT_TRUE(result.isError());
+    EXPECT_NE(result.getError().find("239.0.0.0/8"), std::string::npos);
+  }
+
+  {
+    Configuration config {};
+    config.busConfig.multicastExclusions.push_back({"invalid", "239.200.0.10"});
+
+    const auto result = makeNetworkExclusions(config);
+
+    ASSERT_TRUE(result.isError());
+    EXPECT_NE(result.getError().find("invalid multicast exclusion address"), std::string::npos);
+  }
+
+  {
+    Configuration config {};
+    config.busConfig.multicastExclusions.push_back({"239.200.0.10", "239.200.0.1"});
+
+    const auto result = makeNetworkExclusions(config);
+
+    ASSERT_TRUE(result.isError());
+    EXPECT_NE(result.getError().find("min > max"), std::string::npos);
+  }
+}
+
+/// @test
+/// Rejects a port range with the limits reversed.
+/// @requirements(SEN-909)
+TEST(NetworkExclusion, RejectsInvalidPortRange)
+{
+  Configuration config {};
+  config.portExclusions.push_back({4010, 4000});
+
+  const auto result = makeNetworkExclusions(config);
+
+  ASSERT_TRUE(result.isError());
+  EXPECT_NE(result.getError().find("min > max"), std::string::npos);
+}
+
+/// @test
+/// Finds a usable multicast address across the configured range.
+/// @requirements(SEN-909)
+TEST(NetworkExclusion, FindsUsableMulticastAddress)
+{
+  // Skip an excluded address.
+  {
+    const auto range = makeRange(192, 192, 0, 0, 0, 1);
+    const auto initial = asio::ip::make_address_v4("239.192.0.0");
+
+    MulticastExclusions exclusions;
+    exclusions.add(initial.to_uint(), initial.to_uint());
+    const auto result = getUsableMulticastAddress(initial, range, exclusions);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, asio::ip::make_address_v4("239.192.0.1"));
+  }
+
+  // Continue with the next byte.
+  {
+    const auto range = makeRange(192, 192, 0, 1, 254, 255);
+    const auto initial = asio::ip::make_address_v4("239.192.0.255");
+
+    MulticastExclusions exclusions;
+    exclusions.add(initial.to_uint(), initial.to_uint());
+    const auto result = getUsableMulticastAddress(initial, range, exclusions);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, asio::ip::make_address_v4("239.192.1.254"));
+  }
+
+  // Continue from the end of the range to its beginning.
+  {
+    const auto range = makeRange(192, 192, 0, 0, 0, 1);
+    const auto initial = asio::ip::make_address_v4("239.192.0.1");
+
+    MulticastExclusions exclusions;
+    exclusions.add(initial.to_uint(), initial.to_uint());
+    const auto result = getUsableMulticastAddress(initial, range, exclusions);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, asio::ip::make_address_v4("239.192.0.0"));
+  }
+}
+
+/// @test
+/// Returns no multicast address when the complete range is excluded.
+/// @requirements(SEN-909)
+TEST(NetworkExclusion, ReturnsNoMulticastAddress)
+{
+  const auto range = makeRange(192, 192, 0, 0, 0, 0);
+  MulticastExclusions exclusions;
+  const auto onlyAddress = asio::ip::make_address_v4("239.192.0.0").to_uint();
+  exclusions.add(onlyAddress, onlyAddress);
+
+  EXPECT_FALSE(getUsableMulticastAddress(asio::ip::make_address_v4(onlyAddress), range, exclusions).has_value());
+  EXPECT_FALSE(hasUsableMulticastAddress(range, exclusions));
+}
+
+}  // namespace sen::components::ether

--- a/docs/components/ether.md
+++ b/docs/components/ether.md
@@ -99,6 +99,35 @@ groups to be used by the buses. The default range of addresses is `239.192.0.0` 
 order for this to work, you need to ensure that all the related Sen applications are using the same
 range.
 
+Sen automatically excludes the relative-address blocks reserved by RFC 2365. Additional address
+ranges can be excluded with `busConfig.multicastExclusions`.
+
+```yaml
+load:
+  - name: ether
+    busConfig:
+      multicastExclusions:
+        - min: 239.192.0.0
+          max: 239.192.99.255
+        - min: 239.192.200.0
+          max: 239.192.255.255
+```
+
+### Excluding ports
+
+`portExclusions` lists inclusive port ranges this process must not use. Sen also asks the operating
+system which ports it has reserved and avoids those as well; where it cannot ask -- a container
+without `/proc/sys/net/ipv4/ip_local_port_range`, or Windows without WMI -- it logs a warning and
+continues with only the ranges configured here.
+
+```yaml
+load:
+  - name: ether
+    portExclusions:
+      - min: 8000
+        max: 8080
+```
+
 ### Disabling multicast for bus traffic
 
 You can force Sen to use TCP. The `busConfig.multicastDisabled` configuration parameter can be used


### PR DESCRIPTION
This change prevents using reserved or unavailable multicast addresses and ports.

Also allow defining an additional exclusion range using `busConfig.multicastExclusions` and `portExclusions`.

Resolves SEN-1714