### PR TITLE
feat(ether): add network footprint support

### DIFF
--- a/components/ether/CMakeLists.txt
+++ b/components/ether/CMakeLists.txt
@@ -49,6 +49,8 @@ add_sen_package(
           src/network_exclusion.cpp
           src/port_binding.h
           src/port_binding.cpp
+          src/network_footprint.h
+          src/network_footprint.cpp
   STL_FILES stl/discovery.stl stl/runtime.stl stl/configuration.stl
   PRIVATE_DEPS
     sen::kernel

--- a/components/ether/src/component.cpp
+++ b/components/ether/src/component.cpp
@@ -10,6 +10,7 @@
 #include "discovery.h"
 #include "ether_transport.h"
 #include "network_exclusion.h"
+#include "network_footprint.h"
 #include "tcp_discovery_hub.h"
 #include "util.h"
 
@@ -17,6 +18,7 @@
 #include "sen/core/base/class_helpers.h"
 #include "sen/core/base/compiler_macros.h"
 #include "sen/core/base/result.h"
+#include "sen/core/base/span.h"
 #include "sen/core/meta/var.h"
 #include "sen/kernel/component.h"
 #include "sen/kernel/component_api.h"
@@ -135,10 +137,11 @@ public:
     }
     exclusions_ = std::move(exclusionsResult).getValue();
 
+    auto configuredBusAddresses = api.getConfiguredBusAddresses();
     if (!config_.busConfig.multicastDisabled)
     {
       if (auto collisionCheck =
-            validateConfiguredMulticastBuses(api.getConfiguredBusAddresses(), config_, exclusions_.multicast);
+            validateConfiguredMulticastBuses(configuredBusAddresses, config_, exclusions_.multicast);
           collisionCheck.isError())
       {
         return Err(kernel::ExecError {kernel::ErrorCategory::expectationsNotMet, std::move(collisionCheck).getError()});
@@ -173,6 +176,10 @@ public:
         return std::make_unique<EtherTransport>(config_, session, appName, discovery_, std::move(tracer), exclusions_);
       },
       etherProtocolVersion);
+    api.installFootprintReporter(
+      [this,
+       configuredBusAddresses = std::move(configuredBusAddresses)](Span<const kernel::BusAddress> suppliedBusAddresses)
+      { return makeNetworkFootprint(configuredBusAddresses, suppliedBusAddresses, config_, exclusions_); });
     return done();
   }
 

