### PR TITLE
ci: fix the clang-tidy and newest-gcc nightly lanes

### DIFF
--- a/.conan/profiles/sen_gcc
+++ b/.conan/profiles/sen_gcc
@@ -1,9 +1,13 @@
+{# SEN_GCC_VERSION lets a lane pick the compiler. Without it the version reaches
+   apt and the cache key but not the profile. #}
+{% set gcc_version = os.getenv("SEN_GCC_VERSION") or "12" %}
+
 [settings]
 os=Linux
 arch={{ detect_api.detect_arch() }}
 compiler=gcc
 compiler.cppstd=17
-compiler.version=12
+compiler.version={{ gcc_version }}
 compiler.libcxx=libstdc++11
 build_type=Release
 
@@ -14,4 +18,4 @@ build_type=Release
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
 tools.cmake.cmake_layout:build_folder_vars=['settings.compiler']
-tools.build:compiler_executables={"c": "gcc-12", "cpp": "g++-12"}
+tools.build:compiler_executables={"c": "gcc-{{ gcc_version }}", "cpp": "g++-{{ gcc_version }}"}

--- a/.github/actions/setup_build_context/action.yaml
+++ b/.github/actions/setup_build_context/action.yaml
@@ -70,6 +70,12 @@ runs:
       # libxext for clang compat with sdl2 2.24.0; bats for the installer tests
       run: timeout 1200 sudo apt-get install -y libxext-dev bats
 
+    # conan renders the profile on every command, so this has to outlive the step.
+    - name: Select the gcc version the profile builds with
+      if: ${{ inputs.compiler-name == 'gcc' }}
+      shell: bash
+      run: echo "SEN_GCC_VERSION=${{ inputs.compiler-version }}" >> "$GITHUB_ENV"
+
     - name: Setup conan profile
       shell: bash
       run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -285,10 +285,12 @@ jobs:
               python3 -c 'import json, sys; print(json.load(sys.stdin)["version"])')
           for std in 20 23; do
               echo "::group::consumer at C++$std"
-              # & is the consumer here, so sen and its dependencies keep the
-              # settings they were built with.
+              # The bare setting reaches the consumer, the patterns hold sen and its
+              # dependencies at what they were built with. "&:" would not: under conan
+              # test it names the package under test.
               conan test .conan/test_packages/package "sen/$version@airbus/dev" \
-                  -s "&:compiler.cppstd=$std"
+                  -s "compiler.cppstd=$std" -s "*:compiler.cppstd=17" \
+                  -o "sen/*:with_tests=True" -o "sen/*:with_examples=True"
               echo "::endgroup::"
           done
 

--- a/apps/cli_gen/src/cpp/cpp_generator.cpp
+++ b/apps/cli_gen/src/cpp/cpp_generator.cpp
@@ -42,13 +42,9 @@
 #include <inja/template.hpp>
 
 // std
-#include <algorithm>
 #include <cstddef>
 #include <filesystem>
-#include <fstream>
-#include <ios>
 #include <iostream>
-#include <iterator>
 #include <memory>
 #include <ostream>
 #include <string>


### PR DESCRIPTION
Three fixes for two failing lanes.

`clang-tidy full tree` reported four unused includes in `cpp_generator.cpp`.

The newest-gcc lane never used gcc-14: the profile pinned version 12, so the version reached apt and the cache key but not the build. It now comes from `SEN_GCC_VERSION`.

That lane also asked for a `package_id` that was never built, and put the standard on the package under test rather than the consumer.