### PR TITLE
feat(ether): add configurable ports

### DIFF
--- a/components/ether/CMakeLists.txt
+++ b/components/ether/CMakeLists.txt
@@ -47,6 +47,8 @@ add_sen_package(
           src/shared_buffer_sequence.h
           src/network_exclusion.h
           src/network_exclusion.cpp
+          src/port_binding.h
+          src/port_binding.cpp
   STL_FILES stl/discovery.stl stl/runtime.stl stl/configuration.stl
   PRIVATE_DEPS
     sen::kernel

--- a/components/ether/src/component.cpp
+++ b/components/ether/src/component.cpp
@@ -112,6 +112,19 @@ public:
       });
     }
 
+    // A pinned udpUnicast port cannot work with more than one peer, and the way it fails is
+    // silent: the sockets are per peer, and UDP has no four-tuple to demultiplex on, so with
+    // reuse_address the last one to bind receives everything and the others receive nothing.
+    // Refusing the configuration is better than starting and losing traffic.
+    if (config_.portConfig && std::holds_alternative<PinnedPort>(config_.portConfig->udpUnicast))
+    {
+      return Err(kernel::ExecError {
+        kernel::ErrorCategory::expectationsNotMet,
+        "udpUnicast cannot be pinned: the socket is per peer, so a second peer would either fail "
+        "to bind or silently take the first peer's traffic. Use Ephemeral for udpUnicast.",
+      });
+    }
+
     discovery_ = DiscoverySystem::make(config_, io_);
 
     // run the discovery hub if needed

--- a/components/ether/src/ether_transport.cpp
+++ b/components/ether/src/ether_transport.cpp
@@ -11,6 +11,7 @@
 #include "bus_handler.h"
 #include "discovery.h"
 #include "network_exclusion.h"
+#include "port_binding.h"
 #include "process_handler.h"
 #include "stats.h"
 #include "util.h"
@@ -47,6 +48,7 @@
 #include <string_view>
 #include <system_error>
 #include <thread>
+#include <tuple>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -85,12 +87,20 @@ class Acceptor final
   SEN_NOCOPY_NOMOVE(Acceptor)
 
 public:
-  Acceptor(EtherTransport* transport, asio::io_context& io, uint16_t port): acceptor_(io), transport_(transport)
+  Acceptor(EtherTransport* transport, asio::io_context& io): acceptor_(io), transport_(transport)
   {
-    asio::ip::tcp::endpoint endpoint(asio::ip::tcp::v4(), port);
+    asio::ip::tcp::endpoint endpoint(asio::ip::tcp::v4(), 0);
     acceptor_.open(endpoint.protocol());
     acceptor_.set_option(asio::ip::tcp::acceptor::reuse_address(true));
-    acceptor_.bind(endpoint);
+    bindConfiguredPort(transport_->config_,
+                       transport_->exclusions_.ports,
+                       PortKind::tcpAcceptor,
+                       [this](uint16_t port)
+                       {
+                         asio::error_code error;
+                         std::ignore = acceptor_.bind(asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port), error);
+                         return error;
+                       });
 
     getLogger()->debug("EtherTransport: accepting connections on {}", acceptor_.local_endpoint().port());
     acceptor_.listen();
@@ -226,7 +236,7 @@ void EtherTransport::start(kernel::TransportListener* listener)
     std::lock_guard lock(ioMutex_);
     io_ = std::make_unique<asio::io_context>();
   }
-  acceptor_ = std::make_unique<Acceptor>(this, *io_, 0);
+  acceptor_ = std::make_unique<Acceptor>(this, *io_);
   listener_ = listener;
   discovery_->addListener(this);
 
@@ -262,6 +272,8 @@ void EtherTransport::start(kernel::TransportListener* listener)
 }
 
 const Configuration& EtherTransport::getConfig() const noexcept { return config_; }
+
+const PortExclusionSources& EtherTransport::getPortExclusions() const noexcept { return exclusions_.ports; }
 
 const kernel::ProcessInfo& EtherTransport::getOwnInfo() const noexcept { return ownInfo_; }
 

