### PR TITLE
feat(ether): configurable port range

### DIFF
--- a/components/ether/src/network_exclusion.h
+++ b/components/ether/src/network_exclusion.h
@@ -149,6 +149,13 @@ struct NetworkExclusions
                                                                             const MulticastRange& range,
                                                                             const MulticastExclusions& exclusions);
 
+/// Returns true if the port is excluded by any port source.
+[[nodiscard]] inline bool isPortExcluded(uint16_t port, const PortExclusionSources& exclusions)
+{
+  return exclusions.builtIn.isExcluded(port) || exclusions.configured.isExcluded(port) ||
+         exclusions.os.isExcluded(port);
+}
+
 }  // namespace sen::components::ether
 
 #endif  // SEN_COMPONENTS_ETHER_SRC_NETWORK_EXCLUSION_H

--- a/components/ether/src/port_binding.cpp
+++ b/components/ether/src/port_binding.cpp
@@ -106,9 +106,10 @@ void validateProbeRange(PortKind kind, const ProbePortRange& config)
 {
   if (config.min > config.max)
   {
-    throw std::invalid_argument(std::string("Invalid probe port range for ") + toString(kind) + " (" +
-                                std::to_string(config.min) + "-" + std::to_string(config.max) +
-                                "): min is greater than max.");
+    std::ostringstream oss;
+    oss << "Invalid probe port range for " << toString(kind) << " (" << config.min << '-' << config.max
+        << "): min is greater than max.";
+    sen::throwRuntimeError(oss.str());
   }
 }
 

--- a/components/ether/src/port_binding.cpp
+++ b/components/ether/src/port_binding.cpp
@@ -11,17 +11,26 @@
 #include "network_exclusion.h"
 
 // sen
+#include "sen/core/base/assert.h"
 #include "sen/core/base/class_helpers.h"
 
 // generated code
 #include "stl/configuration.stl.h"
 
+// asio
+#include <asio/error.hpp>
+#include <asio/error_code.hpp>
+
 // std
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <random>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <variant>
+#include <vector>
 
 namespace sen::components::ether
 {
@@ -93,13 +102,36 @@ namespace
   return stream.str();
 }
 
+void validateProbeRange(PortKind kind, const ProbePortRange& config)
+{
+  if (config.min > config.max)
+  {
+    throw std::invalid_argument(std::string("Invalid probe port range for ") + toString(kind) + " (" +
+                                std::to_string(config.min) + "-" + std::to_string(config.max) +
+                                "): min is greater than max.");
+  }
+}
+
+[[nodiscard]] std::size_t pickProbeStartIndex(std::size_t candidateCount)
+{
+  SEN_ASSERT(candidateCount > 0U);
+
+  std::random_device randomDevice;
+  std::uniform_int_distribution<std::size_t> distribution(0U, candidateCount - 1U);
+  return distribution(randomDevice);
+}
+
+[[nodiscard]] std::string rangeToString(const ProbePortRange& config)
+{
+  return std::to_string(config.min) + "-" + std::to_string(config.max);
+}
+
 void bindEphemeral(PortKind kind, const BindPort& bind)
 {
   const auto error = bind(0);
   if (error)
   {
-    throw std::runtime_error(std::string("Failed to bind ephemeral port for ") + toString(kind) + ": " +
-                             error.message());
+    sen::throwRuntimeError(std::string("Failed to bind ephemeral port for ") + toString(kind) + ": " + error.message());
   }
 }
 
