### PR TITLE
test(cli_package): give each init test its own directory

### DIFF
--- a/apps/cli_package/test/init_component_test.cpp
+++ b/apps/cli_package/test/init_component_test.cpp
@@ -6,6 +6,7 @@
 // =====================================================================================================================
 
 #include "../util.h"
+#include "scoped_work_dir.h"
 
 // google test
 #include <gtest/gtest.h>
@@ -59,6 +60,8 @@ TEST(CliPackageInitComponent, NoUpperCammelCase)
 /// Check sen package init-component fails when the path provided already exists
 TEST(CliPackageInitComponent, DirectoryAlreadyExists)
 {
+  const ScopedWorkDir workDir;
+
   CLI::App app;
   app.name("sen package");
 
@@ -69,14 +72,14 @@ TEST(CliPackageInitComponent, DirectoryAlreadyExists)
   EXPECT_EXIT(app.parse("init-component TestComponent"),
               ::testing::ExitedWithCode(2),
               "directory test_component already exists\n");
-
-  std::filesystem::remove_all("test_component");
 }
 
 /// @test
 /// Check sen package init-component creates all expected directories and files when no errors occur
 TEST(CliPackageInitComponent, NoFlags)
 {
+  const ScopedWorkDir workDir;
+
   CLI::App app;
   app.name("sen package");
 
@@ -90,14 +93,14 @@ TEST(CliPackageInitComponent, NoFlags)
 
   EXPECT_TRUE(std::filesystem::exists("test_component/CMakeLists.txt"));
   EXPECT_TRUE(std::filesystem::exists("test_component/src/component.cpp"));
-
-  std::filesystem::remove_all("test_component");
 }
 
 /// @test
 /// Check sen package init-component creates all expected directories and files when --with-config flag is provided
 TEST(CliPackageInitComponent, WithConfigFlag)
 {
+  const ScopedWorkDir workDir;
+
   CLI::App app;
   app.name("sen package");
 
@@ -113,14 +116,14 @@ TEST(CliPackageInitComponent, WithConfigFlag)
   EXPECT_TRUE(std::filesystem::exists("test_component/CMakeLists.txt"));
   EXPECT_TRUE(std::filesystem::exists("test_component/src/component.cpp"));
   EXPECT_TRUE(std::filesystem::exists("test_component/stl/test_component/config.stl"));
-
-  std::filesystem::remove_all("test_component");
 }
 
 /// @test
 /// Check sen package init-component creates all expected directories and files when --full flag is provided
 TEST(CliPackageInitComponent, FullFlag)
 {
+  const ScopedWorkDir workDir;
+
   CLI::App app;
   app.name("sen package");
 
@@ -136,8 +139,6 @@ TEST(CliPackageInitComponent, FullFlag)
   EXPECT_TRUE(std::filesystem::exists("test_component/CMakeLists.txt"));
   EXPECT_TRUE(std::filesystem::exists("test_component/src/component.cpp"));
   EXPECT_TRUE(std::filesystem::exists("test_component/stl/test_component/config.stl"));
-
-  std::filesystem::remove_all("test_component");
 }
 
 /// @test

--- a/apps/cli_package/test/init_package_test.cpp
+++ b/apps/cli_package/test/init_package_test.cpp
@@ -6,6 +6,7 @@
 // =====================================================================================================================
 
 #include "../util.h"
+#include "scoped_work_dir.h"
 
 // google test
 #include <gtest/gtest.h>
@@ -58,6 +59,8 @@ TEST(CliPackageInit, NoClass)
 /// Check sen package init fails when the path provided already exists
 TEST(CliPackageInit, DirectoryAlreadyExists)
 {
+  const ScopedWorkDir workDir;
+
   CLI::App app;
   app.name("sen package");
 
@@ -68,14 +71,14 @@ TEST(CliPackageInit, DirectoryAlreadyExists)
   EXPECT_EXIT(app.parse("init test_package --class TestClass"),
               ::testing::ExitedWithCode(1),
               "directory test_package already exists\n");
-
-  std::filesystem::remove_all("test_package");
 }
 
 /// @test
 /// Check sen package init creates all expected directories and files when no errors occur
 TEST(CliPackageInit, NoErrors)
 {
+  const ScopedWorkDir workDir;
+
   CLI::App app;
   app.name("sen package");
 
@@ -94,8 +97,6 @@ TEST(CliPackageInit, NoErrors)
   EXPECT_TRUE(std::filesystem::exists("test_package/src/test_class.cpp"));
   EXPECT_TRUE(std::filesystem::exists("test_package/stl/test_package/basic_types.stl"));
   EXPECT_TRUE(std::filesystem::exists("test_package/stl/test_package/test_class.stl"));
-
-  std::filesystem::remove_all("test_package");
 }
 
 /// @test

--- a/apps/cli_package/test/scoped_work_dir.h
+++ b/apps/cli_package/test/scoped_work_dir.h
@@ -1,0 +1,55 @@
+// === scoped_work_dir.h ===============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#ifndef SEN_APPS_CLI_PACKAGE_TEST_SCOPED_WORK_DIR_H
+#define SEN_APPS_CLI_PACKAGE_TEST_SCOPED_WORK_DIR_H
+
+// google test
+#include <gtest/gtest.h>
+
+// std
+#include <filesystem>
+#include <random>
+#include <string>
+
+/// Runs a test in a directory of its own: ctest runs one process per test from a shared working
+/// directory, so the fixed relative paths these tests create would collide.
+class ScopedWorkDir
+{
+public:
+  ScopedWorkDir()
+  {
+    const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    // The suffix separates concurrent runs of the same test, which the name alone does not.
+    const std::string name =
+      std::string(info->test_suite_name()) + "." + info->name() + "." + std::to_string(std::random_device {}());
+
+    previous_ = std::filesystem::current_path();
+    dir_ = std::filesystem::temp_directory_path() / name;
+
+    std::filesystem::create_directories(dir_);
+    std::filesystem::current_path(dir_);
+  }
+
+  ~ScopedWorkDir()
+  {
+    std::error_code error;
+    std::filesystem::current_path(previous_, error);
+    std::filesystem::remove_all(dir_, error);
+  }
+
+  ScopedWorkDir(const ScopedWorkDir&) = delete;
+  ScopedWorkDir(ScopedWorkDir&&) = delete;
+  ScopedWorkDir& operator=(const ScopedWorkDir&) = delete;
+  ScopedWorkDir& operator=(ScopedWorkDir&&) = delete;
+
+private:
+  std::filesystem::path previous_;
+  std::filesystem::path dir_;
+};
+
+#endif  // SEN_APPS_CLI_PACKAGE_TEST_SCOPED_WORK_DIR_H


### PR DESCRIPTION
The nightly repeat loop failed on `CliPackageInit.DirectoryAlreadyExists`. ctest registers one entry per test and runs them in parallel from a single working directory, so tests creating and deleting `test_package` and `test_component` race.

Six tests now run in a directory of their own, which leaves their relative paths unchanged. Four of sixteen failed on any parallel run before; 4800 executions after produced none.