### PR TITLE
feat(ether): add collision and probability check

### DIFF
--- a/components/ether/src/bus_handler.cpp
+++ b/components/ether/src/bus_handler.cpp
@@ -15,9 +15,11 @@
 
 // sen
 #include "sen/core/base/assert.h"
+#include "sen/core/base/checked_conversions.h"
 #include "sen/core/base/compiler_macros.h"
 #include "sen/core/base/hash32.h"
 #include "sen/core/base/memory_block.h"
+#include "sen/core/base/result.h"
 #include "sen/core/base/span.h"
 #include "sen/core/io/buffer_writer.h"
 #include "sen/core/io/input_stream.h"
@@ -28,6 +30,7 @@
 
 // generated code
 #include "stl/configuration.stl.h"
+#include "stl/sen/kernel/basic_types.stl.h"
 
 // asio
 #include <asio/buffer.hpp>
@@ -42,13 +45,14 @@
 #include <asio/system_error.hpp>
 
 // std
-#include <algorithm>
 #include <atomic>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -64,19 +68,28 @@ namespace
 
 constexpr uint32_t busHashSeed = 15071983;
 
-//--------------------------------------------------------------------------------------------------------------
-// Helpers
-//--------------------------------------------------------------------------------------------------------------
-
-uint8_t clamp(uint8_t val, const ByteRange& range) { return std::clamp(val, range.min, range.max); }
-
-uint8_t computeByte(const ByteRange& byteRange, uint8_t hash)
+[[nodiscard]] std::string formatBusAddress(const kernel::BusAddress& address)
 {
-  uint8_t minMulticastRange = byteRange.min;  // valid multicast addresses start here
-  uint8_t maxMulticastRange = byteRange.max;  // valid multicast addresses end here
-  uint8_t multicastRangeLen = maxMulticastRange - minMulticastRange;
-  return (multicastRangeLen != 0) ? minMulticastRange + (hash % multicastRangeLen) : minMulticastRange;
+  std::string formattedAddress = address.sessionName;
+  formattedAddress.push_back('.');
+  formattedAddress.append(address.busName);
+  return formattedAddress;
 }