@@ -108,17 +140,164 @@ void bindPinned(PortKind kind, const PinnedPort& config, const PortExclusionSour
   const auto excludedBy = excludedByToString(config.port, exclusions);
   if (!excludedBy.empty())
   {
-    throw std::runtime_error(std::string("Cannot bind pinned port for ") + toString(kind) + " (" +
-                             std::to_string(config.port) + "): excluded by " + excludedBy +
-                             ". No fallback is allowed.");
+    sen::throwRuntimeError(std::string("Cannot bind pinned port for ") + toString(kind) + " (" +
+                           std::to_string(config.port) + "): excluded by " + excludedBy);
   }
 
   const auto error = bind(config.port);
   if (error)
   {
-    throw std::runtime_error(std::string("Failed to bind pinned port for ") + toString(kind) + " (" +
-                             std::to_string(config.port) + "): " + error.message() + ". No fallback is allowed.");
+    sen::throwRuntimeError(std::string("Failed to bind pinned port for ") + toString(kind) + " (" +
+                           std::to_string(config.port) + "): " + error.message());
   }
+}
+
+/// Returns every port between config.min and config.max that is not excluded
+[[nodiscard]] std::vector<uint16_t> getUsablePorts(const ProbePortRange& config, const PortExclusionSources& exclusions)
+{
+  std::vector<uint16_t> usablePorts;
+  usablePorts.reserve(static_cast<std::size_t>(config.max) - static_cast<std::size_t>(config.min) + 1U);
+
+  for (uint32_t port = config.min; port <= config.max; ++port)
+  {
+    const auto candidate = static_cast<uint16_t>(port);
+    if (!isPortExcluded(candidate, exclusions))
+    {
+      usablePorts.push_back(candidate);
+    }
+  }
+
+  return usablePorts;
+}
+
+/// Builds the diagnostic message fragment with the excluded port count and the exclusion source range
+[[nodiscard]] std::string getProbeExclusionDetails(const ProbePortRange& config,
+                                                   const PortExclusionSources& exclusions,
+                                                   std::size_t excludedPortCount)
+{
+  const auto portRangeToString = [](uint16_t min, uint16_t max)
+  {
+    if (min == max)
+    {
+      return std::to_string(min);
+    }
+    return std::to_string(min) + "-" + std::to_string(max);
+  };
+
+  std::ostringstream exclusionSources;
+  bool hasExclusionSource = false;
+  const auto appendExclusionSource = [&](const char* source, const auto& sourceExclusions)
+  {
+    std::ostringstream sourceRanges;
+    bool hasSourceRange = false;
+    for (const auto& range: sourceExclusions.ranges())
+    {
+      const auto min = std::max(config.min, range.min);
+      const auto max = std::min(config.max, range.max);
+      if (min > max)
+      {
+        continue;
+      }
+
+      if (hasSourceRange)
+      {
+        sourceRanges << ", ";
+      }
+      sourceRanges << portRangeToString(min, max);
+      hasSourceRange = true;
+    }
+
+    if (!hasSourceRange)
+    {
+      return;
+    }
+
+    if (hasExclusionSource)
+    {
+      exclusionSources << "; ";
+    }
+    exclusionSources << source << ": " << sourceRanges.str();
+    hasExclusionSource = true;
+  };
+
+  appendExclusionSource("built-in", exclusions.builtIn);
+  appendExclusionSource("configured", exclusions.configured);
+  appendExclusionSource("OS", exclusions.os);
+
+  std::string exclusionDetails = "excluded ports: " + std::to_string(excludedPortCount);
+  if (hasExclusionSource)
+  {
+    exclusionDetails += " (" + exclusionSources.str() + ")";
+  }
+
+  return exclusionDetails;
+}
+
+/// Attempts to bind for each usable port, starting at a random index and wrapping around the vector.
+/// If a port is already in use, the next usable port is tried.
+void bindUsableProbePorts(PortKind kind,
+                          const ProbePortRange& config,
+                          const std::vector<uint16_t>& usablePorts,
+                          const std::string& exclusionDetails,
+                          const BindPort& bind)
+{
+  SEN_ASSERT(!usablePorts.empty());
+  const auto startIndex = pickProbeStartIndex(usablePorts.size());
+  asio::error_code lastError;
+  uint16_t lastAttemptedPort = 0;
+
+  for (std::size_t attempt = 0; attempt < usablePorts.size(); ++attempt)
+  {
+    const auto index = (startIndex + attempt) % usablePorts.size();
+    const auto port = usablePorts.at(index);
+    lastAttemptedPort = port;
+    const auto error = bind(port);
+    if (!error)
+    {
+      return;
+    }
+
+    lastError = error;
+    if (error != asio::error::address_in_use)
+    {
+      sen::throwRuntimeError(std::string("Failed to bind probe port for ") + toString(kind) + " (" +
+                             std::to_string(port) + " in range " + rangeToString(config) + "): " + error.message() +
+                             "; bind attempts: " + std::to_string(attempt + 1U) + "; " + exclusionDetails);
+    }
+  }
+
+  std::string reason = "no port was available";
+  SEN_ASSERT(static_cast<bool>(lastError));
+  reason += "; bind attempts: " + std::to_string(usablePorts.size());
+  reason += "; " + exclusionDetails;
+  reason += "; last attempted port: " + std::to_string(lastAttemptedPort);
+  reason += "; last error: " + lastError.message();
+
+  sen::throwRuntimeError(std::string("Failed to bind probe range for ") + toString(kind) + " (" +
+                         rangeToString(config) + "): " + reason);
+}
+
+/// Validates the configured range, filters excluded ports and binds one usable port.
+void bindProbe(PortKind kind,
+               const ProbePortRange& config,
+               const PortExclusionSources& exclusions,
+               const BindPort& bind)
+{
+  validateProbeRange(kind, config);
+
+  const auto usablePorts = getUsablePorts(config, exclusions);
+  const auto portCount = static_cast<std::size_t>(config.max) - static_cast<std::size_t>(config.min) + 1U;
+  const auto excludedPortCount = portCount - usablePorts.size();
+  const auto exclusionDetails = getProbeExclusionDetails(config, exclusions, excludedPortCount);
+
+  if (usablePorts.empty())
+  {
+    sen::throwRuntimeError(std::string("Failed to bind probe range for ") + toString(kind) + " (" +
+                           rangeToString(config) + "): all ports are excluded; " + exclusionDetails +
+                           "; bind attempts: 0.");
+  }
+
+  bindUsableProbePorts(kind, config, usablePorts, exclusionDetails, bind);
 }
 
 }  // namespace
