### PR TITLE
fix: build clean at C++20

### DIFF
--- a/components/rest/src/base_router.cpp
+++ b/components/rest/src/base_router.cpp
@@ -72,7 +72,11 @@ std::pair<std::string, std::regex> BaseRouter::parseAndValidateRoute(const std::
     ::sen::throwRuntimeError("Invalid route path");
   }
 
-  const std::regex paramMatcherRegex("/" + std::string(pathUrlParamRegex));
+  // Built by appending rather than with operator+, which gcc 12 reports as a huge memcpy when the
+  // string methods are constexpr under C++20.
+  std::string paramMatcher = "/";
+  paramMatcher += pathUrlParamRegex;
+  const std::regex paramMatcherRegex(paramMatcher);
   std::string paramMatcherStr = std::regex_replace(path, paramMatcherRegex, "/(" + std::string(pathSegmentRegex) + ")");
 
   return {paramMatcherStr, std::regex(paramMatcherStr)};

--- a/libs/core/src/lang/stl_scanner.cpp
+++ b/libs/core/src/lang/stl_scanner.cpp
@@ -414,7 +414,9 @@ void StlScanner::number(Sign sign)
     if (sign == Sign::negative)
     {
       value = -value;
-      lexeme.insert(0, "-");
+      // The character overload. The const char* one takes a length gcc 12 cannot bound, which it
+      // reports as a huge memcpy when the string methods are constexpr under C++20.
+      lexeme.insert(0, 1, '-');
     }
 
     tokens_.emplace_back(StlTokenType::real, lexeme, value, current_);
@@ -428,7 +430,7 @@ void StlScanner::number(Sign sign)
     if (sign == Sign::negative)
     {
       value = -value;
-      lexeme.insert(0, "-");
+      lexeme.insert(0, 1, '-');
     }
 
     tokens_.emplace_back(StlTokenType::integral, lexeme, value, current_);


### PR DESCRIPTION
gcc 12 turns `std::string::insert` and `operator+` into a memcpy whose length it cannot bound, and reports it as accessing 2^63 bytes. The string methods are `constexpr` under C++20, which changes the inlining enough to trigger it.

Two sites, both plain concatenation. 394/394 targets build at C++20 under `-Werror`, and the same at C++17.