### PR TITLE
fix(ci): restore the body-is-missing exemption for dependency titles

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -17,6 +17,10 @@ types=build,chore,ci,docs,feat,fix,perf,refactor,revert,test
 # Dependency bumps are written by Dependabot and cite compare URLs that run well past
 # the line limit and cannot be wrapped. The limit still applies to everything else,
 # including the rest of a dependency commit's body.
+#
+# This list REPLACES the one in [general] for matching titles, it does not add to it,
+# so body-is-missing has to be repeated here. Without it the pull request title check
+# fails: it pipes a bare title into gitlint, which then has no body at all.
 [ignore-by-title]
 regex=^chore\(deps\)
-ignore=body-max-line-length
+ignore=body-max-line-length,body-is-missing


### PR DESCRIPTION
Follow-up to #107, which broke the check it was written to unblock.

gitlint's `[ignore-by-title]` **replaces** the `[general] ignore` list for matching titles rather than adding to it. #107 named only `body-max-line-length`, so `body-is-missing` stopped being ignored for `chore(deps)` commits.

That lands on the pull request *title* check: `main.yaml:87` pipes a bare title into gitlint, so there is no body at all and `body-is-missing` fires. Every Dependabot pull request fails on it, and so does #112.

| case | with #107 | with this |
|---|---|---|
| Dependabot PR title, title only | fail | **pass** |
| Dependabot commit, 149-character URLs | pass | pass |
| Ordinary `fix(kernel)` title | pass | pass |
| Human over-long body line | caught | caught |

Verified against the real commit from #101 and a bare title, not a reconstruction.

The comment records why `body-is-missing` appears twice, because the duplication looks redundant and is not.