+
+/// Estimates collision probability using the birthday problem
+[[nodiscard]] double computeBirthdayCollisionProbability(std::size_t busCount, uint64_t usableAddressCount) noexcept
+{
+  if (busCount < 2U || usableAddressCount == 0U)
+  {
+    return 0.0;
+  }
+
+  const auto n = sen::std_util::checkedConversion<double>(busCount);
+  const auto usableSpace = sen::std_util::checkedConversion<double>(usableAddressCount);
+  return 1.0 - std::exp(-(n * (n - 1.0)) / (2.0 * usableSpace));
+}
+
+}  // namespace
 
 asio::ip::address computeMulticastAddress(uint32_t sessionId,
                                           uint32_t busId,
@@ -85,36 +98,90 @@ asio::ip::address computeMulticastAddress(uint32_t sessionId,
                                           const MulticastExclusions& exclusions)
 {
   const auto hash = hashCombine(busHashSeed, sessionId, busId, discoveryPort);
-  const auto hashBytes = reinterpret_cast<const uint8_t*>(&hash);  // NOLINT
-
-  const uint8_t byte0 = computeByte(range[0], hashBytes[0]);  // NOLINT
-  const uint8_t byte1 = computeByte(range[1], hashBytes[1]);  // NOLINT
-  const uint8_t byte2 = computeByte(range[2], hashBytes[2]);  // NOLINT
-  const uint8_t byte3 = computeByte(range[3], hashBytes[3]);  // NOLINT
-
-  // NOLINTNEXTLINE
-  asio::ip::address_v4::bytes_type bytes = {byte0, byte1, byte2, byte3};
-
-  for (std::size_t i = 0; i < bytes.size(); ++i)
-  {
-    bytes[i] = clamp(bytes[i], range[i]);  // NOLINT
-  }
-
-  const auto address = getUsableMulticastAddress(asio::ip::address_v4(bytes), range, exclusions);
-
-  // component.cpp rejects a range with no usable address before the component starts, so this
-  // normally cannot fire. It stays because that check is skipped when multicast is disabled, and
-  // because it is per-bus rather than over the whole range.
-  if (!address)
+  const auto usableAddressCount = usableMulticastAddressCount(range, exclusions);
+  if (usableAddressCount == 0U)
   {
     throwRuntimeError("multicast address range has no usable addresses after applying exclusions");
   }
 
+  const auto usableAddressIndex = hash % usableAddressCount;
+  const auto address = getUsableMulticastAddressAtIndex(usableAddressIndex, range, exclusions);
+  SEN_ENSURE(address.has_value());
   SEN_ENSURE(address->is_multicast());
   return *address;
 }
 
-}  // namespace
+Result<MulticastCollisionAnalysis, std::string> analyzeConfiguredMulticastBuses(
+  const std::vector<kernel::BusAddress>& configuredBusAddresses,
+  uint16_t discoveryPort,
+  const MulticastRange& range,
+  const MulticastExclusions& exclusions)
+{
+  MulticastCollisionAnalysis analysis;
+  analysis.usableAddressCount = usableMulticastAddressCount(range, exclusions);
+  if (analysis.usableAddressCount == 0U)
+  {
+    return Err(std::string("multicast address range has no usable addresses after applying exclusions"));
+  }
+
+  analysis.allocations.reserve(configuredBusAddresses.size());
+  std::unordered_map<uint32_t, std::size_t> allocationIndexByGroupAddress;
+  allocationIndexByGroupAddress.reserve(configuredBusAddresses.size());
+
+  for (const auto& busAddress: configuredBusAddresses)
+  {
+    const auto sessionId = crc32(busAddress.sessionName);
+    const auto busId = crc32(busAddress.busName);
+    const auto groupAddress = computeMulticastAddress(sessionId, busId, discoveryPort, range, exclusions).to_v4();
+    ConfiguredBusMulticastAllocation allocation {busAddress, sessionId, busId, groupAddress};
+
+    const auto [groupItr, inserted] =
+      allocationIndexByGroupAddress.try_emplace(groupAddress.to_uint(), analysis.allocations.size());
+    if (!inserted)
+    {
+      const auto& existingAllocation = analysis.allocations.at(groupItr->second);
+      if (existingAllocation.busAddress == busAddress)
+      {
+        continue;
+      }
+      analysis.selfCollisions.push_back(MulticastSelfCollision {existingAllocation, allocation});
+    }
+
+    analysis.allocations.push_back(std::move(allocation));
+  }
+
+  analysis.collisionProbability =
+    computeBirthdayCollisionProbability(analysis.allocations.size(), analysis.usableAddressCount);
+  return Ok(std::move(analysis));
+}
+
+std::string formatMulticastSelfCollision(const std::vector<MulticastSelfCollision>& collisionsToReport)
+{
+  std::string error;
+  for (const auto& collision: collisionsToReport)
+  {
+    if (!error.empty())
+    {
+      error.push_back('\n');
+    }
+    error.append("multicast self-collision: buses '");
+    error.append(formatBusAddress(collision.firstAllocation.busAddress));
+    error.append("' (sessionId=");
+    error.append(std::to_string(collision.firstAllocation.sessionId));
+    error.append(", busId=");
+    error.append(std::to_string(collision.firstAllocation.busId));
+    error.append(") and '");
+    error.append(formatBusAddress(collision.secondAllocation.busAddress));
+    error.append("' (sessionId=");
+    error.append(std::to_string(collision.secondAllocation.sessionId));
+    error.append(", busId=");
+    error.append(std::to_string(collision.secondAllocation.busId));
+    error.append(") both map to ");
+    error.append(collision.firstAllocation.groupAddress.to_string());
+  }
+
+  return error;
+}
 
 //--------------------------------------------------------------------------------------------------------------
 // BusHandler

--- a/components/ether/src/bus_handler.h
+++ b/components/ether/src/bus_handler.h
@@ -17,13 +17,83 @@
 #include "shared_buffer_sequence.h"
 
 // sen
+#include "sen/core/base/result.h"
 #include "sen/kernel/tracer.h"
 
 // generated code
 #include "stl/configuration.stl.h"
