### PR TITLE
fix(kernel): create one proxy per object ID in local participants

### DIFF
--- a/libs/core/src/obj/remote_object.cpp
+++ b/libs/core/src/obj/remote_object.cpp
@@ -264,7 +264,7 @@ bool RemoteObject::responseReceived(MethodResponseData& response)
   PendingResponseContainerType::node_type pendingResponseHandle;
   {  // try to find a matching handle
     MutexLock pendingResponsesLock(pendingResponsesMutex_);
-    auto itr = pendingResponses_.find(response.callId);
+    const auto itr = pendingResponses_.find(response.callId);
     if (itr == pendingResponses_.end())
     {
       return false;

--- a/libs/kernel/src/bus/local_participant.cpp
+++ b/libs/kernel/src/bus/local_participant.cpp
@@ -57,6 +57,14 @@ using sen::util::makeLockedRange;
 namespace sen::kernel::impl
 {
 
+namespace
+{
+
+/// Number of drains between expired proxy cleanups
+constexpr std::size_t proxyCleanupPeriod = 64U;
+
+}  // namespace
+
 LocalParticipant::LocalParticipant(ObjectOwnerId id,
                                    const BusAddress& busAddress,
                                    std::shared_ptr<impl::Session> session,
@@ -175,6 +183,43 @@ void LocalParticipant::removeSingleObject(Object* instance)
   localObjectNames_.erase(instance->getLocalName());
 }
 
+std::shared_ptr<sen::impl::ProxyObject> LocalParticipant::lookUpProxyByObjectId(ObjectId id) const
+{
+  if (const auto itr = objectIdToProxy_.find(id); itr != objectIdToProxy_.end())
+  {
+    if (auto proxy = itr->second.lock())
+    {
+      return proxy;
+    }
+
+    objectIdToProxy_.erase(itr);
+  }
+
+  return nullptr;
+}
+
+void LocalParticipant::registerProxy(const ObjectId id, std::shared_ptr<sen::impl::ProxyObject> proxy)
+{
+  if (proxy)
+  {
+    objectIdToProxy_.insert_or_assign(id, std::move(proxy));
+  }
+}
+
+void LocalParticipant::cleanupExpiredProxies()
+{
+  for (auto itr = objectIdToProxy_.begin(); itr != objectIdToProxy_.end();)
+  {
+    if (itr->second.expired())
+    {
+      itr = objectIdToProxy_.erase(itr);
+      continue;
+    }
+
+    ++itr;
+  }
+}
+
 bool LocalParticipant::handleRejectedPublications(const PublicationRejection& rejections, RemoteParticipant* whom)
 {
 
@@ -275,6 +320,13 @@ void LocalParticipant::drainInputs()
     }
 
     proxyManager->notifyChangesToLocalListeners();
+  }
+
+  // Avoid scanning the cache on every drain, lookups also remove expired entries
+  if (++drainsSinceProxyCleanup_ >= proxyCleanupPeriod)
+  {
+    cleanupExpiredProxies();
+    drainsSinceProxyCleanup_ = 0U;
   }
 }
 

--- a/libs/kernel/src/bus/local_participant.h
+++ b/libs/kernel/src/bus/local_participant.h
@@ -23,18 +23,22 @@
 #include "sen/core/base/class_helpers.h"
 #include "sen/core/base/span.h"
 #include "sen/core/obj/detail/native_object_impl.h"
+#include "sen/core/obj/detail/proxy_object.h"
 #include "sen/core/obj/interest.h"
 #include "sen/core/obj/native_object.h"
+#include "sen/core/obj/object.h"
 #include "sen/core/obj/object_filter.h"
 #include "sen/core/obj/object_provider.h"
 #include "sen/core/obj/object_source.h"
 #include "sen/kernel/transport.h"
 
 // std
+#include <cstddef>
 #include <list>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <unordered_map>
 #include <vector>
 
 // spdlog
@@ -133,6 +137,19 @@ private:
   void flushLocalObjectsState(const std::list<::sen::impl::SerializableEvent>& events);
   void removeSingleObject(Object* instance);
 
+private:  // to be accessed from the ProxyManager to check the cache before constructing a proxy
+  friend class ProxyManager;
+
+  /// Looks up a cached proxy by its ID, returning an active shared_ptr or nullptr if expired. Expired entries are
+  /// removed lazily when encountered.
+  [[nodiscard]] std::shared_ptr<sen::impl::ProxyObject> lookUpProxyByObjectId(ObjectId id) const;
+
+  /// Registers an active proxy into the cache, storing it internally as a non-owning weak_ptr.
+  void registerProxy(ObjectId id, std::shared_ptr<sen::impl::ProxyObject> proxy);
+
+  /// Removes expired entries from the proxy cache. This is called periodically during drain.
+  void cleanupExpiredProxies();
+
 private:
   impl::Runner* owner_;
   std::shared_ptr<Session> session_;
@@ -144,6 +161,9 @@ private:
   ::sen::impl::WorkQueue& workQueue_;
   std::shared_mutex interestsOnOthersMutex_;
   std::vector<std::shared_ptr<ProxyManager>> interestsOnOthers_;
+  // Mutable because lookup also removes an expired entry, while remaining logically a cache lookup.
+  mutable std::unordered_map<ObjectId, std::weak_ptr<sen::impl::ProxyObject>> objectIdToProxy_;
+  std::size_t drainsSinceProxyCleanup_ {0U};
   std::mutex participantsMutex_;
   std::vector<Participant*> participants_;
   std::string objectsNamePrefix_;

--- a/libs/kernel/src/bus/proxy_manager.cpp
+++ b/libs/kernel/src/bus/proxy_manager.cpp
@@ -15,6 +15,7 @@
 #include "sen/core/obj/detail/proxy_object.h"
 #include "sen/core/obj/detail/work_queue.h"
 #include "sen/core/obj/interest.h"
+#include "sen/core/obj/object.h"
 #include "sen/core/obj/object_provider.h"
 
 // std
@@ -92,10 +93,18 @@ ProxyManager::~ProxyManager()
   additionsToDelete_.clear();
 }
 