@@ -132,6 +311,7 @@ void bindConfiguredPort(const Configuration& config,
     ::sen::Overloaded {
       [&](const Ephemeral&) { bindEphemeral(kind, bind); },
       [&](const PinnedPort& pinnedPort) { bindPinned(kind, pinnedPort, exclusions, bind); },
+      [&](const ProbePortRange& probeRange) { bindProbe(kind, probeRange, exclusions, bind); },
     },
     getPortBinding(config, kind));
 }

--- a/components/ether/src/port_binding.h
+++ b/components/ether/src/port_binding.h
@@ -35,6 +35,14 @@ enum class PortKind
 
 using BindPort = sen::std_util::move_only_function<asio::error_code(uint16_t) const>;
 
+/// Binds a port using the configured mode for the given port kind.
+///
+/// Throws if the configuration is invalid, the selected port is excluded or no port can be bound.
+///
+/// @param config: ether configuration with the port settings.
+/// @param exclusions: port exclusions that must not be used.
+/// @param kind: port type to bind.
+/// @param bind: function called with the port to bind, returning the bind result.
 void bindConfiguredPort(const Configuration& config,
                         const PortExclusionSources& exclusions,
                         PortKind kind,

--- a/components/ether/stl/configuration.stl
+++ b/components/ether/stl/configuration.stl
@@ -87,10 +87,18 @@ struct PinnedPort
   port : u16
 }
 
+// Bind within [min,max], random start, walk forward
+struct ProbePortRange
+{
+  min : u16,
+  max : u16
+}
+
 variant PortBinding
 {
   Ephemeral,
   PinnedPort,
+  ProbePortRange
 }
 
 // This configuration is per process and does not need to match across Sen instances.

--- a/components/ether/test/port_binding_test.cpp
+++ b/components/ether/test/port_binding_test.cpp
@@ -552,15 +552,14 @@ TEST(PortBinding, RejectsInvalidProbeRange)
   asio::ip::tcp::socket socket(io);
   bool bindCalled = false;
 
-  EXPECT_THROW(bindConfiguredPort(config,
-                                  exclusions,
-                                  PortKind::tcpSource,
-                                  [&](uint16_t port)
-                                  {
-                                    bindCalled = true;
-                                    return bindTcpSocket(socket, port);
-                                  }),
-               std::invalid_argument);
+  EXPECT_ANY_THROW(bindConfiguredPort(config,
+                                      exclusions,
+                                      PortKind::tcpSource,
+                                      [&](uint16_t port)
+                                      {
+                                        bindCalled = true;
+                                        return bindTcpSocket(socket, port);
+                                      }));
 
   EXPECT_FALSE(bindCalled);
 }

--- a/components/ether/test/port_binding_test.cpp
+++ b/components/ether/test/port_binding_test.cpp
@@ -15,6 +15,7 @@
 #include "stl/configuration.stl.h"
 
 // asio