--- a/components/ether/src/ether_transport.h
+++ b/components/ether/src/ether_transport.h
@@ -49,6 +49,7 @@ public:
 
 public:
   [[nodiscard]] const Configuration& getConfig() const noexcept;
+  [[nodiscard]] const PortExclusionSources& getPortExclusions() const noexcept;
 
 public:  // implements Transport
   [[nodiscard]] const kernel::ProcessInfo& getOwnInfo() const noexcept override;

--- a/components/ether/src/port_binding.cpp
+++ b/components/ether/src/port_binding.cpp
@@ -1,0 +1,139 @@
+// === port_binding.cpp ================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#include "port_binding.h"
+
+// component
+#include "network_exclusion.h"
+
+// sen
+#include "sen/core/base/class_helpers.h"
+
+// generated code
+#include "stl/configuration.stl.h"
+
+// std
+#include <cstdint>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+namespace sen::components::ether
+{
+
+namespace
+{
+
+[[nodiscard]] const char* toString(PortKind kind) noexcept
+{
+  switch (kind)
+  {
+    case PortKind::tcpAcceptor:
+      return "TCP acceptor";
+    case PortKind::udpUnicast:
+      return "UDP unicast";
+    case PortKind::tcpSource:
+      return "TCP source";
+  }
+  return "unknown";
+}
+
+[[nodiscard]] const PortBinding& getPortBinding(const Configuration& config, PortKind kind)
+{
+  static const PortBinding ephemeral = Ephemeral {};
+
+  if (!config.portConfig)
+  {
+    return ephemeral;
+  }
+
+  switch (kind)
+  {
+    case PortKind::tcpAcceptor:
+      return config.portConfig->tcpAcceptor;
+    case PortKind::udpUnicast:
+      return config.portConfig->udpUnicast;
+    case PortKind::tcpSource:
+      return config.portConfig->tcpSource;
+  }
+  return ephemeral;
+}
+
+[[nodiscard]] std::string excludedByToString(uint16_t port, const PortExclusionSources& exclusions)
+{
+  std::ostringstream stream;
+  bool first = true;
+  const auto appendSource = [&](const char* source)
+  {
+    if (!first)
+    {
+      stream << ", ";
+    }
+    stream << source;
+    first = false;
+  };
+
+  if (exclusions.builtIn.isExcluded(port))
+  {
+    appendSource("built-in exclusions");
+  }
+  if (exclusions.configured.isExcluded(port))
+  {
+    appendSource("configured exclusions");
+  }
+  if (exclusions.os.isExcluded(port))
+  {
+    appendSource("OS exclusions");
+  }
+  return stream.str();
+}
+
+void bindEphemeral(PortKind kind, const BindPort& bind)
+{
+  const auto error = bind(0);
+  if (error)
+  {
+    throw std::runtime_error(std::string("Failed to bind ephemeral port for ") + toString(kind) + ": " +
+                             error.message());
+  }
+}
+
+void bindPinned(PortKind kind, const PinnedPort& config, const PortExclusionSources& exclusions, const BindPort& bind)
+{
+  const auto excludedBy = excludedByToString(config.port, exclusions);
+  if (!excludedBy.empty())
+  {
+    throw std::runtime_error(std::string("Cannot bind pinned port for ") + toString(kind) + " (" +
+                             std::to_string(config.port) + "): excluded by " + excludedBy +
+                             ". No fallback is allowed.");
+  }
+
+  const auto error = bind(config.port);
+  if (error)
+  {
+    throw std::runtime_error(std::string("Failed to bind pinned port for ") + toString(kind) + " (" +
+                             std::to_string(config.port) + "): " + error.message() + ". No fallback is allowed.");
+  }
+}
+
+}  // namespace
+
+void bindConfiguredPort(const Configuration& config,
+                        const PortExclusionSources& exclusions,
+                        PortKind kind,
+                        const BindPort& bind)
+{
+  std::visit(
+    ::sen::Overloaded {
+      [&](const Ephemeral&) { bindEphemeral(kind, bind); },
+      [&](const PinnedPort& pinnedPort) { bindPinned(kind, pinnedPort, exclusions, bind); },
+    },
+    getPortBinding(config, kind));
+}
+
+}  // namespace sen::components::ether