-std::shared_ptr<::sen::impl::ProxyObject> ProxyManager::createProxy(const ObjectAddition& discovery)
+std::shared_ptr<::sen::impl::ProxyObject> ProxyManager::getOrCreateProxy(const ObjectId id,
+                                                                         const ObjectAddition& discovery) const
 {
+  if (auto existing = owner_.lookUpProxyByObjectId(id))
+  {
+    return existing;
+  }
+
   ProxyMaker maker(&workQueue_, proxiesPrefix_, owner_.getId());
-  return std::visit(maker, discovery);
+  auto proxy = std::visit(maker, discovery);
+  owner_.registerProxy(id, proxy);
+  return proxy;
 }
 
 void ProxyManager::notifyChangesToLocalListeners()
@@ -128,7 +137,7 @@ void ProxyManager::processPendingActions()
   recentlyDeletedObjects_.clear();
   recentlyDeletedObjects_.reserve(actions.size());
 
-  auto count = pendingActions_.try_dequeue_bulk(actions.begin(), actions.size());
+  const auto count = pendingActions_.try_dequeue_bulk(actions.begin(), actions.size());
 
   for (std::size_t i = 0U; i < count; ++i)
   {
@@ -136,13 +145,11 @@ void ProxyManager::processPendingActions()
       Overloaded {
         [this](const ObjectAddition& addition)
         {
-          const auto id = getObjectId(addition);
-
           // do not add repeated objects
-          if (presentProxiesList_.find(id) == presentProxiesList_.end())
+          if (const auto id = getObjectId(addition); presentProxiesList_.find(id) == presentProxiesList_.end())
           {
             // create and store the proxy
-            if (const auto proxy = createProxy(addition); proxy != nullptr)
+            if (auto proxy = getOrCreateProxy(id, addition); proxy != nullptr)
             {
               auto [proxyItr, done] = presentProxiesList_.try_emplace(id, std::move(proxy));
 
@@ -163,19 +170,11 @@ void ProxyManager::processPendingActions()
         [this](const ObjectRemoval& removal)
         {
           // try to find a proxy, and remove it if present
-          if (auto listItr = presentProxiesList_.find(removal.objectid); listItr != presentProxiesList_.end())
-          {
-            if (auto* remoteProxy = listItr->second->asRemoteObject(); remoteProxy != nullptr)
-            {
-              remoteProxy->invalidateTransport();
-            }
-
-            presentProxiesList_.erase(listItr);
-          }
+          presentProxiesList_.erase(removal.objectid);
 
           // remove it from presentObjects_
-          auto presentObjectsItr = presentObjects_.find(removal.objectid);
-          if (presentObjectsItr != presentObjects_.end())
+          if (const auto presentObjectsItr = presentObjects_.find(removal.objectid);
+              presentObjectsItr != presentObjects_.end())
           {
             additionsToDelete_.insert(*presentObjectsItr);
             presentObjects_.erase(presentObjectsItr);

--- a/libs/kernel/src/bus/proxy_manager.h
+++ b/libs/kernel/src/bus/proxy_manager.h
@@ -12,6 +12,8 @@
 
 // sen
 #include "sen/core/obj/detail/native_object_proxy.h"
+#include "sen/core/obj/detail/proxy_object.h"
+#include "sen/core/obj/object.h"
 #include "sen/core/obj/object_filter.h"
 #include "sen/core/obj/object_provider.h"
 
@@ -19,6 +21,7 @@
 #include "moodycamel/concurrentqueue.h"
 
 // std
+#include <memory>
 #include <mutex>
 
 namespace sen::kernel::impl
@@ -71,7 +74,8 @@ protected:  // implements ObjectProviderListener
   void onObjectsRemoved(const ObjectRemovalList& removals) override;
 
 private:
-  [[nodiscard]] std::shared_ptr<::sen::impl::ProxyObject> createProxy(const ObjectAddition& discovery);
+  [[nodiscard]] std::shared_ptr<::sen::impl::ProxyObject> getOrCreateProxy(ObjectId id,
+                                                                           const ObjectAddition& discovery) const;
   void processPendingActions();
 
 private:

--- a/libs/kernel/src/bus/remote_participant.cpp
+++ b/libs/kernel/src/bus/remote_participant.cpp
@@ -840,9 +840,12 @@ void RemoteParticipant::rcvObjectUpdate(const ObjectUpdateMessage& message)
 
   if (auto mapItr = trackedProxies_.find(message.objectId); mapItr != trackedProxies_.end())
   {
-    for (auto& elem: *mapItr->second)
+    for (const auto& elem: *mapItr->second)
     {
-      elem->propertyUpdatesReceived(message.buffer, message.time);
+      if (const auto elemPtr = elem.lock())
+      {
+        elemPtr->propertyUpdatesReceived(message.buffer, message.time);
+      }
     }
   }
 }
@@ -993,22 +996,20 @@ void RemoteParticipant::rcvMethodResponse(InputStream& in)
   }
 
   // send the response to the proxy that issued the call
-  RemoteObjectListPtr remotes;
   {
     Lock lock(usageMutex_);
-    auto mapItr = trackedProxies_.find(objectId);
+    const auto mapItr = trackedProxies_.find(objectId);
     if (mapItr == trackedProxies_.end())
     {
       return;
     }
-    remotes = mapItr->second;
-  }
 
-  for (auto& elem: *remotes)
-  {
-    if (elem->responseReceived(responseData))
+    for (const auto& remote: *mapItr->second)
     {
-      break;
+      if (const auto remotePtr = remote.lock(); remotePtr && remotePtr->responseReceived(responseData))
+      {
+        break;
+      }
     }
   }
 }
@@ -1034,9 +1035,12 @@ void RemoteParticipant::rcvEvents(InputStream& in)
     }
 
     // make all the proxies emit the event out of the received buffer
-    for (auto& proxyPtr: *remotes)
+    for (const auto& elem: *remotes)
     {
-      proxyPtr->eventReceived(eventData.eventId, eventData.creationTime, eventData.argumentsBuffer);
+      if (const auto proxyPtr = elem.lock())
+      {
+        proxyPtr->eventReceived(eventData.eventId, eventData.creationTime, eventData.argumentsBuffer);
+      }
     }
   }
 }
@@ -1168,13 +1172,9 @@ void RemoteParticipant::remoteObjectsRemoved(const ObjectsRemoved& msg)
 
     for (const auto elem: interestObjectsRemoval.ids)
     {
-      auto objectId = ObjectId(elem);
-
-      stopTrackingProxy(objectId);
-
       ObjectRemoval removal;
       removal.interestId = interestId;
-      removal.objectid = objectId;
+      removal.objectid = ObjectId(elem);
       removals.push_back(removal);
     }
 
@@ -1887,10 +1887,12 @@ RemoteObjectDiscovery RemoteParticipant::makeRemoteObjectDiscoveryFromProxy(Obje
 {
   if (const auto it = trackedProxies_.find(objectId); it != trackedProxies_.end())
   {
-    auto proxy = it->second->front();
-    auto proxyMaker = createProxyMaker(proxy->getName(), proxy->getId(), proxy->getClass(), proxy->getWriterSchema());
-
-    return {objectId, proxy->getName(), proxy->getClass(), std::move(proxyMaker), interestId, ownerAddress_.id};
+    if (const auto proxyPtr = it->second->front().lock())
+    {
+      auto proxyMaker =
+        createProxyMaker(proxyPtr->getName(), proxyPtr->getId(), proxyPtr->getClass(), proxyPtr->getWriterSchema());
+      return {objectId, proxyPtr->getName(), proxyPtr->getClass(), std::move(proxyMaker), interestId, ownerAddress_.id};
+    }
   }
 
   std::string err = "Could not make remote object discovery (interest ID: ";
@@ -1912,10 +1914,10 @@ std::shared_ptr<::sen::impl::RemoteObject> RemoteParticipant::startTrackingProxy
                                                        : std::make_shared<GenericRemoteObject>(std::move(info));
 
   RemoteObjectListPtr remotes;
-  if (auto mapItr = trackedProxies_.find(proxy->getId()); mapItr == trackedProxies_.end())
+  if (const auto mapItr = trackedProxies_.find(proxy->getId()); mapItr == trackedProxies_.end())
   {
     auto [itr, done] = trackedProxies_.try_emplace(
-      proxy->getId(), std::make_shared<std::vector<std::shared_ptr<::sen::impl::RemoteObject>>>());
+      proxy->getId(), std::make_shared<std::vector<std::weak_ptr<::sen::impl::RemoteObject>>>());
 
     remotes = itr->second;
   }
@@ -1928,7 +1930,10 @@ std::shared_ptr<::sen::impl::RemoteObject> RemoteParticipant::startTrackingProxy
   // otherwise, we take it from what we have received so far
   if (!remotes->empty())
   {
-    proxy->copyStateFrom(*remotes->front());
+    if (const auto otherProxy = remotes->front().lock())
+    {
+      proxy->copyStateFrom(*otherProxy);
+    }
     monitoredObjects_.stopMonitoring(proxy->getId(), session_->getTransport());
   }
   else
@@ -1958,9 +1963,12 @@ void RemoteParticipant::stopTrackingProxy(ObjectId objectId)
   }
 
   // stop the proxy from calling us, since we will no longer exist
-  for (auto& proxy: *remotes)
+  for (const auto& proxy: *remotes)
   {
-    proxy->clearDestructionCallback();
+    if (const auto proxyPtr = proxy.lock())
+    {
+      proxyPtr->clearDestructionCallback();
+    }
   }
 
   {
@@ -1974,10 +1982,10 @@ void RemoteParticipant::proxyAboutToBeDeleted(::sen::impl::RemoteObject* proxy)
 {
   const auto id = proxy->getId();
 
+  Lock lock(usageMutex_);
   RemoteObjectListPtr remotes;
   {
-    Lock lock(usageMutex_);
-    auto mapItr = trackedProxies_.find(id);
+    const auto mapItr = trackedProxies_.find(id);
     if (mapItr == trackedProxies_.end())
     {
       // stop monitoring the object in case the proxy has not been tracked yet
@@ -1987,23 +1995,16 @@ void RemoteParticipant::proxyAboutToBeDeleted(::sen::impl::RemoteObject* proxy)
     remotes = mapItr->second;
   }
 
-  if (auto listItr =
-        std::find_if(remotes->begin(), remotes->end(), [proxy](auto& elem) { return elem.get() == proxy; });
-      listItr != remotes->end())
-  {
-    remotes->erase(listItr);
-  }
+  // the proxy weak ptr that has expired is the one that is being deleted
+  remotes->erase(std::remove_if(remotes->begin(), remotes->end(), [](const auto& elem) { return elem.expired(); }),
+                 remotes->end());
 
   if (remotes->empty())
   {
-    Lock lock(usageMutex_);
     trackedProxies_.erase(id);
   }
 
-  {
-    Lock lock(usageMutex_);
-    monitoredObjects_.stopMonitoring(id, session_->getTransport());
-  }
+  monitoredObjects_.stopMonitoring(id, session_->getTransport());
 }
 
 //--------------------------------------------------------------------------------------------------------------

--- a/libs/kernel/src/bus/remote_participant.h
+++ b/libs/kernel/src/bus/remote_participant.h
@@ -323,7 +323,7 @@ private:
   using Lock = std::scoped_lock<std::recursive_mutex>;
   static constexpr std::size_t smallBufferSize = 64U;
   using SmallPool = FixedMemoryBlockPool<smallBufferSize>;
-  using RemoteObjectListPtr = std::shared_ptr<std::vector<std::shared_ptr<::sen::impl::RemoteObject>>>;
+  using RemoteObjectListPtr = std::shared_ptr<std::vector<std::weak_ptr<::sen::impl::RemoteObject>>>;
   using InterestIdToObjectAdditionsMap = std::unordered_map<InterestId, ObjectAddedList>;
   using ParticipantIdToPendingAdditionsMap = std::unordered_map<ObjectOwnerId, InterestIdToObjectAdditionsMap>;
   using TypeHashToPendingParticipantsAdditionsMap = std::unordered_map<MemberHash, ParticipantIdToPendingAdditionsMap>;

--- a/libs/kernel/test/CMakeLists.txt
+++ b/libs/kernel/test/CMakeLists.txt
@@ -28,8 +28,6 @@ if(NOT MSVC)
     # so neither can be registered when the build leaves it out.
     if(SEN_INTEGRATION_TEST_IMAGE AND SEN_BUILD_ETHER)
       add_subdirectory(integration/object_sync)
-    endif()
-    if(SEN_BUILD_ETHER)
       add_subdirectory(integration/interest_filtering)
     endif()
     #   add_subdirectory(integration/stress_tests/high_churn_subs)

--- a/libs/kernel/test/integration/interest_filtering/CMakeLists.txt
+++ b/libs/kernel/test/integration/interest_filtering/CMakeLists.txt
@@ -13,21 +13,33 @@ add_sen_package(
   PRIVATE_DEPS spdlog::spdlog test_helpers
 )
 
-# TODO (SEN-1735): Enable once the proxies managed in the LocalParticipant have been deduplicated.
-## common environment for the interest filtering integration tests
-#find_package(Python REQUIRED COMPONENTS Interpreter)
-#set(_working_dir $<TARGET_FILE_DIR:sen::cli_run>)
-#
-## We check that the interest condition on a float property works properly in conjunction with an interest without conditions (selectAll) in the same and different components
-#add_sen_integration_test(
-#  interest_filtering_test_1
-#  COMMAND
-#  ${Python_EXECUTABLE}
-#  ${CMAKE_CURRENT_SOURCE_DIR}/../run.py
-#  ${_working_dir}
-#  ${CMAKE_CURRENT_SOURCE_DIR}/config/test_1_proc_1.yaml
-#  ${CMAKE_CURRENT_SOURCE_DIR}/config/test_1_proc_2.yaml
-#  ${CMAKE_CURRENT_SOURCE_DIR}/config/test_1_proc_3.yaml
-#  REQ_DEPS interest_filtering py ether kernel FLAKY USE_TESTCONTAINERS
-#)
-#
+# common environment for the interest filtering integration tests
+find_package(Python REQUIRED COMPONENTS Interpreter)
+set(_working_dir $<TARGET_FILE_DIR:sen::cli_run>)
+set(_script ${CMAKE_CURRENT_SOURCE_DIR}/../run.py)
+
+# We check that the interest condition on a float property works properly in conjunction with an interest without conditions (selectAll) in the same and different components
+add_sen_integration_test(
+  interest_filtering_float_query_filtering
+  COMMAND
+  ${Python_EXECUTABLE}
+  ${_script}
+  ${_working_dir}
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/float_query_filtering_1.yaml
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/float_query_filtering_2.yaml
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/float_query_filtering_3.yaml
+  REQ_DEPS interest_filtering py ether kernel FLAKY USE_TESTCONTAINERS
+)
+
+# Checks that, with multiple subscriptions attached to a single LocalParticipant. Only one proxy per object is created
+add_sen_integration_test(
+  interest_filtering_multi_subscription
+  COMMAND
+  ${Python_EXECUTABLE}
+  ${_script}
+  ${_working_dir}
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/multi_subscription_1.yaml
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/multi_subscription_2.yaml
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/multi_subscription_3.yaml
+  REQ_DEPS interest_filtering py ether kernel FLAKY USE_TESTCONTAINERS
+)

--- a/libs/kernel/test/integration/interest_filtering/config/float_query_filtering_1.yaml
+++ b/libs/kernel/test/integration/interest_filtering/config/float_query_filtering_1.yaml
@@ -1,0 +1,52 @@
+kernel:
+  crashReportDisabled: true
+  logConfig:
+    level: info
+
+load:
+  - name: ether
+    group: 10
+    runDiscoveryHub: 65454
+    discovery:
+      type: TcpDiscovery
+      value:
+        beamPeriod: 100 ms
+        beamExpiryTime: 1 s
+        hubAddress:
+          host: sen-hub
+          port: 65454
+
+build:
+  - name: terminatorComponent1
+    group: 3
+    freqHz: 50
+    imports: [test_helpers, interest_filtering]
+    objects:
+      - name: terminator1
+        class: sen.test.ProcessTerminatorImpl
+        bus: session.bus
+  - name: publisherComponent1
+    group: 3
+    freqHz: 50
+    imports: [test_helpers, interest_filtering]
+    objects:
+      - name: publisher1
+        class: interest_filtering.TestObjectPublisher
+        numOfListeners: 7
+        bus: session.bus
+  - name: listenerComponent1
+    group: 3
+    freqHz: 50
+    imports: [test_helpers, interest_filtering]
+    objects:
+      - name: listener1
+        class: interest_filtering.ListenerTestObjectAll
+        bus: session.bus
+  - name: listenerComponent2
+    group: 3
+    freqHz: 50
+    imports: [test_helpers, interest_filtering]
+    objects:
+      - name: listener2
+        class: interest_filtering.ListenerTestObjectQueryFloat
+        bus: session.bus

--- a/libs/kernel/test/integration/interest_filtering/config/float_query_filtering_2.yaml
+++ b/libs/kernel/test/integration/interest_filtering/config/float_query_filtering_2.yaml
@@ -1,5 +1,7 @@
 kernel:
   crashReportDisabled: true
+  logConfig:
+    level: info
 
 load:
   - name: ether
@@ -14,27 +16,30 @@ load:
           port: 65454
 
 build:
-  - name: terminatorComponent3
+  - name: terminatorComponent2
     group: 3
     freqHz: 50
     imports: [test_helpers, interest_filtering]
     objects:
-      - name: terminator3
-        class: interest_filtering.ProcessTerminatorImpl
+      - name: terminator2
+        class: sen.test.ProcessTerminatorImpl
         bus: session.bus
-  - name: listenerComponent5
+  - name: listenerComponent3
     group: 3
     freqHz: 50
     imports: [test_helpers, interest_filtering]
     objects:
-      - name: listener6
+      - name: listener3
         class: interest_filtering.ListenerTestObjectAll
         bus: session.bus
-  - name: listenerComponent6
+      - name: listener4
+        class: interest_filtering.ListenerTestObjectQueryFloat
+        bus: session.bus
+  - name: listenerComponent4
     group: 3
     freqHz: 50
     imports: [test_helpers, interest_filtering]
     objects:
-      - name: listener7
+      - name: listener5
         class: interest_filtering.ListenerTestObjectQueryFloat
         bus: session.bus

--- a/libs/kernel/test/integration/interest_filtering/config/float_query_filtering_3.yaml
+++ b/libs/kernel/test/integration/interest_filtering/config/float_query_filtering_3.yaml
@@ -1,0 +1,42 @@
+kernel:
+  crashReportDisabled: true
+  logConfig:
+    level: info
+
+load:
+  - name: ether
+    group: 10
+    discovery:
+      type: TcpDiscovery
+      value:
+        beamPeriod: 100 ms
+        beamExpiryTime: 1 s
+        hubAddress:
+          host: sen-hub
+          port: 65454
+
+build:
+  - name: terminatorComponent3
+    group: 3
+    freqHz: 50
+    imports: [test_helpers, interest_filtering]
+    objects:
+      - name: terminator3
+        class: sen.test.ProcessTerminatorImpl
+        bus: session.bus
+  - name: listenerComponent5
+    group: 3
+    freqHz: 50
+    imports: [test_helpers, interest_filtering]
+    objects:
+      - name: listener6
+        class: interest_filtering.ListenerTestObjectAll
+        bus: session.bus
+  - name: listenerComponent6
+    group: 3
+    freqHz: 50
+    imports: [test_helpers, interest_filtering]
+    objects:
+      - name: listener7
+        class: interest_filtering.ListenerTestObjectQueryFloat
+        bus: session.bus

--- a/libs/kernel/test/integration/interest_filtering/config/multi_subscription_1.yaml
+++ b/libs/kernel/test/integration/interest_filtering/config/multi_subscription_1.yaml
@@ -1,0 +1,50 @@
+kernel:
+  crashReportDisabled: true
+
+load:
+  - name: ether
+    group: 10
+    runDiscoveryHub: 65454
+    discovery:
+      type: TcpDiscovery
+      value:
+        beamPeriod: 100 ms
+        beamExpiryTime: 1 s
+        hubAddress:
+          host: sen-hub
+          port: 65454
+
+build:
+  - name: terminatorComponent1
+    group: 3
+    freqHz: 50
+    imports: [test_helpers, interest_filtering]
+    objects:
+      - name: terminator1
+        class: sen.test.ProcessTerminatorImpl
+        bus: session.bus
+  - name: publisherComponent1
+    group: 3
+    freqHz: 50
+    imports: [test_helpers, interest_filtering]
+    objects:
+      - name: publisher1
+        class: interest_filtering.TestObjectPublisher
+        numOfListeners: 7
+        bus: session.bus
+  - name: listenerComponent1
+    group: 3
+    freqHz: 50
+    imports: [test_helpers, interest_filtering]
+    objects:
+      - name: listener1
+        class: interest_filtering.MultipleSubscriptionListener
+        bus: session.bus
+  - name: listenerComponent2
+    group: 3
+    freqHz: 50
+    imports: [test_helpers, interest_filtering]
+    objects:
+      - name: listener2
+        class: interest_filtering.MultipleSubscriptionListener
+        bus: session.bus

--- a/libs/kernel/test/integration/interest_filtering/config/multi_subscription_2.yaml
+++ b/libs/kernel/test/integration/interest_filtering/config/multi_subscription_2.yaml
@@ -28,16 +28,11 @@ build:
     imports: [test_helpers, interest_filtering]
     objects:
       - name: listener3
-        class: interest_filtering.ListenerTestObjectAll
+        class: interest_filtering.MultipleSubscriptionListener
         bus: session.bus
       - name: listener4
-        class: interest_filtering.ListenerTestObjectQueryFloat
+        class: interest_filtering.MultipleSubscriptionListener
         bus: session.bus
-  - name: listenerComponent4
-    group: 3
-    freqHz: 50
-    imports: [test_helpers, interest_filtering]
-    objects:
       - name: listener5
-        class: interest_filtering.ListenerTestObjectAll
+        class: interest_filtering.MultipleSubscriptionListener
         bus: session.bus

--- a/libs/kernel/test/integration/interest_filtering/config/multi_subscription_3.yaml
+++ b/libs/kernel/test/integration/interest_filtering/config/multi_subscription_3.yaml
@@ -4,7 +4,6 @@ kernel:
 load:
   - name: ether
     group: 10
-    runDiscoveryHub: 65454
     discovery:
       type: TcpDiscovery
       value:
@@ -15,36 +14,27 @@ load:
           port: 65454
 
 build:
-  - name: terminatorComponent1
+  - name: terminatorComponent3
     group: 3
     freqHz: 50
     imports: [test_helpers, interest_filtering]
     objects:
-      - name: terminator1
+      - name: terminator3
         class: sen.test.ProcessTerminatorImpl
         bus: session.bus
-  - name: publisherComponent1
+  - name: listenerComponent4
     group: 3
     freqHz: 50
     imports: [test_helpers, interest_filtering]
     objects:
-      - name: publisher1
-        class: interest_filtering.TestObjectPublisher
-        numOfListeners: 7
+      - name: listener6
+        class: interest_filtering.MultipleSubscriptionListener
         bus: session.bus
-  - name: listenerComponent1
+  - name: listenerComponent5
     group: 3
     freqHz: 50
     imports: [test_helpers, interest_filtering]
     objects:
-      - name: listener1
-        class: interest_filtering.ListenerTestObjectAll
-        bus: session.bus
-  - name: listenerComponent2
-    group: 3
-    freqHz: 50
-    imports: [test_helpers, interest_filtering]
-    objects:
-      - name: listener2
-        class: interest_filtering.ListenerTestObjectQueryFloat
+      - name: listener7
+        class: interest_filtering.MultipleSubscriptionListener
         bus: session.bus

--- a/libs/kernel/test/integration/interest_filtering/src/interest_filtering.cpp
+++ b/libs/kernel/test/integration/interest_filtering/src/interest_filtering.cpp
@@ -24,6 +24,9 @@
 #include "sen/kernel/component_api.h"
 
 // std
+#include <algorithm>
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -31,6 +34,7 @@
 #include <string>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 namespace interest_filtering
 {
@@ -77,8 +81,10 @@ protected:
   void action1() override
   {
     bus_ = getApi()->getSource("session.bus");
-    object_ = std::make_shared<TestObjectImpl>("testObject");
+    object_ = std::make_shared<TestObjectImpl>(getName() + "_testObject");
     bus_->add(object_);
+
+    getLogger()->error("OBJECT ID {}", object_->getId().get());
 
     PublisherImpl::action1();
   }
@@ -96,6 +102,7 @@ private:
 
 SEN_EXPORT_CLASS(TestObjectPublisher)
 
+// Time gap big enough for the listeners to receive updates
 constexpr sen::Duration oneSecond {1E9};
 
 // This listener does the following:
@@ -108,100 +115,59 @@ public:
   using ListenerImpl::ListenerImpl;
 
 public:
+  void registered(sen::kernel::RegistrationApi& api) override
+  {
+    ListenerImpl::registered(api);
+
+    sub_ = getApi()->selectAllFrom<TestObjectInterface>(
+      "session.bus",
+      [this](const auto& addedObjects)
+      {
+        guards_.reserve(std::distance(addedObjects.begin(), addedObjects.end()));
+        for (auto* object: addedObjects)
+        {
+          guards_.emplace_back(object->onHeartbeatChanged({this,
+                                                           [this]()
+                                                           {
+                                                             if (++numOfHbUpdates_ == 10U)
+                                                             {
+                                                               SEN_ASSERT(sub_->list.getObjects().size() == 1);
+                                                               ListenerImpl::check1();
+                                                             }
+                                                           }}));
+        }
+      });
+  }
+
   void update(sen::kernel::RunApi& runApi) override
   {
     ListenerImpl::update(runApi);
+
     time_ = runApi.getTime();
 
-    // advance if 1 second passed since the startTime_ (without object deletions)
-    if (time_ - *startTime_ > oneSecond)
+    // wait for one second without removals before check2
+    if (check2Start_ && time_ - *check2Start_ > oneSecond)
     {
-      doAdvance_ = true;
+      SEN_ASSERT(sub_->list.getObjects().size() == 1);
+      check2Start_.reset();
+      ListenerImpl::check2();
     }
   }
 
 protected:
   void check1() override
   {
-    sub_ = getApi()->selectAllFrom<TestObjectInterface>(
-      "session.bus",
-      [this](const auto& addedObjects)
-      {
-        // check that only one object is detected
-        SEN_ASSERT(std::distance(addedObjects.begin(), addedObjects.end()) == 1U);
-        object_ = *addedObjects.begin();
-        doAdvance_ = true;
-        hbGuard_ =
-          object_->onHeartbeatChanged({this,
-                                       [this]()
-                                       {
-                                         // maybe advance state when the object is alive (check 10 updates)
-                                         if (doAdvance_)
-                                         {
-                                           if (getName() == "listener3")
-                                           {
-                                             getLogger()->info("checking {} alive.... {}", getName(), numOfHbUpdates_);
-                                           }
-                                           checkAliveAndAdvanceTest(10U);
-                                         }
-                                       }});
-      });
+    // no code needed here
   }
 
-  void check2() override
-  {
-    // wait 1 second to check that no object was deleted, then check that the object is still alive (checking 10
-    // updates)
-    if (!startTime_)
-    {
-      startTime_ = time_;
-    }
-
-    // if a deletion is detected, fail the test
-    std::ignore = sub_->list.onRemoved(
-      [this](const auto& deletedObjects)
-      {
-        std::ignore = deletedObjects;
-        getLogger()->info("listener all received deletion");
-        SEN_ASSERT(false);
-      });
-  }
+  void check2() override { check2Start_ = time_; }
 
 private:
-  void checkAliveAndAdvanceTest(const uint32_t numberOfUpdatesToCheck)
-  {
-    if (++numOfHbUpdates_ == numberOfUpdatesToCheck)
-    {
-      if (const auto currentState = getState(); currentState == sen::test::ConnectionState::step1)
-      {
-        if (getName() == "listener3")
-        {
-          getLogger()->info("{} -> check1", getName());
-        }
-        ListenerImpl::check1();
-      }
-      else if (currentState == sen::test::ConnectionState::step2)
-      {
-        if (getName() == "listener3")
-        {
-          getLogger()->info("{} -> check2", getName());
-        }
-        ListenerImpl::check2();
-      }
-
-      numOfHbUpdates_ = 0;
-      doAdvance_ = false;
-    }
-  }
-
-private:
-  TestObjectInterface* object_;
   std::shared_ptr<sen::Subscription<TestObjectInterface>> sub_;
-  sen::ConnectionGuard hbGuard_;
-  uint32_t numOfHbUpdates_;
-  bool doAdvance_ = false;
+  uint32_t numOfHbUpdates_ = 0U;
   sen::TimeStamp time_;
-  std::optional<sen::TimeStamp> startTime_;
+  std::optional<sen::TimeStamp> check2Start_;
+  std::vector<sen::ConnectionGuard> guards_;
 };
 
 SEN_EXPORT_CLASS(ListenerTestObjectAll)
@@ -216,44 +182,37 @@ public:
   using ListenerImpl::ListenerImpl;
 
 public:
-  void update(sen::kernel::RunApi& runApi) override
+  void registered(sen::kernel::RegistrationApi& api) override
   {
-    ListenerImpl::update(runApi);
-    time_ = runApi.getTime();
+    ListenerImpl::registered(api);
 
-    // advance if 1 second passed since the startTime_ (without object deletions)
-    if (time_ - *startTime_ > oneSecond)
-    {
-      doAdvance_ = true;
-    }
-  }
-
-protected:
-  void check1() override
-  {
-    bus_ = getApi()->getSource("session.bus");
+    bus_ = api.getSource("session.bus");
 
     std::ignore = testObjectList_.onAdded(
       [this](const auto& addedObjects)
       {
-        // check that only one object is detected
-        SEN_ASSERT(std::distance(addedObjects.begin(), addedObjects.end()) == 1U);
-        object_ = *addedObjects.begin();
-        doAdvance_ = true;
-        hbGuard_ = object_->onHeartbeatChanged({this,
-                                                [this]()
-                                                {
-                                                  // maybe advance state when the object is alive (check 10 updates)
-                                                  if (doAdvance_)
-                                                  {
-                                                    getLogger()->info("receiving updates....");
-                                                    if (++numOfHbUpdates_ == 5U)
-                                                    {
-                                                      ListenerImpl::check1();
-                                                      doAdvance_ = false;
-                                                    }
-                                                  }
-                                                }});
+        guards_.reserve(std::distance(addedObjects.begin(), addedObjects.end()));
+        for (auto* object: addedObjects)
+        {
+          guards_.emplace_back(object->onHeartbeatChanged({this,
+                                                           [this]()
+                                                           {
+                                                             if (++numOfHbUpdates_ == 10U)
+                                                             {
+                                                               SEN_ASSERT(testObjectList_.getObjects().size() == 1);
+                                                               ListenerImpl::check1();
+                                                             }
+                                                           }}));
+        }
+      });
+
+    std::ignore = testObjectList_.onRemoved(
+      [this](const auto& deletedObjects)
+      {
+        getLogger()->error("{} RECEIVED DELETION", getName());
+        SEN_ASSERT(std::distance(deletedObjects.begin(), deletedObjects.end()) == 1U);
+        SEN_ASSERT(testObjectList_.getObjects().empty());
+        ListenerImpl::check2();
       });
 
     bus_->addSubscriber(
@@ -263,30 +222,125 @@ protected:
       true);
   }
 
+  void update(sen::kernel::RunApi& runApi) override
+  {
+    ListenerImpl::update(runApi);
+
+    time_ = runApi.getTime();
+  }
+
+protected:
+  void check1() override
+  {
+    // no code needed
+  }
+
   void check2() override
   {
-    // if a deletion is detected, fail the test
-    std::ignore = testObjectList_.onRemoved(
-      [this](const auto& deletedObjects)
-      {
-        getLogger()->info("{} removed", getName());
-        // test that the object is deleted after the changes
-        SEN_ASSERT(object_->asObject().getId() == (*deletedObjects.begin())->asObject().getId());
-        ListenerImpl::check2();
-      });
+    // no code needed
   }
 
 private:
   std::shared_ptr<sen::ObjectSource> bus_;
   sen::ObjectList<TestObjectInterface> testObjectList_;
-  TestObjectInterface* object_;
-  sen::ConnectionGuard hbGuard_;
-  uint32_t numOfHbUpdates_;
-  bool doAdvance_ = false;
+  uint32_t numOfHbUpdates_ = 0U;
   sen::TimeStamp time_;
-  std::optional<sen::TimeStamp> startTime_;
+  std::vector<sen::ConnectionGuard> guards_;
 };
 
 SEN_EXPORT_CLASS(ListenerTestObjectQueryFloat)
+
+// This listener does the following:
+// - check1: detects the test object with 5 different subscriptions with different interests each. All interests
+// should find the object. Checks that the proxy pointed to by all interests is unique.
+// - check2: after object properties change. Checks that only one of the subscriptions find the object.
+class MultipleSubscriptionListener final: public sen::test::ListenerImpl
+{
+public:
+  using ListenerImpl::ListenerImpl;
+
+public:
+  void update(sen::kernel::RunApi& runApi) override
+  {
+    ListenerImpl::update(runApi);
+
+    const auto nullProxies = getNullProxies();
+
+    // perform check1 once the object has been detected in all 5 subscriptions
+    if (getState() == sen::test::ConnectionState::step1 && nullProxies.empty())
+    {
+      // check that all subscriptions point to the same object
+      SEN_ASSERT(
+        std::all_of(objects_.begin(), objects_.end(), [first = objects_[0]](const auto& obj) { return obj == first; }));
+
+      ListenerImpl::check1();
+    }
+
+    // check2 once the only subscription that detects the object is the first query (no where condition)
+    if (getState() == sen::test::ConnectionState::step2 && nullProxies.size() == 4 &&
+        std::find(nullProxies.begin(), nullProxies.end(), 0) == nullProxies.end())
+    {
+      ListenerImpl::check2();
+    }
+  }
+
+protected:
+  void check1() override
+  {
+    bus_ = getApi()->getSource("session.bus");
+
+    for (size_t i = 0U; i < lists_.size(); ++i)
+    {
+      std::ignore = lists_.at(i).onAdded([&obj = objects_.at(i)](const auto& iterators) { obj = *iterators.begin(); });
+
+      std::ignore = lists_.at(i).onRemoved(
+        [&obj = objects_.at(i)](const auto& iterators)
+        {
+          if (obj == *iterators.begin())
+          {
+            obj = nullptr;
+          }
+        });
+
+      bus_->addSubscriber(sen::Interest::make(queries.at(i), getApi()->getTypes()), &lists_.at(i), true);
+    }
+  }
+
+  void check2() override
+  {
+    // disable automatic step 2
+  }
+
+private:
+  /// Returns the indexes of the TestObjectInterface pointers received in the subscriptions that are nullptr (the
+  /// object is not currently among the detections for that subscription)
+  std::vector<size_t> getNullProxies() const
+  {
+    std::vector<size_t> indexes;
+    indexes.reserve(objects_.size());
+    for (size_t i = 0U; i < objects_.size(); ++i)
+    {
+      if (objects_.at(i) == nullptr)
+      {
+        indexes.push_back(i);
+      }
+    }
+    return indexes;
+  }
+
+private:
+  static constexpr std::array<std::string_view, 5U> queries {
+    "SELECT interest_filtering.TestObject FROM session.bus",
+    "SELECT interest_filtering.TestObject FROM session.bus WHERE floatProp < 10.0",
+    "SELECT interest_filtering.TestObject FROM session.bus WHERE boolProp = false",
+    R"(SELECT interest_filtering.TestObject FROM session.bus WHERE enumProp IN ("first", "second"))",
+    "SELECT interest_filtering.TestObject FROM session.bus WHERE structProp.member2 = 0"};
+
+  std::shared_ptr<sen::ObjectSource> bus_;
+  std::array<sen::ObjectList<TestObjectInterface>, 5U> lists_;
+  std::array<TestObjectInterface*, 5U> objects_ {};
+};
+
+SEN_EXPORT_CLASS(MultipleSubscriptionListener)
 
 }  // namespace interest_filtering


### PR DESCRIPTION
Resolves SEN-1735.

### Issue
In Sen's bus subsystem, when a consuming component has **two or more Interests that both match the same Object**, the code creates **multiple independent proxy instances** for that single underlying Object, all owned by the same consumer component.

The design invariant is: **at most one proxy per `(Object, consuming-component)`**. When a consuming component has multiple overlapping subscriptions matching the same source Object, they should share a single proxy instance.

### Fix
Add a **`LocalParticipant`-level proxy cache** that allows multiple `ProxyManager`s to share the same proxy instance for the same `(Object, consuming-component)`.
`LocalParticipant::lookupProxyByObjectId(id)` upgrades the `weak_ptr`; returns nullptr if expired (proxy was destroyed and no one else held it).

`LocalParticipant::registerProxy(id, proxy)` inserts into the cache.

When a proxy is destroyed (last refcount drop), the cache entry's `weak_ptr` expires naturally. No proactive cleanup needed beyond `try_emplace` semantics overwriting expired entries on next registration. Alternatively, a small cleanup pass during drain can compact expired entries.