+#include "stl/sen/kernel/basic_types.stl.h"
+
+// asio
+#include <asio/ip/address.hpp>
+#include <asio/ip/address_v4.hpp>
+
+// std
+#include <cstdint>
+#include <string>
+#include <vector>
 
 namespace sen::components::ether
 {
+
+/// Computes the multicast group for a bus.
+///
+/// Throws if the configured range has no usable address
+/// @param sessionId: session identifier
+/// @param busId: bus identifier
+/// @param discoveryPort: discovery port used in the address hash
+/// @param range: allowed multicast address range
+/// @param exclusions: addresses excluded from allocation
+/// @return multicast group assigned to the bus
+[[nodiscard]] asio::ip::address computeMulticastAddress(uint32_t sessionId,
+                                                        uint32_t busId,
+                                                        uint16_t discoveryPort,
+                                                        const MulticastRange& range,
+                                                        const MulticastExclusions& exclusions);
+
+/// Multicast allocation for a configured bus.
+struct ConfiguredBusMulticastAllocation
+{
+  kernel::BusAddress busAddress;
+  uint32_t sessionId = 0;
+  uint32_t busId = 0;
+  asio::ip::address_v4 groupAddress;
+};
+
+/// Two different configured buses allocated to the same multicast group.
+struct MulticastSelfCollision
+{
+  ConfiguredBusMulticastAllocation firstAllocation;
+  ConfiguredBusMulticastAllocation secondAllocation;
+};
+
+/// Multicast allocation and collision information for the configured buses.
+struct MulticastCollisionAnalysis
+{
+  std::vector<ConfiguredBusMulticastAllocation> allocations;
+  std::vector<MulticastSelfCollision> selfCollisions;
+  uint64_t usableAddressCount = 0;
+  double collisionProbability = 0.0;
+};
+
+/// Analyzes multicast allocations for configured buses.
+///
+/// @param configuredBusAddresses: bus addresses to analyze
+/// @param discoveryPort: discovery port used to allocate addresses
+/// @param range: allowed multicast address range
+/// @param exclusions: addresses excluded from allocation
+/// @return allocation analysis or an error if no address is usable
+[[nodiscard]] Result<MulticastCollisionAnalysis, std::string> analyzeConfiguredMulticastBuses(
+  const std::vector<kernel::BusAddress>& configuredBusAddresses,
+  uint16_t discoveryPort,
+  const MulticastRange& range,
+  const MulticastExclusions& exclusions);
+
+/// Formats all multicast self-collisions errors.
+///
+/// @param collisionsToReport: collisions to include in the error message
+/// @return actionable error message with one collision per line
+[[nodiscard]] std::string formatMulticastSelfCollision(const std::vector<MulticastSelfCollision>& collisionsToReport);
 
 class BusHandler final: public std::enable_shared_from_this<BusHandler>
 {

--- a/components/ether/src/component.cpp
+++ b/components/ether/src/component.cpp
@@ -6,6 +6,7 @@
 // =====================================================================================================================
 
 // component
+#include "bus_handler.h"
 #include "discovery.h"
 #include "ether_transport.h"
 #include "network_exclusion.h"
@@ -34,9 +35,9 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <variant>
+#include <vector>
 
 // asio
 #include <asio/io_context.hpp>
@@ -52,13 +53,13 @@ namespace
 //--------------------------------------------------------------------------------------------------------------
 
 constexpr const char* defaultDiscoveryGroup = "239.255.0.44";
-constexpr uint16_t defaultDiscoveryPort = 60543;
 constexpr auto defaultBeamingPeriod = std::chrono::milliseconds(1000);
 constexpr uint64_t defaultBusWarningLevel = 100U;
 constexpr uint16_t defaultMulticastPort = 50985;
 constexpr uint8_t multicastByteZero = 239;
 constexpr uint8_t multicastByteOneMin = 192;
 constexpr uint8_t multicastByteOneMax = 195;
+constexpr double multicastCollisionProbabilityWarningThreshold = 0.05;
 
 //--------------------------------------------------------------------------------------------------------------
 // Helpers
@@ -72,6 +73,37 @@ constexpr uint8_t multicastByteOneMax = 195;
 [[nodiscard]] bool isEqualsIgnoreCase(const std::string& a, const std::string& b) noexcept
 {
   return std::equal(a.begin(), a.end(), b.begin(), b.end(), charIsEqualsIgnoreCase);
+}
+
+[[nodiscard]] Result<void, std::string> validateConfiguredMulticastBuses(
+  const std::vector<kernel::BusAddress>& configuredBusAddresses,
+  const Configuration& config,
+  const MulticastExclusions& exclusions)
+{
+  auto analysisResult = analyzeConfiguredMulticastBuses(
+    configuredBusAddresses, getBusDiscoveryPort(config), config.busConfig.multicastRange, exclusions);
+  if (analysisResult.isError())
+  {
+    return Err(std::move(analysisResult).getError());
+  }
+
+  const auto& analysis = analysisResult.getValue();
+  if (!analysis.selfCollisions.empty())
+  {
+    return Err(formatMulticastSelfCollision(analysis.selfCollisions));
+  }
+
+  if (analysis.collisionProbability >= multicastCollisionProbabilityWarningThreshold)
+  {
+    getLogger()->warn(
+      "multicast self-collision probability is high "
+      "(configured buses: {}, usable addresses: {}, probability: {:.2f}%)",
+      analysis.allocations.size(),
+      analysis.usableAddressCount,
+      analysis.collisionProbability * 100.0);
+  }
+
+  return Ok();
 }
 
 }  // namespace
@@ -103,13 +135,14 @@ public:
     }
     exclusions_ = std::move(exclusionsResult).getValue();
 
-    if (!config_.busConfig.multicastDisabled &&
-        !hasUsableMulticastAddress(config_.busConfig.multicastRange, exclusions_.multicast))
+    if (!config_.busConfig.multicastDisabled)
     {
-      return Err(kernel::ExecError {
-        kernel::ErrorCategory::expectationsNotMet,
-        "multicast address range has no usable addresses after applying exclusions",
-      });
+      if (auto collisionCheck =
+            validateConfiguredMulticastBuses(api.getConfiguredBusAddresses(), config_, exclusions_.multicast);
+          collisionCheck.isError())
+      {
+        return Err(kernel::ExecError {kernel::ErrorCategory::expectationsNotMet, std::move(collisionCheck).getError()});
+      }
     }
 
     // A pinned udpUnicast port cannot work with more than one peer, and the way it fails is

--- a/components/ether/src/ether_transport.cpp
+++ b/components/ether/src/ether_transport.cpp
@@ -50,7 +50,6 @@
 #include <thread>
 #include <tuple>
 #include <utility>