--- a/components/ether/src/port_binding.h
+++ b/components/ether/src/port_binding.h
@@ -1,0 +1,45 @@
+// === port_binding.h ==================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#ifndef SEN_COMPONENTS_ETHER_SRC_PORT_BINDING_H
+#define SEN_COMPONENTS_ETHER_SRC_PORT_BINDING_H
+
+// component
+#include "network_exclusion.h"
+
+// sen
+#include "sen/core/base/move_only_function.h"
+
+// generated code
+#include "stl/configuration.stl.h"
+
+// asio
+#include <asio/error_code.hpp>
+
+// std
+#include <cstdint>
+
+namespace sen::components::ether
+{
+
+enum class PortKind
+{
+  tcpAcceptor,
+  udpUnicast,
+  tcpSource,
+};
+
+using BindPort = sen::std_util::move_only_function<asio::error_code(uint16_t) const>;
+
+void bindConfiguredPort(const Configuration& config,
+                        const PortExclusionSources& exclusions,
+                        PortKind kind,
+                        const BindPort& bind);
+
+}  // namespace sen::components::ether
+
+#endif  // SEN_COMPONENTS_ETHER_SRC_PORT_BINDING_H

--- a/components/ether/src/process_handler.cpp
+++ b/components/ether/src/process_handler.cpp
@@ -9,6 +9,7 @@
 
 // component
 #include "ether_transport.h"
+#include "port_binding.h"
 #include "shared_buffer_sequence.h"
 #include "util.h"
 
