### PR TITLE
chore(deps): bump the release-path actions

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -50,7 +50,7 @@ jobs:
         run: python .github/scripts/create_changelog.py > ${{ github.workspace }}-CHANGELOG.txt
 
       - name: Archive the generated changelog
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: changelog
           # The release body comes from this file; an empty artifact would ship
@@ -92,7 +92,7 @@ jobs:
           python .github/scripts/check_package_archive.py build/${{ matrix.compiler.name }}/Release/
 
       - name: Archive generated release package
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           # An archive that does not match is a broken release, not a warning.
           if-no-files-found: error
@@ -112,7 +112,7 @@ jobs:
       - generate_changelog
     steps:
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
 
       - name: Print context
         run: |
@@ -138,7 +138,7 @@ jobs:
           cat SHA256SUMS
 
       - name: Create Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
         if: github.ref_type == 'tag'
         with:
           body_path: changelog/sen-CHANGELOG.txt

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Archive test logs on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: flake-hunt-logs
           path: build/gcc/Release/Testing/
@@ -178,7 +178,7 @@ jobs:
       # Result history lives in these artifacts until a baseline comparison
       # exists to fail on.
       - name: Archive benchmark results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: benchmark-results
           # An empty archive would mean the benchmarks never ran, which is the
@@ -329,7 +329,7 @@ jobs:
           cmake --build build/clang/Debug/ --target generate-coverage-report
 
       - name: Publish the coverage report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-report
           if-no-files-found: error
@@ -371,7 +371,7 @@ jobs:
 
       # Downloaded outside the checkout, so that replaying the change on top
       # of a documentation deploy does not need the report to survive a reset.
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         if: steps.site.outputs.exists == 'true'
         with:
           name: coverage-report

--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Publish the coverage report
         if: matrix.enable_coverage
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-report
           if-no-files-found: error


### PR DESCRIPTION
Combines #102, #108 and #115. Upload and download are a matched pair, and all three are used only in workflows that no pull request runs — so they go together, and CI cannot verify them.

- `actions/upload-artifact` 4 → 7.0.1
- `actions/download-artifact` 5 → 8.0.1
- `softprops/action-gh-release` 2 → 3.0.2

`action-gh-release` 3 and `upload-artifact` 7 are runtime moves to Node 24; the runner requirement is met because every runner is GitHub-hosted, and upload's new `archive` input is not set so artifacts stay zipped.

`download-artifact` 8 is the one with real behaviour changes: it no longer unzips everything, and a digest mismatch now fails the run. Neither `skip-decompress` nor `digest-mismatch` is set. `build_release.yaml:115` downloads every artifact with no inputs and the next step reads `changelog/sen-CHANGELOG.txt` from a directory, so it depends on artifacts still arriving unzipped — which they should, since upload still zips.

## Verification

Green checks here prove nothing: `build_release.yaml` runs on tags and `nightly.yaml` on a schedule. Before merging:

1. `nightly.yaml` via `workflow_dispatch` against this branch — it uploads `coverage-report` and downloads it in the same run, so it exercises the pair.
2. A release dry run: tag this branch `X.Y.Z-rcN`, which produces a **draft** prerelease. Check both platform archives, the changelog, and the installer verification file are present, then delete the draft and the tag.