+#include <asio/error.hpp>
 #include <asio/error_code.hpp>
 #include <asio/io_context.hpp>
 #include <asio/ip/tcp.hpp>
@@ -26,6 +27,7 @@
 
 // std
 #include <cstdint>
+#include <exception>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -268,6 +270,42 @@ TEST(PortBinding, BindsPinnedPort)
 }
 
 /// @test
+/// Checks probe mode configuration
+/// @requirements(SEN-909)
+TEST(PortBinding, BindsProbePort)
+{
+  const auto portTcpSource = pickFreeTcpPort();
+  const auto portTcpAcceptor = pickFreeTcpPort();
+  const auto portUdpUnicast = pickFreeUdpPort();
+  const auto configTcpSource =
+    makeConfigurationWithPort(PortKind::tcpSource, ProbePortRange {portTcpSource, portTcpSource});
+  const auto configTcpAcceptor =
+    makeConfigurationWithPort(PortKind::tcpAcceptor, ProbePortRange {portTcpAcceptor, portTcpAcceptor});
+  const auto configUdpUnicast =
+    makeConfigurationWithPort(PortKind::udpUnicast, ProbePortRange {portUdpUnicast, portUdpUnicast});
+  PortExclusionSources exclusions;
+  asio::io_context ioTcpSource;
+  asio::io_context ioTcpAcceptor;
+  asio::io_context ioUdpUnicast;
+  asio::ip::tcp::socket socketSource(ioTcpSource);
+  asio::ip::tcp::acceptor socketAcceptor(ioTcpAcceptor);
+  asio::ip::udp::socket socketUdp(ioUdpUnicast);
+
+  bindConfiguredPort(
+    configTcpSource, exclusions, PortKind::tcpSource, [&](uint16_t port) { return bindTcpSocket(socketSource, port); });
+
+  bindConfiguredPort(configTcpAcceptor,
+                     exclusions,
+                     PortKind::tcpAcceptor,
+                     [&](uint16_t port) { return bindTcpAcceptor(socketAcceptor, port); });
+
+  bindConfiguredPort(
+    configUdpUnicast, exclusions, PortKind::udpUnicast, [&](uint16_t port) { return bindUdpSocket(socketUdp, port); });
+
+  EXPECT_EQ(socketSource.local_endpoint().port(), portTcpSource);
+}
+
+/// @test
 /// Makes a pin configuration for tcpAcceptor but check that udpUnicast is in ephemeral mode
 /// @requirements(SEN-909)
 TEST(PortBinding, UsesEphemeralForUnsetPorts)
@@ -314,12 +352,11 @@ TEST(PortBinding, RejectsExcludedPinnedPort)
                        });
     FAIL() << "Expected pinned port binding to fail";
   }
-  catch (const std::runtime_error& error)
+  catch (const std::exception& error)
   {
     const std::string message = error.what();
     EXPECT_NE(message.find("TCP source"), std::string::npos);
     EXPECT_NE(message.find("configured exclusions"), std::string::npos);
-    EXPECT_NE(message.find("No fallback"), std::string::npos);
   }
 
   EXPECT_FALSE(bindCalled);
@@ -345,10 +382,210 @@ TEST(PortBinding, FailsWhenPinnedPortIsTaken)
                                     attempts.push_back(port);
                                     return bindTcpAcceptor(acceptor, port);
                                   }),
-               std::runtime_error);
+               std::exception);
 
   ASSERT_EQ(attempts.size(), 1U);
   EXPECT_EQ(attempts.front(), reservedPort.port());
