### PR TITLE
ci(deps): make dependency updates reviewable and mergeable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@
 #
 # Keeps the SHA-pinned GitHub Actions and the CI image base current.
 # Monthly cadence: dependency movement arrives as a reviewable batch.
+#
+# Minor and patch updates are grouped into one pull request, because they carry no
+# decision. Major updates stay separate: each needs checking against how this
+# repository actually uses the action, and holding one must not hold the others.
 
 version: 2
 updates:
@@ -16,6 +20,15 @@ updates:
       interval: monthly
     commit-message:
       prefix: "chore(deps)"
+    # The default of 5 hides updates once majors accumulate.
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: docker
     directory: /tools/ci
@@ -23,3 +36,8 @@ updates:
       interval: monthly
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # The base OS is pinned on purpose. tools/ci/runtime.Dockerfile has to match the
+      # OS the binaries were built on, so moving this is a coordinated change to both
+      # images rather than a dependency bump. Raise it by hand when the time comes.
+      - dependency-name: ubuntu

--- a/.gitlint
+++ b/.gitlint
@@ -9,6 +9,14 @@
 # Subject-only commits are fine; when a body exists it explains why.
 ignore=body-is-missing
 contrib=contrib-title-conventional-commits
+regex-style-search=True
 
 [contrib-title-conventional-commits]
 types=build,chore,ci,docs,feat,fix,perf,refactor,revert,test
+
+# Dependency bumps are written by Dependabot and cite compare URLs that run well past
+# the line limit and cannot be wrapped. The limit still applies to everything else,
+# including the rest of a dependency commit's body.
+[ignore-by-title]
+regex=^chore\(deps\)
+ignore=body-max-line-length

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -373,6 +373,12 @@ the merge-conflict and Windows-filename checks. Pull requests check only
 the changed files; the nightly run checks everything. The nightly run is
 what catches problems caused by updated hooks or rules.
 
+Gitlint exempts `chore(deps)` commits from the body line limit, and only
+that rule. Dependabot cites compare URLs that run past the limit and cannot
+be wrapped, so without the exemption none of its pull requests can merge at
+all. The exemption is written narrowly on purpose: `ci(deps)` is not
+`chore(deps)`, so a human writing about dependencies is still checked.
+
 Exceptions are always written down where they apply: `.hadolint.yaml`
 (DL3008, see the image section), `.pymarkdown.yaml` (MD046, upstream
 crash), `.ruff.toml` per-file ignores (tutorial scripts),
@@ -386,12 +392,45 @@ crash), `.ruff.toml` per-file ignores (tutorial scripts),
 - **Change the matrix**: edit `generate_matrix_jobs.py` and its tests
   together.
 - **Update a tool**: conan is pinned in the three places listed above;
-  actions are pinned by commit SHA (dependabot updates them monthly, and
-  the docker ecosystem watches the base image); pre-commit versions are
-  updated with `pre-commit autoupdate`, except clang-format.
+  actions are pinned by commit SHA and dependabot updates them monthly;
+  pre-commit versions are updated with `pre-commit autoupdate`, except
+  clang-format.
+- **Dependency updates arrive in two shapes.** Minor and patch bumps are
+  grouped into one pull request, because they carry no decision. Majors come
+  separately, because each has to be checked against how this repository uses
+  the action, and holding one must not hold the rest. The base OS is ignored
+  outright: `runtime.Dockerfile` has to match the OS the binaries were built
+  on, so moving it is a coordinated change to both images and is done by hand.
 - **Add a benchmark or a nightly job**: follow the existing shape; a new
   nightly job joins the `needs` list of the tracking-issue job, so its
   failures are reported.
