### PR TITLE
ci(tsan): suppress the ::clear side of the work queue race

### DIFF
--- a/cmake/util/tsan_ignorelist.txt
+++ b/cmake/util/tsan_ignorelist.txt
@@ -62,3 +62,8 @@ race:object_sync::TestObjectRemoteProxy::setNextWritableProp
 
 # TODO(SEN-SEN-1706): data race found while running object_sync_confirmed_events_single_process with TSAN
 race:sen::impl::EventBuffer::addConnection
+
+# TODO(SEN-1511): the ::clear side of the same race. Runner::stopThread clears the
+# work queue during Executor::shutDown while a worker thread is still reading it.
+# Found by RestE2EFixture.invoke_method, but the race is in the kernel shutdown path.
+race:sen::impl::WorkQueueImpl::clear


### PR DESCRIPTION
The nightly TSan lane reports a race in `RestE2EFixture.invoke_method`: `Runner::stopThread` clears the work queue during `Executor::shutDown` while a worker thread is still reading it. Same defect as the existing `::push` entry, so it goes under SEN-1511 too.

This suppresses the report, it does not fix the race. Both entries come out when the concurrency redesign lands: that branch deletes `WorkQueueImpl` outright and has already dropped its own SEN-1511 suppression.