### PR TITLE
chore(deps): bump the docker build actions

### DIFF
--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -25,14 +25,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
 
       # Proves the Dockerfile builds; no registry hosts the image, so the
       # devcontainer and any self-hosted machine build it from this file.
       # Layer caching in the Actions cache keeps unchanged rebuilds fast; only
       # the final layers are cached, since nothing here builds on this image.
       - name: Build image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: tools/ci
           file: tools/ci/Dockerfile
@@ -84,7 +84,7 @@ jobs:
       # The devcontainer builds this stage, and an editor cannot detect a
       # toolchain without these three.
       - name: Build the editor-facing stage
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: tools/ci
           file: tools/ci/Dockerfile


### PR DESCRIPTION
Combines #109 and #110. They touch the same file and buildx sets up the builder that build-push uses, so they move together.

- `docker/setup-buildx-action` 3 → 4.3.0
- `docker/build-push-action` 6 → 7.3.0

Both move to Node 24 and drop deprecated inputs. Neither reaches this repository: `setup-buildx-action` is invoked with no inputs, `build-push-action` uses only core ones, and the removed `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs are unused. The runner requirement is met because every runner is GitHub-hosted.

`image-check` exercises both, so unlike the artifact pair in #102 these checks mean something.