--- a/components/ether/src/network_footprint.cpp
+++ b/components/ether/src/network_footprint.cpp
@@ -1,0 +1,280 @@
+// === network_footprint.cpp ===========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#include "network_footprint.h"
+
+// component
+#include "bus_handler.h"
+#include "network_exclusion.h"
+#include "port_binding.h"
+#include "util.h"
+
+// sen
+#include "sen/core/base/assert.h"
+#include "sen/core/base/class_helpers.h"
+#include "sen/core/base/span.h"
+
+// generated code
+#include "stl/configuration.stl.h"
+#include "stl/sen/kernel/basic_types.stl.h"
+#include "stl/sen/kernel/network_footprint.stl.h"
+
+// asio
+#include <asio/ip/address_v4.hpp>
+
+// std
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace sen::components::ether
+{
+
+namespace
+{
+
+/// Combines configured and supplied buses while preserving order and removing duplicates
+[[nodiscard]] std::vector<kernel::BusAddress> mergeBusAddresses(Span<const kernel::BusAddress> configuredBusAddresses,
+                                                                Span<const kernel::BusAddress> suppliedBusAddresses)
+{
+  std::vector<kernel::BusAddress> busAddresses;
+  busAddresses.reserve(configuredBusAddresses.size() + suppliedBusAddresses.size());
+
+  // Appends addresses that are not already present.
+  const auto appendUnique = [&busAddresses](Span<const kernel::BusAddress> addresses)
+  {
+    for (const auto& address: addresses)
+    {
+      if (std::find(busAddresses.begin(), busAddresses.end(), address) == busAddresses.end())
+      {
+        busAddresses.push_back(address);
+      }
+    }
+  };
+
+  appendUnique(configuredBusAddresses);
+  appendUnique(suppliedBusAddresses);
+  return busAddresses;
+}
+
+/// Classifies a bus as configured or supplied
+[[nodiscard]] kernel::NetworkFootprintBusSource getBusSource(const kernel::BusAddress& busAddress,
+                                                             Span<const kernel::BusAddress> configuredBusAddresses)
+{
+  const auto configured =
+    std::find(configuredBusAddresses.begin(), configuredBusAddresses.end(), busAddress) != configuredBusAddresses.end();
+  return configured ? kernel::NetworkFootprintBusSource::configured : kernel::NetworkFootprintBusSource::supplied;
+}
+
+/// Converts a multicast allocation into a footprint bus identity
+[[nodiscard]] kernel::NetworkFootprintBusIdentity toFootprintBusIdentity(
+  const ConfiguredBusMulticastAllocation& allocation)
+{
+  return {
+    allocation.busAddress.sessionName,
+    allocation.busAddress.busName,
+    allocation.sessionId,
+    allocation.busId,
+  };
+}
+
+/// Converts a multicast allocation into a footprint bus entry
+[[nodiscard]] kernel::NetworkFootprintBus toFootprintBus(const ConfiguredBusMulticastAllocation& allocation,
+                                                         kernel::NetworkFootprintBusSource source)
+{
+  return {
+    allocation.busAddress.sessionName,
+    allocation.busAddress.busName,
+    allocation.sessionId,
+    allocation.busId,
+    allocation.groupAddress.to_string(),
+    source,
+  };
+}
+
+/// Converts a detected multicast collision into its footprint representation
+[[nodiscard]] kernel::NetworkFootprintSelfCollision toFootprintSelfCollision(const MulticastSelfCollision& collision)
+{
+  return {
+    toFootprintBusIdentity(collision.firstAllocation),
+    toFootprintBusIdentity(collision.secondAllocation),
+    collision.firstAllocation.groupAddress.to_string(),
+  };
+}
+
+/// Converts multicast exclusion ranges into textual IPv4 ranges.
+[[nodiscard]] kernel::NetworkFootprintAddressRangeList toFootprintAddressRanges(const MulticastExclusions& exclusions)
+{
+  kernel::NetworkFootprintAddressRangeList footprintRanges;
+  footprintRanges.reserve(exclusions.ranges().size());
+  for (const auto& range: exclusions.ranges())
+  {
+    footprintRanges.push_back(
+      {asio::ip::make_address_v4(range.min).to_string(), asio::ip::make_address_v4(range.max).to_string()});
+  }
+  return footprintRanges;
+}
+
+/// Converts multicast capacity and collision data into the footprint model
+[[nodiscard]] kernel::NetworkFootprintCollision toFootprintCollision(const MulticastCollisionAnalysis& analysis)
+{
+  kernel::NetworkFootprintSelfCollisionList selfCollisions;
+  selfCollisions.reserve(analysis.selfCollisions.size());
+  for (const auto& collision: analysis.selfCollisions)
+  {
+    selfCollisions.push_back(toFootprintSelfCollision(collision));
+  }
+
+  return {
+    analysis.usableAddressCount,
+    static_cast<uint64_t>(analysis.allocations.size()),
+    analysis.collisionProbability,
+    std::move(selfCollisions),
+  };
+}
+
+/// Converts an Ether port kind into its footprint equivalent
+[[nodiscard]] kernel::NetworkFootprintPortKind toFootprintPortKind(PortKind kind)
+{
+  switch (kind)
+  {
+    case PortKind::tcpAcceptor:
+      return kernel::NetworkFootprintPortKind::tcpAcceptor;
+    case PortKind::udpUnicast:
+      return kernel::NetworkFootprintPortKind::udpUnicast;
+    case PortKind::tcpSource:
+      return kernel::NetworkFootprintPortKind::tcpSource;
+  }
+  sen::throwRuntimeError("unknown port kind");
+}
+
+/// Converts a configured port binding into a footprint port entry.
+[[nodiscard]] kernel::NetworkFootprintPort toFootprintPort(PortKind kind, const PortBinding& binding)
+{
+  const auto footprintKind = toFootprintPortKind(kind);
+  return std::visit(
+    ::sen::Overloaded {
+      [footprintKind](const Ephemeral&) -> kernel::NetworkFootprintPort
+      {
+        return {
+          footprintKind,
+          kernel::NetworkFootprintPortMode::ephemeral,
+          kernel::MaybeNetworkFootprintPortValue {},
+        };
+      },
+      [footprintKind](const PinnedPort& pinnedPort) -> kernel::NetworkFootprintPort
+      {
+        return {
+          footprintKind,
+          kernel::NetworkFootprintPortMode::pinned,
+          kernel::NetworkFootprintPortValue {pinnedPort.port},
+        };
+      },
+      [footprintKind](const ProbePortRange& probeRange) -> kernel::NetworkFootprintPort
+      {
+        return {
+          footprintKind,
+          kernel::NetworkFootprintPortMode::probe,
+          kernel::NetworkFootprintPortRange {probeRange.min, probeRange.max},
+        };
+      },
+    },
+    binding);
+}
+
+/// Converts one source of port exclusions into footprint ranges.
+template <typename Tag>
+[[nodiscard]] kernel::NetworkFootprintPortRangeList toFootprintPortRanges(const ExclusionSet<uint16_t, Tag>& exclusions)
+{
+  kernel::NetworkFootprintPortRangeList footprintRanges;
+  footprintRanges.reserve(exclusions.ranges().size());
+  for (const auto& range: exclusions.ranges())
+  {
+    footprintRanges.push_back({range.min, range.max});
+  }
+  return footprintRanges;
+}
+
+/// Converts all port exclusion sources into the footprint model.
+[[nodiscard]] kernel::NetworkFootprintPortExclusions toFootprintPortExclusions(const PortExclusionSources& exclusions)
+{
+  return {
+    toFootprintPortRanges(exclusions.builtIn),
+    toFootprintPortRanges(exclusions.configured),
+    toFootprintPortRanges(exclusions.os),
+  };
+}
+
+/// Analyzes the reported buses and builds the multicast footprint section.
+[[nodiscard]] kernel::NetworkFootprintMulticast buildMulticastFootprint(
+  const std::vector<kernel::BusAddress>& busAddresses,
+  Span<const kernel::BusAddress> configuredBusAddresses,
+  uint16_t discoveryPort,
+  const BusConfig& config,
+  const MulticastExclusions& exclusions)
+{
+  const auto analysisResult =
+    analyzeConfiguredMulticastBuses(busAddresses, discoveryPort, config.multicastRange, exclusions);
+  if (analysisResult.isError())
+  {
+    sen::throwRuntimeError(analysisResult.getError());
+  }
+  const auto& analysis = analysisResult.getValue();
+
+  kernel::NetworkFootprintBusList buses;
+  buses.reserve(analysis.allocations.size());
+  for (const auto& allocation: analysis.allocations)
+  {
+    buses.push_back(toFootprintBus(allocation, getBusSource(allocation.busAddress, configuredBusAddresses)));
+  }
+
+  return {
+    config.multicastPort,
+    std::move(buses),
+    toFootprintAddressRanges(exclusions),
+    toFootprintCollision(analysis),
+  };
+}
+
+/// Builds the port entries from the effective ether configuration.
+[[nodiscard]] kernel::NetworkFootprintPortList buildPortFootprints(const Configuration& config)
+{
+  kernel::NetworkFootprintPortList ports;
+  ports.reserve(3U);
+  ports.push_back(toFootprintPort(PortKind::tcpAcceptor, getPortBinding(config, PortKind::tcpAcceptor)));
+  ports.push_back(toFootprintPort(PortKind::udpUnicast, getPortBinding(config, PortKind::udpUnicast)));
+  ports.push_back(toFootprintPort(PortKind::tcpSource, getPortBinding(config, PortKind::tcpSource)));
+  return ports;
+}
+
+}  // namespace
+
+kernel::NetworkFootprint makeNetworkFootprint(Span<const kernel::BusAddress> configuredBusAddresses,
+                                              Span<const kernel::BusAddress> suppliedBusAddresses,
+                                              const Configuration& config,
+                                              const NetworkExclusions& exclusions)
+{
+  const auto discoveryPort = getBusDiscoveryPort(config);
+  kernel::MaybeNetworkFootprintMulticast multicast;
+  if (!config.busConfig.multicastDisabled)
+  {
+    const auto busAddresses = mergeBusAddresses(configuredBusAddresses, suppliedBusAddresses);
+    multicast = buildMulticastFootprint(
+      busAddresses, configuredBusAddresses, discoveryPort, config.busConfig, exclusions.multicast);
+  }
+
+  return {
+    discoveryPort,
+    std::move(multicast),
+    buildPortFootprints(config),
+    toFootprintPortExclusions(exclusions.ports),
+  };
+}
+
+}  // namespace sen::components::ether