@@ -113,8 +114,6 @@ ProcessHandler::ProcessHandler(EtherTransport* transport,
   , udpOutQueue_(transport->getConfig().processUdpOutQueue)
   , tracer_(tracer)
 {
-  tcpSocket_.open(asio::ip::tcp::v4());
-  configureTcpSocket(tcpSocket_, transport->getConfig());
 }
 
 void ProcessHandler::startHandlingIncomingConnection()
@@ -124,6 +123,21 @@ void ProcessHandler::startHandlingIncomingConnection()
 
 void ProcessHandler::startConnection(std::vector<asio::ip::basic_endpoint<asio::ip::tcp>> endpoints)
 {
+  if (!tcpSocket_.is_open())
+  {
+    try
+    {
+      prepareTcpSourceSocket();
+    }
+    catch (const std::exception& error)
+    {
+      logger_->error("could not prepare TCP source socket: {}", error.what());
+      const auto keepAlive = shared_from_this();
+      keepAlive->onDisconnected(asio::error::operation_aborted);
+      return;
+    }
+  }
+
   auto endpoint = endpoints.back();
   endpoints.pop_back();
 
@@ -349,11 +363,57 @@ void ProcessHandler::busMessageReceived(Span<const uint8_t> receivedData,
 // Connection management
 //--------------------------------------------------------------------------------------------------------------
 
+void ProcessHandler::prepareTcpSourceSocket()
+{
+  tcpSocket_.open(asio::ip::tcp::v4());
+  configureTcpSocket(tcpSocket_, transport_->getConfig());
+
+  // One socket per peer, so a pinned source port is bound once per peer. TCP demultiplexes on the
+  // whole four-tuple, so several connections may share a local port as long as the remote ends
+  // differ, which is the case here; without this the second peer fails to bind and is dropped.
+  asio::error_code reuseError;
+  std::ignore = tcpSocket_.set_option(asio::ip::tcp::socket::reuse_address(true), reuseError);
+  if (reuseError)
+  {
+    logger_->warn("could not set reuse_address on the TCP source socket: {}", reuseError.message());
+  }
+
+  bindConfiguredPort(transport_->getConfig(),
+                     transport_->getPortExclusions(),
+                     PortKind::tcpSource,
+                     [this](uint16_t port)
+                     {
+                       asio::error_code error;
+                       std::ignore = tcpSocket_.bind(asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port), error);
+                       return error;
+                     });
+}
+
 void ProcessHandler::onConnected()
 {
   logger_->debug("ProcessHandler: onConnected()");
 
-  udpSocket_ = asio::ip::udp::socket(io_, asio::ip::udp::endpoint(asio::ip::address_v4::any(), 0));
+  try
+  {
+    udpSocket_.open(asio::ip::udp::v4());
+    bindConfiguredPort(transport_->getConfig(),
+                       transport_->getPortExclusions(),
+                       PortKind::udpUnicast,
+                       [this](uint16_t port)
+                       {
+                         asio::error_code error;
+                         std::ignore =
+                           udpSocket_.bind(asio::ip::udp::endpoint(asio::ip::address_v4::any(), port), error);
+                         return error;
+                       });
+  }
+  catch (const std::exception& error)
+  {
+    logger_->error("could not prepare UDP unicast socket: {}", error.what());
+    const auto keepAlive = shared_from_this();
+    keepAlive->onDisconnected(asio::error::operation_aborted);
+    return;
+  }
 
   Hello hello {};
   hello.info = transport_->getOwnInfo();

--- a/components/ether/src/process_handler.h
+++ b/components/ether/src/process_handler.h
@@ -99,6 +99,7 @@ private:
                  sen::kernel::Tracer& tracer);
 
 private:
+  void prepareTcpSourceSocket();
   void onConnected();
   void onDisconnected(const asio::error_code& err);
 

--- a/components/ether/stl/configuration.stl
+++ b/components/ether/stl/configuration.stl
@@ -78,6 +78,35 @@ struct PortRange
 
 sequence<PortRange> PortExclusions;
 
+// Let the operating system select an ephemeral port
+struct Ephemeral {}
+
+// Bind exactly this port, fail closed if taken
+struct PinnedPort
+{
+  port : u16
+}
+
+variant PortBinding
+{
+  Ephemeral,
+  PinnedPort,
+}
+
+// This configuration is per process and does not need to match across Sen instances.
+// Exclusions apply to a pinned port, not to an ephemeral one: an ephemeral bind asks the OS for
+// any free port and does not learn which it was given.
+// udpUnicast cannot be pinned. Its socket is per peer and UDP has no four-tuple to demultiplex
+// on, so a second peer either fails to bind or silently takes the first peer's traffic.
+struct PortConfig
+{
+  tcpAcceptor : PortBinding,  // inbound TCP listener
+  udpUnicast  : PortBinding,  // per-peer UDP unicast; must be Ephemeral
+  tcpSource   : PortBinding   // outbound TCP source port
+}
+
+optional<PortConfig> MaybePortConfig;
+
 // Remember to set these to the same value in all related Sen instances
 struct BusConfig
 {
@@ -109,6 +138,7 @@ struct Configuration
   processTcpOutQueue : QueueConfig,            // Queue for communicating with processes over TCP
   busConfig          : BusConfig,              // Bus transport configuration
   portExclusions     : PortExclusions,         // Port ranges that this process must not use
+  portConfig         : MaybePortConfig,        // If not present, all port bindings are Ephemeral
   runDiscoveryHub    : MaybeDiscoveryHubPort,  // If present, run the TCP discovery hub on this port
   networkDevice      : MaybeDeviceName         // If present, the network device to use
 }

--- a/components/ether/test/CMakeLists.txt
+++ b/components/ether/test/CMakeLists.txt
@@ -8,6 +8,7 @@
 add_sen_unit_test_suite(
   ether_test
   network_exclusion_test.cpp
+  port_binding_test.cpp
   LINK_DEPS
   sen::core
   asio::asio

--- a/components/ether/test/port_binding_test.cpp
+++ b/components/ether/test/port_binding_test.cpp
@@ -1,0 +1,403 @@
+// === port_binding_test.cpp ===========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#include "network_exclusion.h"
+#include "port_binding.h"
+
+// sen
+#include "sen/core/base/assert.h"
+
+// generated code
+#include "stl/configuration.stl.h"
+
+// asio
+#include <asio/error_code.hpp>
+#include <asio/io_context.hpp>
+#include <asio/ip/tcp.hpp>
+#include <asio/ip/udp.hpp>
+#include <asio/socket_base.hpp>
+
+// gtest
+#include <gtest/gtest.h>
+
+// std
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace sen::components::ether
+{
+
+namespace
+{
+
+[[nodiscard]] Configuration makeDefaultConfiguration(MaybePortConfig portConfig)
+{
+  return Configuration {DiscoveryConfig {},
+                        QueueConfig {},
+                        QueueConfig {},
+                        QueueConfig {},
+                        BusConfig {},
+                        PortExclusions {},
+                        std::move(portConfig),
+                        MaybeDiscoveryHubPort {},
+                        MaybeDeviceName {}};
+}
+
+[[nodiscard]] PortConfig makePortConfig(PortKind kind, PortBinding binding)
+{
+  switch (kind)
+  {
+    case PortKind::tcpAcceptor:
+      return PortConfig {std::move(binding), Ephemeral {}, Ephemeral {}};
+    case PortKind::udpUnicast:
+      return PortConfig {Ephemeral {}, std::move(binding), Ephemeral {}};
+    case PortKind::tcpSource:
+      return PortConfig {Ephemeral {}, Ephemeral {}, std::move(binding)};
+  }
+  sen::throwRuntimeError("unknown port kind");
+}
+
+[[nodiscard]] Configuration makeConfigurationWithPort(PortKind kind, PortBinding binding)
+{
+  return makeDefaultConfiguration(MaybePortConfig {makePortConfig(kind, std::move(binding))});
+}
+
+[[nodiscard]] asio::error_code bindTcpAcceptor(asio::ip::tcp::acceptor& acceptor, uint16_t port)
+{
+  asio::error_code error;
+  if (!acceptor.is_open())
+  {
+    std::ignore = acceptor.open(asio::ip::tcp::v4(), error);
+  }
+  if (!error)
+  {
+    std::ignore = acceptor.bind(asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port), error);
+  }
+  if (!error)
+  {
+    std::ignore = acceptor.listen(asio::socket_base::max_listen_connections, error);
+  }
+  return error;
+}
+
+[[nodiscard]] asio::error_code bindTcpSocket(asio::ip::tcp::socket& socket, uint16_t port)
+{
+  asio::error_code error;
+  if (!socket.is_open())
+  {
+    std::ignore = socket.open(asio::ip::tcp::v4(), error);
+  }
+  if (!error)
+  {
+    std::ignore = socket.bind(asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port), error);
+  }
+  return error;
+}
+
+[[nodiscard]] asio::error_code bindUdpSocket(asio::ip::udp::socket& socket, uint16_t port)
+{
+  asio::error_code error;
+  if (!socket.is_open())
+  {
+    std::ignore = socket.open(asio::ip::udp::v4(), error);
+  }
+  if (!error)
+  {
+    std::ignore = socket.bind(asio::ip::udp::endpoint(asio::ip::udp::v4(), port), error);
+  }
+  return error;
+}
+
+class TcpPortReservation final
+{
+public:
+  explicit TcpPortReservation(uint16_t port = 0): acceptor_(io_)
+  {
+    const auto error = bindTcpAcceptor(acceptor_, port);
+    if (error)
+    {
+      sen::throwRuntimeError("failed to reserve TCP port for test: " + error.message());
+    }
+  }
+
+  [[nodiscard]] uint16_t port() const { return acceptor_.local_endpoint().port(); }
+
+private:
+  asio::io_context io_;
+  asio::ip::tcp::acceptor acceptor_;
+};
+
+/// Helper to get an available TCP port from OS (and then use manually on tests)
+[[nodiscard]] uint16_t pickFreeTcpPort()
+{
+  asio::io_context io;
+  asio::ip::tcp::acceptor acceptor(io);
+  if (const auto error = bindTcpAcceptor(acceptor, 0))
+  {
+    sen::throwRuntimeError("failed to pick TCP port for test: " + error.message());
+  }
+
+  return acceptor.local_endpoint().port();
+}
+
+[[nodiscard]] uint16_t pickFreeUdpPort()
+{
+  asio::io_context io;
+  asio::ip::udp::socket socket(io);
+  if (const auto error = bindUdpSocket(socket, 0))
+  {
+    sen::throwRuntimeError("failed to pick UDP port for test: " + error.message());
+  }
+
+  return socket.local_endpoint().port();
+}
+
+}  // namespace
+
+/// @test
+/// If there is no configuration, uses ephemeral mode
+/// @requirements(SEN-909)
+TEST(PortBinding, UsesEphemeralByDefault)
+{
+  const auto config = makeDefaultConfiguration(MaybePortConfig {});
+  PortExclusionSources exclusions;
+  asio::io_context io;
+  asio::ip::tcp::acceptor acceptor(io);
+
+  bindConfiguredPort(config,
+                     exclusions,
+                     PortKind::tcpAcceptor,
+                     [&](uint16_t port)
+                     {
+                       EXPECT_EQ(port, 0);
+                       return bindTcpAcceptor(acceptor, port);
+                     });
+
+  EXPECT_GT(acceptor.local_endpoint().port(), 0);
+}
+
+/// @test
+/// Checks ephemeral mode configuration
+/// @requirements(SEN-909)
+TEST(PortBinding, BindsEphemeralPort)
+{
+  const auto configTcpSource = makeConfigurationWithPort(PortKind::tcpSource, Ephemeral {});
+  const auto configTcpAcceptor = makeConfigurationWithPort(PortKind::tcpAcceptor, Ephemeral {});
+  const auto configUdpUnicast = makeConfigurationWithPort(PortKind::udpUnicast, Ephemeral {});
+  PortExclusionSources exclusions;
+  asio::io_context ioTcpSource;
+  asio::io_context ioTcpAcceptor;
+  asio::io_context ioUdpUnicast;
+  asio::ip::tcp::socket socketSource(ioTcpSource);
+  asio::ip::tcp::acceptor socketAcceptor(ioTcpAcceptor);
+  asio::ip::udp::socket socketUdp(ioUdpUnicast);
+
+  bindConfiguredPort(configTcpSource,
+                     exclusions,
+                     PortKind::tcpSource,
+                     [&](uint16_t port)
+                     {
+                       EXPECT_EQ(port, 0);
+                       return bindTcpSocket(socketSource, port);
+                     });
+
+  bindConfiguredPort(configTcpAcceptor,
+                     exclusions,
+                     PortKind::tcpAcceptor,
+                     [&](uint16_t port)
+                     {
+                       EXPECT_EQ(port, 0);
+                       return bindTcpAcceptor(socketAcceptor, port);
+                     });
+
+  bindConfiguredPort(configUdpUnicast,
+                     exclusions,
+                     PortKind::udpUnicast,
+                     [&](uint16_t port)
+                     {
+                       EXPECT_EQ(port, 0);
+                       return bindUdpSocket(socketUdp, port);
+                     });
+
+  EXPECT_GT(socketSource.local_endpoint().port(), 0);
+  EXPECT_GT(socketAcceptor.local_endpoint().port(), 0);
+  EXPECT_GT(socketUdp.local_endpoint().port(), 0);
+}
+
+/// @test
+/// Checks pin mode configuration
+/// @requirements(SEN-909)
+/// @test Two peers can share one pinned TCP source port, which is why reuse_address is set on it.
+/// Without the option the second bind fails with "address already in use" and that peer is dropped.
+TEST(PortBinding, SharesAPinnedTcpSourcePortBetweenPeers)
+{
+  const auto pinnedPort = pickFreeTcpPort();
+  const auto config = makeConfigurationWithPort(PortKind::tcpSource, PinnedPort {pinnedPort});
+  PortExclusionSources exclusions;
+  asio::io_context io;
+  asio::ip::tcp::socket first(io);
+  asio::ip::tcp::socket second(io);
+
+  const auto bindWithReuse = [&](asio::ip::tcp::socket& socket)
+  {
+    return [&socket](uint16_t port)
+    {
+      asio::error_code error;
+      if (!socket.is_open())
+      {
+        std::ignore = socket.open(asio::ip::tcp::v4(), error);
+      }
+      if (!error)
+      {
+        std::ignore = socket.set_option(asio::ip::tcp::socket::reuse_address(true), error);
+      }
+      if (!error)
+      {
+        std::ignore = socket.bind(asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port), error);
+      }
+      return error;
+    };
+  };
+
+  bindConfiguredPort(config, exclusions, PortKind::tcpSource, bindWithReuse(first));
+  bindConfiguredPort(config, exclusions, PortKind::tcpSource, bindWithReuse(second));
+
+  EXPECT_EQ(first.local_endpoint().port(), pinnedPort);
+  EXPECT_EQ(second.local_endpoint().port(), pinnedPort);
+
+  // The other half of the claim: without the option the second bind is refused, which is what
+  // dropped the second peer. Asserting it here keeps the reason for setting the option visible.
+  asio::ip::tcp::socket third(io);
+  asio::error_code error;
+  std::ignore = third.open(asio::ip::tcp::v4(), error);
+  std::ignore = third.bind(asio::ip::tcp::endpoint(asio::ip::tcp::v4(), pinnedPort), error);
+  EXPECT_TRUE(error) << "a bind without reuse_address should have been refused";
+}
+
+TEST(PortBinding, BindsPinnedPort)
+{
+  const auto portTcpSource = pickFreeTcpPort();
+  const auto portTcpAcceptor = pickFreeTcpPort();
+  const auto portUdpUnicast = pickFreeUdpPort();
+  const auto configTcpSource = makeConfigurationWithPort(PortKind::tcpSource, PinnedPort {portTcpSource});
+  const auto configTcpAcceptor = makeConfigurationWithPort(PortKind::tcpAcceptor, PinnedPort {portTcpAcceptor});
+  const auto configUdpUnicast = makeConfigurationWithPort(PortKind::udpUnicast, PinnedPort {portUdpUnicast});
+  PortExclusionSources exclusions;
+  asio::io_context ioTcpSource;
+  asio::io_context ioTcpAcceptor;
+  asio::io_context ioUdpUnicast;
+  asio::ip::tcp::socket socketSource(ioTcpSource);
+  asio::ip::tcp::acceptor socketAcceptor(ioTcpAcceptor);
+  asio::ip::udp::socket socketUdp(ioUdpUnicast);
+
+  bindConfiguredPort(
+    configTcpSource, exclusions, PortKind::tcpSource, [&](uint16_t port) { return bindTcpSocket(socketSource, port); });
+
+  bindConfiguredPort(configTcpAcceptor,
+                     exclusions,
+                     PortKind::tcpAcceptor,
+                     [&](uint16_t port) { return bindTcpAcceptor(socketAcceptor, port); });
+
+  bindConfiguredPort(
+    configUdpUnicast, exclusions, PortKind::udpUnicast, [&](uint16_t port) { return bindUdpSocket(socketUdp, port); });
+
+  // The pinned port itself, not merely a port: an ephemeral fallback would satisfy a check
+  // that the port is non-zero, which is the failure this test exists to catch.
+  EXPECT_EQ(socketSource.local_endpoint().port(), portTcpSource);
+  EXPECT_EQ(socketAcceptor.local_endpoint().port(), portTcpAcceptor);
+  EXPECT_EQ(socketUdp.local_endpoint().port(), portUdpUnicast);
+}
+
+/// @test
+/// Makes a pin configuration for tcpAcceptor but check that udpUnicast is in ephemeral mode
+/// @requirements(SEN-909)
+TEST(PortBinding, UsesEphemeralForUnsetPorts)
+{
+  const auto config = makeConfigurationWithPort(PortKind::tcpAcceptor, PinnedPort {pickFreeTcpPort()});
+  PortExclusionSources exclusions;
+  asio::io_context io;
+  asio::ip::udp::socket socket(io);
+
+  bindConfiguredPort(config,
+                     exclusions,
+                     PortKind::udpUnicast,
+                     [&](uint16_t port)
+                     {
+                       EXPECT_EQ(port, 0);
+                       return bindUdpSocket(socket, port);
+                     });
+
+  EXPECT_GT(socket.local_endpoint().port(), 0);
+}
+
+/// @test
+/// Checks that making a pin configuration in an excluded port fails
+/// @requirements(SEN-909)
+TEST(PortBinding, RejectsExcludedPinnedPort)
+{
+  const auto pinnedPort = pickFreeTcpPort();
+  const auto config = makeConfigurationWithPort(PortKind::tcpSource, PinnedPort {pinnedPort});
+  PortExclusionSources exclusions;
+  exclusions.configured.add(pinnedPort, pinnedPort);
+  asio::io_context io;
+  asio::ip::tcp::socket socket(io);
+  bool bindCalled = false;
+
+  try
+  {
+    bindConfiguredPort(config,
+                       exclusions,
+                       PortKind::tcpSource,
+                       [&](uint16_t port)
+                       {
+                         bindCalled = true;
+                         return bindTcpSocket(socket, port);
+                       });
+    FAIL() << "Expected pinned port binding to fail";
+  }
+  catch (const std::runtime_error& error)
+  {
+    const std::string message = error.what();
+    EXPECT_NE(message.find("TCP source"), std::string::npos);
+    EXPECT_NE(message.find("configured exclusions"), std::string::npos);
+    EXPECT_NE(message.find("No fallback"), std::string::npos);
+  }
+
+  EXPECT_FALSE(bindCalled);
+}
+
+/// @test
+/// Keep a TCP port busy and check that a pinned bind to the same port fails
+/// @requirements(SEN-909)
+TEST(PortBinding, FailsWhenPinnedPortIsTaken)
+{
+  const TcpPortReservation reservedPort;
+  const auto config = makeConfigurationWithPort(PortKind::tcpAcceptor, PinnedPort {reservedPort.port()});
+  PortExclusionSources exclusions;
+  asio::io_context io;
+  asio::ip::tcp::acceptor acceptor(io);
+  std::vector<uint16_t> attempts;
+
+  EXPECT_THROW(bindConfiguredPort(config,
+                                  exclusions,
+                                  PortKind::tcpAcceptor,
+                                  [&](uint16_t port)
+                                  {
+                                    attempts.push_back(port);
+                                    return bindTcpAcceptor(acceptor, port);
+                                  }),
+               std::runtime_error);
+
+  ASSERT_EQ(attempts.size(), 1U);
+  EXPECT_EQ(attempts.front(), reservedPort.port());
+}
+
+}  // namespace sen::components::ether