+}
+
+/// @test
+/// Checks that probe skips ports excluded by configuration
+/// @requirements(SEN-909)
+TEST(PortBinding, SkipsExcludedProbePort)
+{
+  const auto expectedPort = pickFreeTcpPort();
+  const auto excludedPort = static_cast<uint16_t>(expectedPort - 1U);
+  const auto config = makeConfigurationWithPort(PortKind::tcpAcceptor, ProbePortRange {excludedPort, expectedPort});
+  PortExclusionSources exclusions;
+  exclusions.configured.add(excludedPort, excludedPort);
+  asio::io_context io;
+  asio::ip::tcp::acceptor acceptor(io);
+
+  bindConfiguredPort(
+    config, exclusions, PortKind::tcpAcceptor, [&](uint16_t port) { return bindTcpAcceptor(acceptor, port); });
+
+  EXPECT_EQ(acceptor.local_endpoint().port(), expectedPort);
+}
+
+/// @test
+/// Checks that probe tries another port when a candidate is already in use
+/// @requirements(SEN-909)
+TEST(PortBinding, RetriesProbePort)
+{
+  const auto config = makeConfigurationWithPort(PortKind::tcpAcceptor, ProbePortRange {20000, 20002});
+  PortExclusionSources exclusions;
+  std::vector<uint16_t> attempts;
+
+  bindConfiguredPort(config,
+                     exclusions,
+                     PortKind::tcpAcceptor,
+                     [&](uint16_t port)
+                     {
+                       attempts.push_back(port);
+                       return port == 20001 ? asio::error_code {} : asio::error::address_in_use;
+                     });
+
+  ASSERT_FALSE(attempts.empty());
+  EXPECT_EQ(attempts.back(), 20001);
+  EXPECT_LE(attempts.size(), 3U);
+  for (const auto port: attempts)
+  {
+    EXPECT_GE(port, 20000);
+    EXPECT_LE(port, 20002);
+  }
+}
+
+/// @test
+/// Checks that probe fails when every candidate port is unavailabe
+/// @requirements(SEN-909)
+TEST(PortBinding, FailsProbeRange)
+{
+  const TcpPortReservation reservedPort;
+  const auto config =
+    makeConfigurationWithPort(PortKind::tcpAcceptor, ProbePortRange {reservedPort.port(), reservedPort.port()});
+  PortExclusionSources exclusions;
+  asio::io_context io;
+  asio::ip::tcp::acceptor acceptor(io);
+  std::vector<uint16_t> attempts;
+
+  EXPECT_THROW(bindConfiguredPort(config,
+                                  exclusions,
+                                  PortKind::tcpAcceptor,
+                                  [&](uint16_t port)
+                                  {
+                                    attempts.push_back(port);
+                                    return bindTcpAcceptor(acceptor, port);
+                                  }),
+               std::exception);
+
+  ASSERT_EQ(attempts.size(), 1U);
+  EXPECT_EQ(attempts.front(), reservedPort.port());
+}
+
+/// @test
+/// Checks that probe diagnostics explain excluded ranges
+/// @requirements(SEN-909)
+TEST(PortBinding, ReportsExcludedProbeRange)
+{
+  const auto config = makeConfigurationWithPort(PortKind::tcpAcceptor, ProbePortRange {20000, 20002});
+  PortExclusionSources exclusions;
+  exclusions.configured.add(20000, 20001);
+  exclusions.os.add(20002, 20002);
+  bool bindCalled = false;
+  std::string message;
+
+  try
+  {
+    bindConfiguredPort(config,
+                       exclusions,
+                       PortKind::tcpAcceptor,
+                       [&](uint16_t port)
+                       {
+                         std::ignore = port;
+                         bindCalled = true;
+                         return asio::error_code {};
+                       });
+    FAIL() << "Expected probe range binding to fail";
+  }
+  catch (const std::exception& error)
+  {
+    message = error.what();
+  }
+
+  EXPECT_FALSE(bindCalled);
+  EXPECT_NE(message.find("TCP acceptor"), std::string::npos);
+  EXPECT_NE(message.find("20000-20002"), std::string::npos);
+  EXPECT_NE(message.find("all ports are excluded"), std::string::npos);
+  EXPECT_NE(message.find("excluded ports: 3"), std::string::npos);
+  EXPECT_NE(message.find("configured: 20000-20001"), std::string::npos);
+  EXPECT_NE(message.find("OS: 20002"), std::string::npos);
+  EXPECT_NE(message.find("bind attempts: 0"), std::string::npos);
+}
+
+/// @test
+/// Checks that probe diagnostics explain exhausted bind attempts
+/// @requirements(SEN-909)
+TEST(PortBinding, ReportsUnavailableProbeRange)
+{
+  const auto config = makeConfigurationWithPort(PortKind::tcpAcceptor, ProbePortRange {20000, 20002});
+  PortExclusionSources exclusions;
+  exclusions.configured.add(20000, 20000);
+  std::vector<uint16_t> attempts;
+  std::string message;
+
+  try
+  {
+    bindConfiguredPort(config,
+                       exclusions,
+                       PortKind::tcpAcceptor,
+                       [&](uint16_t port)
+                       {
+                         attempts.push_back(port);
+                         return asio::error::address_in_use;
+                       });
+    FAIL() << "Expected probe range binding to fail";
+  }
+  catch (const std::exception& error)
+  {
+    message = error.what();
+  }
+
+  ASSERT_EQ(attempts.size(), 2U);
+  EXPECT_NE(message.find("TCP acceptor"), std::string::npos);
+  EXPECT_NE(message.find("20000-20002"), std::string::npos);
+  EXPECT_NE(message.find("no port was available"), std::string::npos);
+  EXPECT_NE(message.find("bind attempts: 2"), std::string::npos);
+  EXPECT_NE(message.find("excluded ports: 1"), std::string::npos);
+  EXPECT_NE(message.find("configured: 20000"), std::string::npos);
+  EXPECT_NE(message.find("last attempted port: " + std::to_string(attempts.back())), std::string::npos);
+  EXPECT_NE(message.find("last error:"), std::string::npos);
+}
+
+/// @test
+/// Checks that an invalid probe range fails before binding
+/// @requirements(SEN-909)
+TEST(PortBinding, RejectsInvalidProbeRange)
+{
+  const auto config = makeConfigurationWithPort(PortKind::tcpSource, ProbePortRange {20002, 20000});
+  PortExclusionSources exclusions;
+  asio::io_context io;
+  asio::ip::tcp::socket socket(io);
+  bool bindCalled = false;
+
+  EXPECT_THROW(bindConfiguredPort(config,
+                                  exclusions,
+                                  PortKind::tcpSource,
+                                  [&](uint16_t port)
+                                  {
+                                    bindCalled = true;
+                                    return bindTcpSocket(socket, port);
+                                  }),
+               std::invalid_argument);
+
+  EXPECT_FALSE(bindCalled);
+}
+
+/// @test
+/// Checks that probe stops on errors that are not caused by an occupied port
+/// @requirements(SEN-909)
+TEST(PortBinding, StopsProbeOnError)
+{
+  const auto config = makeConfigurationWithPort(PortKind::udpUnicast, ProbePortRange {20000, 20000});
+  PortExclusionSources exclusions;
+  std::vector<uint16_t> attempts;
+
+  EXPECT_THROW(bindConfiguredPort(config,
+                                  exclusions,
+                                  PortKind::udpUnicast,
+                                  [&](uint16_t port)
+                                  {
+                                    attempts.push_back(port);
+                                    return asio::error::operation_not_supported;
+                                  }),
+               std::exception);
+
+  ASSERT_EQ(attempts.size(), 1U);
+  EXPECT_EQ(attempts.front(), 20000);
 }
 
 }  // namespace sen::components::ether