--- a/components/ether/src/network_footprint.h
+++ b/components/ether/src/network_footprint.h
@@ -1,0 +1,39 @@
+// === network_footprint.h =============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#ifndef SEN_COMPONENTS_ETHER_SRC_NETWORK_FOOTPRINT_H
+#define SEN_COMPONENTS_ETHER_SRC_NETWORK_FOOTPRINT_H
+
+// component
+#include "network_exclusion.h"
+
+// sen
+#include "sen/core/base/span.h"
+
+// generated code
+#include "stl/configuration.stl.h"
+#include "stl/sen/kernel/basic_types.stl.h"
+#include "stl/sen/kernel/network_footprint.stl.h"
+
+namespace sen::components::ether
+{
+
+/// Builds the network footprint
+///
+/// @param configuredBusAddresses: bus addresses configured
+/// @param suppliedBusAddresses: additional bus addresses supplied
+/// @param config: ether configuration used to calculate the footprint
+/// @param exclusions: multicast and port exclusions
+/// @return the network footprint
+[[nodiscard]] kernel::NetworkFootprint makeNetworkFootprint(Span<const kernel::BusAddress> configuredBusAddresses,
+                                                            Span<const kernel::BusAddress> suppliedBusAddresses,
+                                                            const Configuration& config,
+                                                            const NetworkExclusions& exclusions);
+
+}  // namespace sen::components::ether
+
+#endif  // SEN_COMPONENTS_ETHER_SRC_NETWORK_FOOTPRINT_H

--- a/components/ether/src/port_binding.cpp
+++ b/components/ether/src/port_binding.cpp
@@ -52,27 +52,6 @@ namespace
   return "unknown";
 }
 