--- a/docs/components/ether.md
+++ b/docs/components/ether.md
@@ -90,6 +90,41 @@ If you have other interfaces, use `eth0` (or your preferred interface) instead o
 
 Remember to also do it if you are inside a Docker container (use `--cap-add=NET_ADMIN` and `eth0`).
 
+## Configuring process ports
+
+By default, Sen asks the operating system to select the TCP and UDP ports. The optional
+`portConfig` parameter has one independent entry for each process port, and each entry can use any
+supported port binding mode:
+
+- `tcpAcceptor`: TCP listening port used to accept incoming process connections.
+- `tcpSource`: TCP source port used when initiating outgoing process connections.
+- `udpUnicast`: UDP unicast port used for per-peer best-effort traffic.
+
+Each entry accepts the same port binding modes:
+
+- `Ephemeral`: let the operating system select the port. This is the default.
+- `PinnedPort`: use one exact port.
+
+Pinned ports fail if the configured port cannot be used.
+This configuration is local to each process and does not need to match in other Sen applications.
+If `portConfig` is omitted, all process ports use `Ephemeral`.
+
+```yaml
+load:
+  - name: ether
+    portConfig:
+      tcpAcceptor:
+        type: PinnedPort
+        value:
+          port: 20000
+      udpUnicast:
+        type: Ephemeral
+      tcpSource:
+        type: PinnedPort
+        value:
+          port: 22000
+```
+
 ## Controlling multicast
 
 Sen uses multicast to distribute information to multiple receivers with minimum overhead. The


### PR DESCRIPTION
Adds support for configuring the TCP acceptor, TCP source and UDP unicast ports.

Each port can use a fixed value or be assigned automatically by the OS (default behavior).

Resolves SEN-1715