### PR TITLE
test(kernel): enable the process-based integration suites

### DIFF
--- a/libs/kernel/test/CMakeLists.txt
+++ b/libs/kernel/test/CMakeLists.txt
@@ -10,11 +10,12 @@ add_subdirectory(unit)
 # Disable integration tests in Windows
 if(NOT MSVC)
   add_subdirectory(integration/test_helpers)
-  # TODO(SEN-1725): Need to figure out github support
-  # add_subdirectory(integration/transport)
-  # add_subdirectory(integration/runtime_compatibility)
-  # add_subdirectory(integration/crash_report)
-  # add_subdirectory(integration/type_clash)
+  # These drive several `sen run` processes through runner.py; they need no
+  # container, only the ether and py components.
+  add_subdirectory(integration/transport)
+  add_subdirectory(integration/runtime_compatibility)
+  add_subdirectory(integration/crash_report)
+  add_subdirectory(integration/type_clash)
   #
   # integration tests that use containers (only available in Linux)
   if(LINUX)

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -437,11 +437,13 @@ stack**, and the pull request it blocks is not necessarily the one being merged.
 - MSVC jobs build but do not run tests (SEN-1725). Uploading coverage to an
   external service is wired but disabled (SEN-1726); the published report and
   the floor cover the same ground without sending anything outside.
-- Only the `object_sync` container suite runs, and only on the two x86 gcc
-  legs. The other container suites (transport, runtime compatibility, crash
-  report, type clash) are still disabled and need the same verify-and-enable
-  treatment.
-- The Windows legs do not build the examples yet.
+- `object_sync` is the only suite that uses containers, and it runs only on the
+  two x86 gcc legs, because they are the ones that set a runtime image.
+  Transport, runtime compatibility, crash report and type clash are a different
+  thing: they drive several `sen run` processes through `runner.py` and need no
+  container at all, only the ether and py components.
+- The Windows legs do not build the examples yet, and are excluded from the
+  standard test workflow entirely, so they run no tests on a pull request.
 - What runs on a pull request is decided by the pull request's own copy of
   the workflows and of `classify_changes.py`, because that is how GitHub
   runs `pull_request` workflows. A green `CI OK` therefore means "the checks


### PR DESCRIPTION
Four suites were disabled under `TODO(SEN-1725)`. They need no container, only the ether and py components, so `mode=full` already builds what they use.

`architecture.md` called them container suites and said the Windows legs skip the examples; they run no tests on a pull request at all. Corrected both.

Not verified locally — the pipeline is the check.