-[[nodiscard]] const PortBinding& getPortBinding(const Configuration& config, PortKind kind)
-{
-  static const PortBinding ephemeral = Ephemeral {};
-
-  if (!config.portConfig)
-  {
-    return ephemeral;
-  }
-
-  switch (kind)
-  {
-    case PortKind::tcpAcceptor:
-      return config.portConfig->tcpAcceptor;
-    case PortKind::udpUnicast:
-      return config.portConfig->udpUnicast;
-    case PortKind::tcpSource:
-      return config.portConfig->tcpSource;
-  }
-  return ephemeral;
-}
-
 [[nodiscard]] std::string excludedByToString(uint16_t port, const PortExclusionSources& exclusions)
 {
   std::ostringstream stream;
@@ -302,6 +281,27 @@ void bindProbe(PortKind kind,
 }
 
 }  // namespace
+
+[[nodiscard]] const PortBinding& getPortBinding(const Configuration& config, PortKind kind)
+{
+  static const PortBinding ephemeral = Ephemeral {};
+
+  if (!config.portConfig)
+  {
+    return ephemeral;
+  }
+
+  switch (kind)
+  {
+    case PortKind::tcpAcceptor:
+      return config.portConfig->tcpAcceptor;
+    case PortKind::udpUnicast:
+      return config.portConfig->udpUnicast;
+    case PortKind::tcpSource:
+      return config.portConfig->tcpSource;
+  }
+  return ephemeral;
+}
 
 void bindConfiguredPort(const Configuration& config,
                         const PortExclusionSources& exclusions,

--- a/components/ether/src/port_binding.h
+++ b/components/ether/src/port_binding.h
@@ -48,6 +48,12 @@ void bindConfiguredPort(const Configuration& config,
                         PortKind kind,
                         const BindPort& bind);
 
+/// Selects the configured port binding for the given port kind
+///
+/// @param config: ether configuration with the port settings.
+/// @param kind: port type.
+/// @return selected binding.
+[[nodiscard]] const PortBinding& getPortBinding(const Configuration& config, PortKind kind);
 }  // namespace sen::components::ether
 
 #endif  // SEN_COMPONENTS_ETHER_SRC_PORT_BINDING_H

