### PR TITLE
ci: widen mypy to the whole repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,13 +85,21 @@ repos:
       # Guards the CI image; example Dockerfiles are tutorial content
       files: ^tools/
 
-# Scoped to the CI scripts: repo-wide mypy is blocked by duplicate test
-# module names under apps/cli_gen; widen the scope when that is resolved.
+# Covers every tracked Python file except three, each excluded for a reason
+# rather than to hide a finding:
+#   .cmake-format.py            a cmake-format config, not source: its names are
+#                               injected by the loader, which is why ruff already
+#                               carries noqa: F821 for it
+#   .conan/test_packages/...    a second conanfile, and mypy resolves both to the
+#                               module "conanfile"
+#   apps/cli_gen/test/test20/   a second test.py, same collision
+# --explicit-package-bases is what lets the rest resolve from the repository root.
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v2.3.1
   hooks:
     - id: mypy
-      files: ^\.github/scripts/
+      args: [--explicit-package-bases, --ignore-missing-imports]
+      exclude: ^(\.cmake-format\.py|\.conan/test_packages/|apps/cli_gen/test/test20/)
       additional_dependencies: [types-PyYAML==6.0.12.20260815]
 
 - repo: https://github.com/jorisroovers/gitlint

--- a/libs/kernel/test/integration/run.py
+++ b/libs/kernel/test/integration/run.py
@@ -102,8 +102,7 @@ def abort(container_list: list[DockerContainer], thread_list: list[Thread]) -> N
     cleanup(container_list)
 
     for t in thread_list:
-        if isinstance(t, Thread):
-            t.join()
+        t.join()
 
     sys.exit(1)
 
@@ -163,7 +162,9 @@ if __name__ == "__main__":
                 # start the container (with the host environment) and the log thread
                 container.env.update(os.environ)
                 container.start()
-                log_threads.append(Thread(target=stream_logs, args=(container,), daemon=True).start())
+                log_thread = Thread(target=stream_logs, args=(container,), daemon=True)
+                log_thread.start()
+                log_threads.append(log_thread)
                 containers.append(container)
 
             deadline = time.time() + TIMEOUT
@@ -179,7 +180,7 @@ if __name__ == "__main__":
                 # pass the test if all processes have exited successfully
                 if all(w.status == "exited" for w in wrapped):
                     # join the logger threads
-                    list(map(Thread.join, [t for t in log_threads if isinstance(t, Thread)]))
+                    list(map(Thread.join, log_threads))
                     break
 
                 time.sleep(0.2)


### PR DESCRIPTION
The scope was `^\.github/scripts/`, with a comment saying repo-wide mypy was blocked by duplicate test module names under `apps/cli_gen`. That was true but incomplete, and the fix is smaller than it suggested.

There are two collisions, not one: `apps/cli_gen/test/test19/test.py` against `test20/test.py`, and the root `conanfile.py` against `.conan/test_packages/package/conanfile.py`. Excluding one of each pair, plus `.cmake-format.py` — a cmake-format config whose names are injected by its loader, which is why ruff already carries `noqa: F821` for it — leaves everything else resolving with `--explicit-package-bases`.

That took the checked set from 15 files to 33, and found one real defect:

```python
log_threads.append(Thread(target=stream_logs, args=(container,), daemon=True).start())
```

`Thread.start()` returns `None`, so the list held `None` and the log threads were never joined. Two `isinstance(t, Thread)` guards existed to survive that; both are removed with the cause.

Verified: the hook now fires on files that were previously out of scope, the three exclusions skip, `test19/test.py` is still checked, and mypy reports no issues across all 33.