-#include <variant>
 #include <vector>
 
 namespace sen::components::ether
@@ -471,14 +470,17 @@ void EtherTransport::localParticipantJoinedBus(ObjectOwnerId participant, kernel
   {
     const auto procId = ownInfo_.processId;
 
-    uint16_t port = 60543;
-    if (std::holds_alternative<MulticastDiscovery>(config_.discovery))
-    {
-      port = std::get<MulticastDiscovery>(config_.discovery).port;
-    }
-
-    auto handler = BusHandler::make(
-      sessionId_, bus, busName, procId, listener_, port, *io_, config_, *tracer_, counters_, exclusions_.multicast);
+    auto handler = BusHandler::make(sessionId_,
+                                    bus,
+                                    busName,
+                                    procId,
+                                    listener_,
+                                    getBusDiscoveryPort(config_),
+                                    *io_,
+                                    config_,
+                                    *tracer_,
+                                    counters_,
+                                    exclusions_.multicast);
     handler->startReading();
 
     auto [itr, done] = busMap_.try_emplace(bus, std::move(handler));

--- a/components/ether/src/network_exclusion.cpp
+++ b/components/ether/src/network_exclusion.cpp
@@ -10,6 +10,7 @@
 #include "util.h"
 
 // sen
+#include "sen/core/base/assert.h"
 #include "sen/core/base/checked_conversions.h"
 #include "sen/core/base/result.h"
 
@@ -35,6 +36,7 @@
 #endif
 
 // std
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
@@ -610,13 +612,127 @@ Result<NetworkExclusions, std::string> makeNetworkExclusions(const Configuration
 
 bool hasUsableMulticastAddress(const MulticastRange& range, const MulticastExclusions& exclusions)
 {
-  asio::ip::address_v4::bytes_type bytes {};
-  for (std::size_t index = 0; index < bytes.size(); ++index)
+  return usableMulticastAddressCount(range, exclusions) != 0U;
+}
+
+namespace
+{
+
+/// Counts all the addresses in the configured multicast range and including limit.
+[[nodiscard]] uint64_t countMulticastAddressesUpTo(const MulticastRange& range, uint32_t limit)
+{
+  const auto limitBytes = asio::ip::make_address_v4(limit).to_bytes();
+  uint64_t loosePrefixCount = 0;
+  uint64_t tightPrefixCount = 1;
+
+  for (std::size_t index = 0; index < range.size(); ++index)
   {
-    bytes.at(index) = range.at(index).min;
+    const auto& byteRange = range.at(index);
+    const auto limitByte = limitBytes.at(index);
+    const auto byteRangeSize = static_cast<uint64_t>(byteRange.max) - static_cast<uint64_t>(byteRange.min) + 1U;
+
+    uint64_t nextLoosePrefixCount = loosePrefixCount * byteRangeSize;
+    uint64_t nextTightPrefixCount = 0;
+
+    for (uint32_t byte = byteRange.min; byte <= byteRange.max; ++byte)
+    {
+      if (byte < limitByte)
+      {
+        nextLoosePrefixCount += tightPrefixCount;
+      }
+      else if (byte == limitByte)
+      {
+        nextTightPrefixCount += tightPrefixCount;
+      }
+      else
+      {
+        break;
+      }
+    }
+
+    loosePrefixCount = nextLoosePrefixCount;
+    tightPrefixCount = nextTightPrefixCount;
   }
 
-  return getUsableMulticastAddress(asio::ip::address_v4(bytes), range, exclusions).has_value();
+  return loosePrefixCount + tightPrefixCount;
+}
+
+[[nodiscard]] uint64_t countMulticastRangeValuesInInterval(const MulticastRange& range, uint32_t min, uint32_t max)
+{
+  if (min > max)
+  {
+    return 0;
+  }
+
+  const auto valuesUpToMax = countMulticastAddressesUpTo(range, max);
+  if (min == 0)
+  {
+    return valuesUpToMax;
+  }
+
+  return valuesUpToMax - countMulticastAddressesUpTo(range, min - 1U);
+}
+
+/// Counts usable multicast range addresses after applying exclusions.
+[[nodiscard]] uint64_t countUsableMulticastAddressesUpTo(const MulticastRange& range,
+                                                         const MulticastExclusions& exclusions,
+                                                         uint32_t limit)
+{
+  auto usableAddressCount = countMulticastAddressesUpTo(range, limit);
+
+  for (const auto& exclusionRange: exclusions.ranges())
+  {
+    if (exclusionRange.min > limit)
+    {
+      break;
+    }
+
+    const auto excludedIntervalMax = std::min(exclusionRange.max, limit);
+    usableAddressCount -= countMulticastRangeValuesInInterval(range, exclusionRange.min, excludedIntervalMax);
+  }
+
+  return usableAddressCount;
+}
+
+}  // namespace
+
+uint64_t usableMulticastAddressCount(const MulticastRange& range, const MulticastExclusions& exclusions)
+{
+  return countUsableMulticastAddressesUpTo(range, exclusions, std::numeric_limits<uint32_t>::max());
+}
+
+std::optional<asio::ip::address_v4> getUsableMulticastAddressAtIndex(uint64_t usableIndex,
+                                                                     const MulticastRange& range,
+                                                                     const MulticastExclusions& exclusions)
+{
+  const auto usableAddressCount = usableMulticastAddressCount(range, exclusions);
+  if (usableIndex >= usableAddressCount)
+  {
+    return std::nullopt;
+  }
+
+  // the number of usable address up to each candidate never decreases
+  // use binary search to find the requested address
+  uint32_t lowerAddress = 0;
+  uint32_t upperAddress = std::numeric_limits<uint32_t>::max();
+  while (lowerAddress < upperAddress)
+  {
+    const auto addressDistance = upperAddress - lowerAddress;
+    const auto candidateAddress = lowerAddress + (addressDistance / 2U);
+    const auto candidateUsableCount = countUsableMulticastAddressesUpTo(range, exclusions, candidateAddress);
+
+    if (candidateUsableCount > usableIndex)
+    {
+      upperAddress = candidateAddress;
+    }
+    else
+    {
+      lowerAddress = candidateAddress + 1U;
+    }
+  }
+
+  SEN_ENSURE(!exclusions.isExcluded(lowerAddress));
+  return asio::ip::make_address_v4(lowerAddress);
 }
 
 [[nodiscard]] std::optional<asio::ip::address_v4> getUsableMulticastAddress(asio::ip::address_v4 candidate,

--- a/components/ether/src/network_exclusion.h
+++ b/components/ether/src/network_exclusion.h
@@ -140,6 +140,17 @@ struct NetworkExclusions
 /// Returns an error for invalid input.
 [[nodiscard]] Result<NetworkExclusions, std::string> makeNetworkExclusions(const Configuration& config);
 
+/// Returns the number of non-excluded addresses covered by the multicast range.
+[[nodiscard]] uint64_t usableMulticastAddressCount(const MulticastRange& range, const MulticastExclusions& exclusions);
+
+/// Returns the usable multicast address at a zero-based index, ordered by its numeric IPv4 value.
+/// The indexed address space contains the configured multicast range after removing all exclusions.
+/// Returns nullopt when usableIndex is outside that address space.
+[[nodiscard]] std::optional<asio::ip::address_v4> getUsableMulticastAddressAtIndex(
+  uint64_t usableIndex,
+  const MulticastRange& range,
+  const MulticastExclusions& exclusions);
+
 /// Returns true if the multicast range has a usable address.
 [[nodiscard]] bool hasUsableMulticastAddress(const MulticastRange& range, const MulticastExclusions& exclusions);
 

--- a/components/ether/src/util.cpp
+++ b/components/ether/src/util.cpp
@@ -24,8 +24,10 @@
 #include <spdlog/logger.h>
 
 // std
+#include <cstdint>
 #include <stdexcept>
 #include <tuple>
+#include <variant>
 
 #ifdef __linux
 #  include <sys/socket.h>
@@ -38,6 +40,15 @@ namespace sen::components::ether
 {
 
 std::shared_ptr<spdlog::logger> getLogger() { return kernel::KernelApi::getOrCreateLogger("ether"); }
+
+uint16_t getBusDiscoveryPort(const Configuration& config) noexcept
+{
+  if (const auto* multicastConfig = std::get_if<MulticastDiscovery>(&config.discovery))
+  {
+    return multicastConfig->port;
+  }
+  return defaultDiscoveryPort;
+}
 
 void configureMulticastSocket(asio::ip::udp::socket& socket,
                               asio::ip::udp::endpoint multicastEndpoint,

--- a/components/ether/src/util.h
+++ b/components/ether/src/util.h
@@ -36,6 +36,7 @@ class ProcessHandler;
 class Acceptor;
 
 constexpr uint32_t etherProtocolVersion = 2;
+constexpr uint16_t defaultDiscoveryPort = 60543;
 
 struct NetworkInterfaceInfo
 {
@@ -58,6 +59,12 @@ template <typename T, typename B>
 }
 
 [[nodiscard]] std::vector<NetworkInterfaceInfo> getLocalInterfaces(const Configuration& config);
+
+/// Gets the discovery port used to compute bus multicast address allocation.
+///
+/// @param config: ether configuration containing the discovery settings
+/// @return configured multicast discovery port
+[[nodiscard]] uint16_t getBusDiscoveryPort(const Configuration& config) noexcept;
 
 void configureMulticastSocket(asio::ip::udp::socket& socket,
                               asio::ip::udp::endpoint multicastEndpoint,

--- a/components/ether/test/CMakeLists.txt
+++ b/components/ether/test/CMakeLists.txt
@@ -7,11 +7,14 @@
 
 add_sen_unit_test_suite(
   ether_test
+  bus_handler_test.cpp
   network_exclusion_test.cpp
   port_binding_test.cpp
   LINK_DEPS
   sen::core
   asio::asio
+  concurrentqueue::concurrentqueue
+  spdlog::spdlog
   ether_for_testing
 )
 

--- a/components/ether/test/bus_handler_test.cpp
+++ b/components/ether/test/bus_handler_test.cpp
@@ -1,0 +1,113 @@
+// === bus_handler_test.cpp ============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#include "bus_handler.h"
+
+// generated code
+#include "stl/configuration.stl.h"
+#include "stl/sen/kernel/basic_types.stl.h"
+
+// gtest
+#include <gtest/gtest.h>
+
+// asio
+#include <asio/ip/address_v4.hpp>
+
+// std
+#include <cmath>
+#include <string>
+#include <vector>
+
+namespace sen::components::ether
+{
+
+namespace
+{
+
+[[nodiscard]] MulticastRange makeSingleAddressRange(const std::string& address)
+{
+  const auto bytes = asio::ip::make_address_v4(address).to_bytes();
+  return {
+    ByteRange {bytes.at(0), bytes.at(0)},
+    ByteRange {bytes.at(1), bytes.at(1)},
+    ByteRange {bytes.at(2), bytes.at(2)},
+    ByteRange {bytes.at(3), bytes.at(3)},
+  };
+}
+
+}  // namespace
+
+/// @test
+/// Detects a collision and computes its probability over the usable address space.
+/// @requirements(SEN-909)
+TEST(BusHandler, LowCollisionRisk)
+{
+  constexpr double warningThreshold = 0.05;
+  const MulticastRange range {ByteRange {239, 239}, ByteRange {192, 192}, ByteRange {0, 0}, ByteRange {0, 19}};
+  const std::vector<kernel::BusAddress> configuredBusAddresses {{"session", "first"}, {"session", "second"}};
+
+  const auto result = analyzeConfiguredMulticastBuses(configuredBusAddresses, 15000, range, {});
+
+  ASSERT_TRUE(result.isOk());
+  const auto& analysis = result.getValue();
+  ASSERT_EQ(analysis.allocations.size(), 2U);
+  EXPECT_EQ(analysis.usableAddressCount, 20U);
+  EXPECT_TRUE(analysis.selfCollisions.empty());
+  EXPECT_NE(analysis.allocations.at(0).groupAddress, analysis.allocations.at(1).groupAddress);
+  EXPECT_NEAR(analysis.collisionProbability, 1.0 - std::exp(-1.0 / 20.0), 1e-12);
+  EXPECT_LT(analysis.collisionProbability, warningThreshold);
+}
+
+/// @test
+/// Detects a collision and computes its probability over the usable address space.
+/// @requirements(SEN-909)
+TEST(BusHandler, DetectsMulticastCollision)
+{
+  const auto range = makeSingleAddressRange("239.192.0.10");
+  const std::vector<kernel::BusAddress> configuredBusAddresses {
+    {"session", "first"},
+    {"session", "second"},
+    {"session", "first"},
+  };
+
+  const auto result = analyzeConfiguredMulticastBuses(configuredBusAddresses, 15000, range, {});
+
+  ASSERT_TRUE(result.isOk());
+  const auto& analysis = result.getValue();
+  ASSERT_EQ(analysis.allocations.size(), 2U);
+  ASSERT_EQ(analysis.selfCollisions.size(), 1U);
+  EXPECT_EQ(analysis.usableAddressCount, 1U);
+  EXPECT_NEAR(analysis.collisionProbability, 1.0 - std::exp(-1.0), 1e-12);
+  EXPECT_EQ(analysis.allocations.at(0).groupAddress, asio::ip::make_address_v4("239.192.0.10"));
+  EXPECT_EQ(analysis.allocations.at(1).groupAddress, asio::ip::make_address_v4("239.192.0.10"));
+
+  const auto message = formatMulticastSelfCollision(analysis.selfCollisions);
+  EXPECT_NE(message.find("session.first"), std::string::npos);
+  EXPECT_NE(message.find("session.second"), std::string::npos);
+  EXPECT_NE(message.find("239.192.0.10"), std::string::npos);
+  EXPECT_NE(message.find("sessionId="), std::string::npos);
+  EXPECT_NE(message.find("busId="), std::string::npos);
+}
+
+/// @test
+/// Reports an error when exclusions remove the complete multicast range.
+/// @requirements(SEN-909)
+TEST(BusHandler, RejectsFullyExcludedRange)
+{
+  const auto range = makeSingleAddressRange("239.192.0.10");
+  const auto onlyAddress = asio::ip::make_address_v4("239.192.0.10").to_uint();
+  MulticastExclusions exclusions;
+  exclusions.add(onlyAddress, onlyAddress);
+
+  const auto result =
+    analyzeConfiguredMulticastBuses({kernel::BusAddress {"session", "bus"}}, 15000, range, exclusions);
+
+  ASSERT_TRUE(result.isError());
+  EXPECT_NE(result.getError().find("no usable addresses"), std::string::npos);
+}
+
+}  // namespace sen::components::ether

--- a/components/ether/test/network_exclusion_test.cpp
+++ b/components/ether/test/network_exclusion_test.cpp
@@ -294,6 +294,54 @@ TEST(NetworkExclusion, FindsUsableMulticastAddress)
 }
 
 /// @test
+/// Counts usable multicast addresses by intersecting ranges.
+/// @requirements(SEN-909)
+TEST(NetworkExclusion, CountsUsableMulticastAddresses)
+{
+  const auto range = makeRange(192, 193, 0, 0, 0, 3);
+  MulticastExclusions exclusions;
+  exclusions.add(asio::ip::make_address_v4("239.192.0.1").to_uint(),
+                 asio::ip::make_address_v4("239.192.0.2").to_uint());
+  exclusions.add(asio::ip::make_address_v4("239.193.0.0").to_uint(),
+                 asio::ip::make_address_v4("239.193.0.0").to_uint());
+  exclusions.add(asio::ip::make_address_v4("239.194.0.0").to_uint(),
+                 asio::ip::make_address_v4("239.194.0.255").to_uint());
+
+  EXPECT_EQ(usableMulticastAddressCount(range, exclusions), 5U);
+}
+
+/// @test
+/// Selects usable multicast addresses by their index.
+/// @requirements(SEN-909)
+TEST(NetworkExclusion, SelectsAddressByIndex)
+{
+  const auto range = makeRange(192, 192, 0, 0, 10, 13);
+  MulticastExclusions exclusions;
+  exclusions.add(asio::ip::make_address_v4("239.192.0.11").to_uint(),
+                 asio::ip::make_address_v4("239.192.0.11").to_uint());
+
+  EXPECT_EQ(getUsableMulticastAddressAtIndex(0, range, exclusions), asio::ip::make_address_v4("239.192.0.10"));
+  EXPECT_EQ(getUsableMulticastAddressAtIndex(1, range, exclusions), asio::ip::make_address_v4("239.192.0.12"));
+  EXPECT_EQ(getUsableMulticastAddressAtIndex(2, range, exclusions), asio::ip::make_address_v4("239.192.0.13"));
+  EXPECT_FALSE(getUsableMulticastAddressAtIndex(3, range, exclusions).has_value());
+}
+
+/// @test
+/// Selects indexed addresses correctly across gaps in the multicast range
+/// @requirements(SEN-909)
+TEST(NetworkExclusion, SelectsAcrossRangeBlocks)
+{
+  const auto range = makeRange(192, 192, 0, 1, 254, 255);
+  MulticastExclusions exclusions;
+  exclusions.add(asio::ip::make_address_v4("239.192.0.255").to_uint(),
+                 asio::ip::make_address_v4("239.192.0.255").to_uint());
+
+  EXPECT_EQ(getUsableMulticastAddressAtIndex(0, range, exclusions), asio::ip::make_address_v4("239.192.0.254"));
+  EXPECT_EQ(getUsableMulticastAddressAtIndex(1, range, exclusions), asio::ip::make_address_v4("239.192.1.254"));
+  EXPECT_EQ(getUsableMulticastAddressAtIndex(2, range, exclusions), asio::ip::make_address_v4("239.192.1.255"));
+}
+
+/// @test
 /// Returns no multicast address when the complete range is excluded.
 /// @requirements(SEN-909)
 TEST(NetworkExclusion, ReturnsNoMulticastAddress)
@@ -305,6 +353,8 @@ TEST(NetworkExclusion, ReturnsNoMulticastAddress)
 
   EXPECT_FALSE(getUsableMulticastAddress(asio::ip::make_address_v4(onlyAddress), range, exclusions).has_value());
   EXPECT_FALSE(hasUsableMulticastAddress(range, exclusions));
+  EXPECT_EQ(usableMulticastAddressCount(range, exclusions), 0U);
+  EXPECT_FALSE(getUsableMulticastAddressAtIndex(0, range, exclusions).has_value());
 }
 
 }  // namespace sen::components::ether

--- a/libs/kernel/include/sen/kernel/component_api.h
+++ b/libs/kernel/include/sen/kernel/component_api.h
@@ -140,6 +140,9 @@ public:
   /// Gets the (optional) application name passed to the kernel as a configuration parameter
   [[nodiscard]] const std::string& getAppName() const noexcept;
 
+  /// Gets configured non-local bus addresses
+  [[nodiscard]] std::vector<BusAddress> getConfiguredBusAddresses() const;
+
   /// The work queue of this runner
   [[nodiscard]] ::sen::impl::WorkQueue* getWorkQueue() const noexcept;
 

--- a/libs/kernel/src/bus/session.h
+++ b/libs/kernel/src/bus/session.h
@@ -27,10 +27,14 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 namespace sen::kernel::impl
 {
+
+/// Session reserved for buses that do not use a network transport
+inline constexpr std::string_view localSessionName = "local";
 
 class SessionManager;
 class RemoteParticipant;

--- a/libs/kernel/src/bus/session_manager.cpp
+++ b/libs/kernel/src/bus/session_manager.cpp
@@ -190,8 +190,8 @@ std::shared_ptr<Session> SessionManager::getOrOpenSession(const std::string& nam
     }
 
     // create the transport
-    auto transport = name == "local" || factory_ == nullptr ? std::make_unique<EmptyTransport>(name)
-                                                            : factory_(name, kernel_.makeTracer(name));
+    auto transport = name == localSessionName || factory_ == nullptr ? std::make_unique<EmptyTransport>(name)
+                                                                     : factory_(name, kernel_.makeTracer(name));
 
     // create the session
     sessionPtr = std::make_shared<Session>(this, name, std::move(transport), kernel_, messageDispatcher_);

--- a/libs/kernel/src/component_api_impl.cpp
+++ b/libs/kernel/src/component_api_impl.cpp
@@ -7,6 +7,7 @@
 
 // implementation
 #include "./kernel_impl.h"
+#include "bus/session.h"
 
 // sen
 #include "bus/remote_participant.h"  // NOLINT(misc-include-cleaner) false positive
@@ -36,6 +37,7 @@
 #include <spdlog/spdlog.h>
 
 // std
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <functional>
@@ -43,9 +45,52 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace sen::kernel
 {
+
+namespace
+{
+
+[[nodiscard]] bool isValidNonLocalBusAddress(const BusAddress& address) noexcept
+{
+  return !address.sessionName.empty() && !address.busName.empty() && address.sessionName != impl::localSessionName;
+}
+
+[[nodiscard]] std::optional<BusAddress> tryParseBusAddress(const std::string& address)
+{
+  const auto tokens = ::sen::impl::split(address, '.');
+  if (tokens.size() != 2U)
+  {
+    return std::nullopt;
+  }
+  return BusAddress {tokens.at(0U), tokens.at(1U)};
+}
+
+void addUniqueBusAddress(std::vector<BusAddress>& busAddresses, const BusAddress& address)
+{
+  if (!isValidNonLocalBusAddress(address))
+  {
+    return;
+  }
+
+  const auto alreadyAdded = std::find(busAddresses.begin(), busAddresses.end(), address) != busAddresses.end();
+  if (!alreadyAdded)
+  {
+    busAddresses.push_back(address);
+  }
+}
+
+void addUniqueBusAddress(std::vector<BusAddress>& busAddresses, const std::string& address)
+{
+  if (const auto parsedAddress = tryParseBusAddress(address))
+  {
+    addUniqueBusAddress(busAddresses, *parsedAddress);
+  }
+}
+
+}  // namespace
 
 namespace impl
 {
@@ -134,8 +179,8 @@ std::shared_ptr<ObjectSource> KernelApi::getSource(const BusAddress& address)
 
 std::shared_ptr<ObjectSource> KernelApi::getSource(const std::string& address)
 {
-  auto tokens = ::sen::impl::split(address, '.');
-  if (tokens.size() != 2U)
+  const auto parsedAddress = tryParseBusAddress(address);
+  if (!parsedAddress)
   {
     std::string err;
     err.append("invalid bus address '");
@@ -144,7 +189,7 @@ std::shared_ptr<ObjectSource> KernelApi::getSource(const std::string& address)
     throwRuntimeError(err);
   }
 
-  return getSource(BusAddress {tokens.at(0U), tokens.at(1U)});
+  return getSource(*parsedAddress);
 }
 
 SessionsDiscoverer& KernelApi::getSessionsDiscoverer() noexcept { return impl::getSessionsDiscoverer(runner_); }
@@ -155,6 +200,29 @@ const ProcessInfo* KernelApi::fetchOwnerInfo(const Object* object) const noexcep
 }
 
 const std::string& KernelApi::getAppName() const noexcept { return kernel_.getConfig().getParams().appName; }
+
+std::vector<BusAddress> KernelApi::getConfiguredBusAddresses() const
+{
+  std::vector<BusAddress> configuredBusAddresses;
+  const auto& config = kernel_.getConfig();
+
+  addUniqueBusAddress(configuredBusAddresses, config.getParams().bus);
+  const auto runMode = config.getParams().runMode;
+  if (runMode == RunMode::virtualTime || runMode == RunMode::virtualTimeRunning)
+  {
+    addUniqueBusAddress(configuredBusAddresses, config.getParams().clockBus);
+  }
+
+  for (const auto& pipeline: config.getPipelinesToLoad())
+  {
+    for (const auto& object: pipeline.objects)
+    {
+      addUniqueBusAddress(configuredBusAddresses, object.bus);
+    }
+  }
+
+  return configuredBusAddresses;
+}
 
 ::sen::impl::WorkQueue* KernelApi::getWorkQueue() const noexcept { return impl::getWorkQueue(runner_); }
 


### PR DESCRIPTION
Implements a config-time collision check for multicast addresses.

During the ether component startup, the system computes the multicast addresses for all configured buses and fails closed with a diagnostic message if any two different buses map to the same address.

Additionally, a warning based on the birthday paradox formula has been integrated to alert if the collision probability exceeds 5% based on the number of configured buses.

Resolves SEN-1716