--- a/components/ether/test/CMakeLists.txt
+++ b/components/ether/test/CMakeLists.txt
@@ -9,6 +9,7 @@ add_sen_unit_test_suite(
   ether_test
   bus_handler_test.cpp
   network_exclusion_test.cpp
+  network_footprint_test.cpp
   port_binding_test.cpp
   LINK_DEPS
   sen::core

--- a/components/ether/test/network_footprint_test.cpp
+++ b/components/ether/test/network_footprint_test.cpp
@@ -1,0 +1,223 @@
+// === network_footprint_test.cpp ======================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#include "network_footprint.h"
+
+// component
+#include "network_exclusion.h"
+
+// sen
+#include "sen/core/base/hash32.h"
+
+// generated code
+#include "stl/configuration.stl.h"
+#include "stl/sen/kernel/basic_types.stl.h"
+#include "stl/sen/kernel/network_footprint.stl.h"
+
+// gtest
+#include <gtest/gtest.h>
+
+// asio
+#include <asio/ip/address_v4.hpp>
+
+// std
+#include <cmath>
+#include <cstdint>
+#include <exception>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace sen::components::ether
+{
+
+namespace
+{
+
+constexpr uint16_t discoveryPort = 15000;
+constexpr uint16_t multicastPort = 16000;
+constexpr uint16_t probePortMin = 21000;
+constexpr uint16_t probePortMax = 21999;
+constexpr uint16_t pinnedPort = 25000;
+constexpr const char* multicastAddress = "239.192.0.10";
+
+[[nodiscard]] MulticastRange makeSingleAddressRange(const std::string& address)
+{
+  const auto bytes = asio::ip::make_address_v4(address).to_bytes();
+  return {
+    ByteRange {bytes.at(0), bytes.at(0)},
+    ByteRange {bytes.at(1), bytes.at(1)},
+    ByteRange {bytes.at(2), bytes.at(2)},
+    ByteRange {bytes.at(3), bytes.at(3)},
+  };
+}
+
+[[nodiscard]] Configuration makeConfiguration(bool multicastDisabled = false)
+{
+  Configuration config {};
+  MulticastDiscovery discovery {};
+  discovery.port = discoveryPort;
+  config.discovery = std::move(discovery);
+  config.busConfig.multicastRange = makeSingleAddressRange(multicastAddress);
+  config.busConfig.multicastPort = multicastPort;
+  config.busConfig.multicastDisabled = multicastDisabled;
+  config.portConfig.emplace(PortConfig {
+    Ephemeral {},
+    ProbePortRange {probePortMin, probePortMax},
+    PinnedPort {pinnedPort},
+  });
+  return config;
+}
+
+[[nodiscard]] NetworkExclusions makeExclusions()
+{
+  NetworkExclusions exclusions;
+  exclusions.multicast.add(asio::ip::make_address_v4("239.192.0.20").to_uint(),
+                           asio::ip::make_address_v4("239.192.0.21").to_uint());
+  exclusions.ports.builtIn.add(0, 1023);
+  exclusions.ports.configured.add(21001, 21002);
+  exclusions.ports.os.add(49152, 65535);
+  return exclusions;
+}
+
+}  // namespace
+
+/// @test
+/// Checks that the footprint contains configured network and conflicts.
+/// @requirements(SEN-909)
+TEST(NetworkFootprint, BuildsNetworkFootprint)
+{
+  const auto config = makeConfiguration();
+  const auto exclusions = makeExclusions();
+  const std::vector<kernel::BusAddress> configuredBusAddresses {
+    {"session", "configured"},
+    {"session", "configured"},
+  };
+  const std::vector<kernel::BusAddress> suppliedBusAddresses {
+    {"session", "configured"},
+    {"session", "supplied"},
+    {"session", "supplied"},
+  };
+
+  const auto footprint = makeNetworkFootprint(configuredBusAddresses, suppliedBusAddresses, config, exclusions);
+
+  EXPECT_EQ(footprint.discoveryPort, discoveryPort);
+  ASSERT_TRUE(footprint.multicast.has_value());
+  const auto& multicast = footprint.multicast.value();
+  EXPECT_EQ(multicast.port, multicastPort);
+  ASSERT_EQ(multicast.buses.size(), 2U);
+
+  const auto& configuredBus = multicast.buses.at(0);
+  EXPECT_EQ(configuredBus.sessionName, "session");
+  EXPECT_EQ(configuredBus.busName, "configured");
+  EXPECT_EQ(configuredBus.sessionId, crc32("session"));
+  EXPECT_EQ(configuredBus.busId, crc32("configured"));
+  EXPECT_EQ(configuredBus.groupAddress, multicastAddress);
+  EXPECT_EQ(configuredBus.source, kernel::NetworkFootprintBusSource::configured);
+
+  const auto& suppliedBus = multicast.buses.at(1);
+  EXPECT_EQ(suppliedBus.sessionName, "session");
+  EXPECT_EQ(suppliedBus.busName, "supplied");
+  EXPECT_EQ(suppliedBus.sessionId, crc32("session"));
+  EXPECT_EQ(suppliedBus.busId, crc32("supplied"));
+  EXPECT_EQ(suppliedBus.groupAddress, multicastAddress);
+  EXPECT_EQ(suppliedBus.source, kernel::NetworkFootprintBusSource::supplied);
+
+  ASSERT_EQ(multicast.exclusions.size(), 1U);
+  EXPECT_EQ(multicast.exclusions.front().min, "239.192.0.20");
+  EXPECT_EQ(multicast.exclusions.front().max, "239.192.0.21");
+
+  EXPECT_EQ(multicast.collision.usableSpaceSize, 1U);
+  EXPECT_EQ(multicast.collision.busCount, 2U);
+  EXPECT_NEAR(multicast.collision.probability, 1.0 - std::exp(-1.0), 1e-12);
+  ASSERT_EQ(multicast.collision.selfCollisions.size(), 1U);
+  const auto& collision = multicast.collision.selfCollisions.front();
+  EXPECT_EQ(collision.firstBus.sessionName, "session");
+  EXPECT_EQ(collision.firstBus.busName, "configured");
+  EXPECT_EQ(collision.firstBus.sessionId, crc32("session"));
+  EXPECT_EQ(collision.firstBus.busId, crc32("configured"));
+  EXPECT_EQ(collision.secondBus.sessionName, "session");
+  EXPECT_EQ(collision.secondBus.busName, "supplied");
+  EXPECT_EQ(collision.secondBus.sessionId, crc32("session"));
+  EXPECT_EQ(collision.secondBus.busId, crc32("supplied"));
+  EXPECT_EQ(collision.groupAddress, multicastAddress);
+
+  ASSERT_EQ(footprint.ports.size(), 3U);
+  EXPECT_EQ(footprint.ports.at(0).kind, kernel::NetworkFootprintPortKind::tcpAcceptor);
+  EXPECT_EQ(footprint.ports.at(0).mode, kernel::NetworkFootprintPortMode::ephemeral);
+  EXPECT_FALSE(footprint.ports.at(0).value.has_value());
+
+  EXPECT_EQ(footprint.ports.at(1).kind, kernel::NetworkFootprintPortKind::udpUnicast);
+  EXPECT_EQ(footprint.ports.at(1).mode, kernel::NetworkFootprintPortMode::probe);
+  ASSERT_TRUE(footprint.ports.at(1).value.has_value());
+  const auto& probeRange = std::get<kernel::NetworkFootprintPortRange>(footprint.ports.at(1).value.value());
+  EXPECT_EQ(probeRange.min, probePortMin);
+  EXPECT_EQ(probeRange.max, probePortMax);
+
+  EXPECT_EQ(footprint.ports.at(2).kind, kernel::NetworkFootprintPortKind::tcpSource);
+  EXPECT_EQ(footprint.ports.at(2).mode, kernel::NetworkFootprintPortMode::pinned);
+  ASSERT_TRUE(footprint.ports.at(2).value.has_value());
+  const auto exactPort = std::get<uint16_t>(footprint.ports.at(2).value.value());
+  EXPECT_EQ(exactPort, pinnedPort);
+
+  ASSERT_EQ(footprint.portExclusions.builtIn.size(), 1U);
+  EXPECT_EQ(footprint.portExclusions.builtIn.front().min, 0U);
+  EXPECT_EQ(footprint.portExclusions.builtIn.front().max, 1023U);
+  ASSERT_EQ(footprint.portExclusions.configured.size(), 1U);
+  EXPECT_EQ(footprint.portExclusions.configured.front().min, 21001U);
+  EXPECT_EQ(footprint.portExclusions.configured.front().max, 21002U);
+  ASSERT_EQ(footprint.portExclusions.operatingSystem.size(), 1U);
+  EXPECT_EQ(footprint.portExclusions.operatingSystem.front().min, 49152U);
+  EXPECT_EQ(footprint.portExclusions.operatingSystem.front().max, 65535U);
+}
+
+/// @test
+/// Omits multicast and reports ephemeral ports when no port configuration is present
+/// @requirements(SEN-909)
+TEST(NetworkFootprint, OmitsDisabledMulticast)
+{
+  auto config = makeConfiguration(true);
+  config.portConfig.reset();
+  const auto exclusions = makeExclusions();
+  const std::vector<kernel::BusAddress> suppliedBusAddresses {{"session", "bus"}};
+
+  const auto footprint = makeNetworkFootprint({}, suppliedBusAddresses, config, exclusions);
+
+  EXPECT_EQ(footprint.discoveryPort, discoveryPort);
+  EXPECT_FALSE(footprint.multicast.has_value());
+  ASSERT_EQ(footprint.ports.size(), 3U);
+  for (const auto& port: footprint.ports)
+  {
+    EXPECT_EQ(port.mode, kernel::NetworkFootprintPortMode::ephemeral);
+    EXPECT_FALSE(port.value.has_value());
+  }
+  EXPECT_EQ(footprint.portExclusions.configured.size(), 1U);
+}
+
+/// @test
+/// Rejects a multicast configuration with no usable address.
+/// @requirements(SEN-909)
+TEST(NetworkFootprint, RejectsMulticastWithoutUsableAddress)
+{
+  const auto config = makeConfiguration();
+  NetworkExclusions exclusions;
+  const auto onlyAddress = asio::ip::make_address_v4(multicastAddress).to_uint();
+  exclusions.multicast.add(onlyAddress, onlyAddress);
+  const std::vector<kernel::BusAddress> suppliedBusAddresses {{"session", "bus"}};
+
+  try
+  {
+    static_cast<void>(makeNetworkFootprint({}, suppliedBusAddresses, config, exclusions));
+    FAIL() << "Expected makeNetworkFootprint to throw";
+  }
+  catch (const std::exception& error)
+  {
+    EXPECT_NE(std::string(error.what()).find("no usable addresses"), std::string::npos);
+  }
+}
+
+}  // namespace sen::components::ether

--- a/libs/kernel/CMakeLists.txt
+++ b/libs/kernel/CMakeLists.txt
@@ -14,6 +14,7 @@ set(kernel_stl_files
     stl/sen/kernel/log.stl
     stl/sen/kernel/basic_types.stl
     stl/sen/kernel/kernel_objects.stl
+    stl/sen/kernel/network_footprint.stl
     stl/sen/kernel/type_specs.stl
 )
 

--- a/libs/kernel/include/sen/kernel/component_api.h
+++ b/libs/kernel/include/sen/kernel/component_api.h
@@ -11,6 +11,7 @@
 // sen
 #include "sen/core/base/compiler_macros.h"
 #include "sen/core/base/duration.h"
+#include "sen/core/base/move_only_function.h"
 #include "sen/core/base/mutex_utils.h"
 #include "sen/core/base/result.h"
 #include "sen/core/base/span.h"
@@ -32,6 +33,7 @@
 
 // generated code
 #include "stl/sen/kernel/basic_types.stl.h"
+#include "stl/sen/kernel/network_footprint.stl.h"
 
 // spdlog
 #include <spdlog/logger.h>
@@ -58,6 +60,9 @@ using FuncResult = Result<void, ExecError>;
 
 /// The result of operations that may be called multiple times.
 using PassResult = Result<OpState, ExecError>;
+
+/// Callable that builds a network footprint from bus addresses.
+using NetworkFootprintReporter = NetworkFootprint(Span<const BusAddress>) const;
 
 class SessionsDiscoverer;
 class RunApi;
@@ -237,6 +242,10 @@ public:
 
   /// Installs a tracer factory.
   void installTracerFactory(TracerFactory&& factory) const;
+
+  /// Installs a footprint reporter.
+  /// The kernel stores a single reporter, installing another replaces the existing one.
+  void installFootprintReporter(sen::std_util::move_only_function<NetworkFootprintReporter>&& reporter);
 
 private:
   Kernel& kernel_;

--- a/libs/kernel/src/component_api_impl.cpp
+++ b/libs/kernel/src/component_api_impl.cpp
@@ -13,6 +13,7 @@
 #include "bus/remote_participant.h"  // NOLINT(misc-include-cleaner) false positive
 #include "sen/core/base/assert.h"
 #include "sen/core/base/duration.h"
+#include "sen/core/base/move_only_function.h"
 #include "sen/core/base/mutex_utils.h"
 #include "sen/core/base/span.h"
 #include "sen/core/base/timestamp.h"
@@ -270,6 +271,11 @@ void PreloadApi::installTransportFactory(TransportFactory&& factory, uint32_t tr
 void PreloadApi::installTracerFactory(TracerFactory&& factory) const
 {
   kernel_.pimpl_->installTracerFactory(std::move(factory));
+}
+
+void PreloadApi::installFootprintReporter(sen::std_util::move_only_function<NetworkFootprintReporter>&& reporter)
+{
+  kernel_.pimpl_->installFootprintReporter(std::move(reporter));
 }
 
 //--------------------------------------------------------------------------------------------------------------

--- a/libs/kernel/src/kernel_impl.cpp
+++ b/libs/kernel/src/kernel_impl.cpp
@@ -16,16 +16,20 @@
 #include "wall_clock.h"
 
 // sen
+#include "sen/core/base/assert.h"
 #include "sen/core/base/compiler_macros.h"
+#include "sen/core/base/move_only_function.h"
 #include "sen/core/base/span.h"
 #include "sen/core/meta/class_type.h"
 #include "sen/core/meta/var.h"
+#include "sen/kernel/component_api.h"
 #include "sen/kernel/kernel.h"
 #include "sen/kernel/kernel_config.h"
 #include "sen/kernel/tracer.h"
 
 // generated code
 #include "stl/sen/kernel/basic_types.stl.h"
+#include "stl/sen/kernel/network_footprint.stl.h"
 
 // spdlog
 #include <spdlog/logger.h>
@@ -293,6 +297,20 @@ std::unique_ptr<Tracer> KernelImpl::makeTracer(std::string_view contextName) { r
 
 void KernelImpl::installTracerFactory(TracerFactory&& factory) { tracerFactory_ = std::move(factory); }
 
+void KernelImpl::installFootprintReporter(sen::std_util::move_only_function<NetworkFootprintReporter>&& reporter)
+{
+  networkReport_ = std::move(reporter);
+}
+
+NetworkFootprint KernelImpl::getNetworkFootprint(Span<const BusAddress> busAddresses) const
+{
+  if (!networkReport_)
+  {
+    throwRuntimeError("network footprint reporter is not installed; ensure the ether component is configured");
+  }
+  return networkReport_(busAddresses);
+}
+
 Span<const ComponentInfo> KernelImpl::getImportedPackages() const noexcept { return importedPackages_; }
 
 Span<const ComponentInfo> KernelImpl::getLoadedComponents() const noexcept { return loadedComponents_; }
@@ -323,10 +341,12 @@ void KernelImpl::registerImportedPackages(Span<const ComponentInfo> packages)
 extern "C" SEN_EXPORT void get0x2cfc8aa4Types(::sen::ExportedTypesList& types);  // basic_types.stl
 extern "C" SEN_EXPORT void get0xf7949d6aTypes(::sen::ExportedTypesList& types);  // log.stl
 extern "C" SEN_EXPORT void get0xc817451aTypes(::sen::ExportedTypesList& types);  // type_specs.stl
+extern "C" SEN_EXPORT void get0x982f88ecTypes(::sen::ExportedTypesList& types);  // network_footprint.stl
 
 extern "C" SEN_EXPORT void get0x5b269ebdTypes(::sen::ExportedTypesList& types)
 {
   get0x2cfc8aa4Types(types);
   get0xf7949d6aTypes(types);
   get0xc817451aTypes(types);
+  get0x982f88ecTypes(types);
 }

--- a/libs/kernel/src/kernel_impl.h
+++ b/libs/kernel/src/kernel_impl.h
@@ -18,12 +18,15 @@
 
 // sen
 #include "sen/core/base/class_helpers.h"
+#include "sen/core/base/move_only_function.h"
 #include "sen/core/base/span.h"
+#include "sen/kernel/component_api.h"
 #include "sen/kernel/kernel.h"
 #include "sen/kernel/kernel_config.h"
 
 // generated
 #include "stl/sen/kernel/basic_types.stl.h"
+#include "stl/sen/kernel/network_footprint.stl.h"
 
 // spdlog
 #include <spdlog/fwd.h>
@@ -33,6 +36,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -121,6 +125,12 @@ public:
   /// Set the factory function for creating tracers
   void installTracerFactory(TracerFactory&& factory);
 
+  /// Set the reporter used to build process network footprint
+  void installFootprintReporter(sen::std_util::move_only_function<NetworkFootprintReporter>&& reporter);
+
+  /// Builds a network footprint for the supplied bus addresses
+  NetworkFootprint getNetworkFootprint(Span<const BusAddress> busAddresses) const;
+
 private:
   /// Implementation of run() depending on the run mode stated in the configuration.
   [[nodiscard]] int applyRunMode(KernelBlockMode blockMode);
@@ -168,6 +178,7 @@ private:
   CustomTypeRegistry types_;
   SessionManager sessionManager_;
   std::function<std::unique_ptr<Tracer>(std::string_view)> tracerFactory_;
+  sen::std_util::move_only_function<NetworkFootprintReporter> networkReport_;
   std::vector<ComponentInfo> importedPackages_;
   std::vector<ComponentInfo> loadedComponents_;
 };

--- a/libs/kernel/stl/sen/kernel/network_footprint.stl
+++ b/libs/kernel/stl/sen/kernel/network_footprint.stl
@@ -1,0 +1,135 @@
+package sen.kernel;
+
+// Bus source
+enum NetworkFootprintBusSource : u8
+{
+  configured, // Read from process configuration
+  supplied,   // Added when requesting an offline report
+  runtime     // Discovered from the buses that are live in the process
+}
+
+// Names and IDs that identify a bus
+struct NetworkFootprintBusIdentity
+{
+  sessionName : string,
+  busName     : string,
+  sessionId   : u32,
+  busId       : u32
+}
+
+// Multicast endpoint allocated to a bus
+struct NetworkFootprintBus
+{
+  sessionName  : string,
+  busName      : string,
+  sessionId    : u32,
+  busId        : u32,
+  groupAddress : string,
+  source       : NetworkFootprintBusSource
+}
+
+// Buses included in a network footprint
+sequence<NetworkFootprintBus> NetworkFootprintBusList;
+
+// Inclusive IPv4 address range excluded from multicast allocation
+struct NetworkFootprintAddressRange
+{
+  min : string,
+  max : string
+}
+
+sequence<NetworkFootprintAddressRange> NetworkFootprintAddressRangeList;
+
+// Two buses allocated to the same multicast group
+struct NetworkFootprintSelfCollision
+{
+  firstBus     : NetworkFootprintBusIdentity,
+  secondBus    : NetworkFootprintBusIdentity,
+  groupAddress : string
+}
+
+// Multicast address conflicts found in the reported buses
+sequence<NetworkFootprintSelfCollision> NetworkFootprintSelfCollisionList;
+
+// Multicast allocation capacity and collision information
+struct NetworkFootprintCollision
+{
+  usableSpaceSize : u64,                               // Number of addresses available
+  busCount        : u64,                               // Number of reported buses
+  probability     : f64,                               // Estimated conflict from 0 to 1
+  selfCollisions  : NetworkFootprintSelfCollisionList  // Collisions in the reported buses
+}
+
+// Multicast information in the network footprint
+struct NetworkFootprintMulticast
+{
+  port       : u16,                               // Shared multicast port used by every bus
+  buses      : NetworkFootprintBusList,           // Multicast address used by each bus
+  exclusions : NetworkFootprintAddressRangeList,  // Addresses that cannot be used
+  collision  : NetworkFootprintCollision          // Available addresses and conflict information
+}
+
+optional<NetworkFootprintMulticast> MaybeNetworkFootprintMulticast;
+
+// Type of socket opened by the process
+enum NetworkFootprintPortKind : u8
+{
+  tcpAcceptor,
+  udpUnicast,
+  tcpSource
+}
+
+// Port allocation policy
+enum NetworkFootprintPortMode : u8
+{
+  ephemeral,
+  probe,
+  pinned
+}
+
+// Inclusive range from which a port may be selected
+struct NetworkFootprintPortRange
+{
+  min : u16,
+  max : u16
+}
+
+// Known port number or range
+variant NetworkFootprintPortValue
+{
+  u16,
+  NetworkFootprintPortRange
+}
+
+// The value is not present when the port number is not known
+optional<NetworkFootprintPortValue> MaybeNetworkFootprintPortValue;
+
+// Socket type, port selection mode and port value
+struct NetworkFootprintPort
+{
+  kind  : NetworkFootprintPortKind,
+  mode  : NetworkFootprintPortMode,
+  value : MaybeNetworkFootprintPortValue
+}
+
+// Ports used by the process
+sequence<NetworkFootprintPort> NetworkFootprintPortList;
+
+sequence<NetworkFootprintPortRange> NetworkFootprintPortRangeList;
+
+// Port ranges that cannot be used
+struct NetworkFootprintPortExclusions
+{
+  builtIn         : NetworkFootprintPortRangeList,
+  configured      : NetworkFootprintPortRangeList,
+  operatingSystem : NetworkFootprintPortRangeList
+}
+
+// Network endpoints predicted offline or observed at runtime for one process
+struct NetworkFootprint
+{
+  discoveryPort  : u16,                             // Discovery port used to calculate multicast addresses
+  multicast      : MaybeNetworkFootprintMulticast,  // Multicast allocation details
+  ports          : NetworkFootprintPortList,        // Port settings
+  portExclusions : NetworkFootprintPortExclusions   // Port ranges that cannot be used
+}


### PR DESCRIPTION
Adds the `stl` to represent a network footprint report and internal support needed to build it. The report describes the buses and their multicast addresses, multicast exclusions, conflicts and the ports used.

A new reporter can now be installed through `PreloadApi` and invoked by the kernel with a list of bus addresses.

Resolves SEN-1717