--- a/docs/components/ether.md
+++ b/docs/components/ether.md
@@ -86,7 +86,10 @@ Each entry accepts the same port binding modes:
 
 - `Ephemeral`: let the operating system select the port. This is the default.
 - `PinnedPort`: use one exact port.
+- `ProbePortRange`: try ports inside a configured range until one can be bound.
 
+When ProbePortRange is enabled, Sen starts from a random point in the range and scans forward with
+wrap-around and bind the first available port. It fails if no port in the range can be used.
 Pinned ports fail if the configured port cannot be used.
 This configuration is local to each process and does not need to match in other Sen applications.
 If `portConfig` is omitted, all process ports use `Ephemeral`.
@@ -102,9 +105,24 @@ load:
       udpUnicast:
         type: Ephemeral
       tcpSource:
-        type: PinnedPort
+        type: ProbePortRange
         value:
-          port: 22000
+          min: 21000
+          max: 25000
+```
+
+### Excluding process ports
+
+The `portExclusions` parameter declares port ranges that `PinnedPort` and `ProbePortRange` must not use.
+It does not affect to `Ephemeral`, where Sen asks the operating system to choose the port.
+Sen also avoids well-known ports (0-1023) and operating system ranges reported as dynamic/ephemeral.
+
+```yaml
+load:
+  - name: ether
+    portExclusions:
+      - min: 10000
+        max: 20000
 ```
 
 ## Controlling Multicast


### PR DESCRIPTION
Adds support for the ProbePortRange port binding mode in the ether component.

With this mode, users can configure an inclusive port range. It starts probing from a random point within the range and bind to the first available port.

Resolves SEN-1723