+
+## Landing a change
+
+`main` allows squash only and requires linear history, and required checks are
+strict, so a pull request has to contain the tip of `main` to merge. One merge
+therefore makes every other open pull request stale.
+
+Chained pull requests are a stack, and **`gh pr merge` refuses them**: it
+answers that the pull request "must be merged using the asynchronous merge
+REST API". Use `gh stack merge <n> --yes --squash`, which merges every
+unmerged pull request up to and including the one named, in one all-or-nothing
+operation. The resulting history is the same as merging each from the bottom
+up: one commit per pull request, nothing collapsed.
+
+Two consequences follow, and neither is visible from the workflows:
+
+- **Merging rebases everything above it.** The branches are rewritten onto the
+  new `main`, so their commits get new SHAs and their pipelines run again.
+  This is inherent to stacked merging, not a setting that can be turned off.
+- **Cancelled runs leave a red `CI OK` behind.** When a rebase supersedes a
+  run in flight, its aggregate check reports failure and stays in the rollup.
+  Look for a later successful `CI OK` on the same commit before treating one
+  as a real failure; GitHub enforces the most recent.
+
+`main` also requires review threads to be resolved. Because the stack merge is
+all-or-nothing, **one unresolved comment on one pull request blocks the entire
+stack**, and the pull request it blocks is not necessarily the one being merged.
 
 ## Known limitations
 


### PR DESCRIPTION
Dependabot opened six pull requests within minutes of `.github/dependabot.yml` landing with #74. None of them could merge, and reviewing them showed why.

## Dependabot could not merge at all

Every one of its pull requests fails `Python checks` → `CI OK`. The cause is `gitlint` rule B1: Dependabot writes bodies containing compare URLs of 102 and 149 characters against an 80-character limit, and a URL cannot be wrapped.

The dependency config and the linter that rejects its output shipped in the same merge, so this could only surface once Dependabot actually ran.

The exemption is deliberately narrow — `chore(deps)` titles only, and only the body-length rule. Everything else still applies to Dependabot, and every rule still applies in full to everyone else. Verified against the real commit from #101: it passes, while an over-long body line in an ordinary commit is still rejected. The commit in this very pull request was rejected once for an 81-character line, because `ci(deps)` is not `chore(deps)`.

## Group minor and patch

Of the six, only #101 (`ccache-action` 1.2.20 → 1.2.23) needed no thought. Minor and patch bumps carry no decision, so they now arrive as one pull request — which is what the file already said it wanted: *"dependency movement arrives as a reviewable batch."*

## Keep majors separate

Deliberately not grouped. The four majors did not share a verdict:

- `setup-python` 6 → 7 removes the `pip-install` input — unused here, safe
- `checkout` 6 → 7 blocks fork checkout for `pull_request_target` / `workflow_run` — neither trigger is used here, safe
- `cache/restore` 5 → 6 raises the minimum runner version — all runners are GitHub-hosted, safe
- `upload-artifact` 4 → 7 pairs with `download-artifact`, pinned three majors behind, and the only workflows that download are `build_release.yaml` and `nightly.yaml`, which no pull request runs — **needs holding**

Grouping majors would have meant holding all four to hold one.

## Lift the limit from 5 to 10

The default of five is why `download-artifact` v8 never appeared: the five open majors filled the quota, so the sixth update was invisible. A hidden update looks exactly like no update.

## Ignore the CI base OS

`tools/ci/Dockerfile` is pinned to `ubuntu:22.04` on purpose. `tools/ci/runtime.Dockerfile` states that its `BASE` must match the OS the binaries were built on, so moving the base is a coordinated change to both images rather than a dependency bump. Left unignored it would be proposed and closed every month.

## Documentation

`tools/ci/architecture.md` said the docker ecosystem watches the base image, which this pull request makes untrue, and said nothing about how a stack is landed. Both are corrected, and the gitlint exemption is explained where the other exceptions are already listed.

The new **Landing a change** section records four things that cost real time and are not discoverable from the workflow files: `gh pr merge` refuses stacked pull requests and `gh stack merge` is the command; merging one rebases everything above it, so their pipelines re-run; a run cancelled by that rebase leaves a red `CI OK` behind that is not a failure; and because the stack merge is all-or-nothing, one unresolved review thread blocks the whole stack rather than just its own pull request.
