### PR TITLE
chore: add Luis Gutierrez as code owner for dead reckoning

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
 * @EnriqueParodi
+
+# Dead reckoning. Both owners are listed so either can review the other's changes:
+# GitHub does not let an author approve their own pull request.
+/libs/util/include/sen/util/dr/         @EnriqueParodi @luisgutierrezpereda
+/libs/util/src/dr/                      @EnriqueParodi @luisgutierrezpereda
+/libs/util/test/dead_reckoner_test.cpp  @EnriqueParodi @luisgutierrezpereda
+/libs/util/test/coordinates_test.cpp    @EnriqueParodi @luisgutierrezpereda


### PR DESCRIPTION
Luis is now in the org with write access, so a CODEOWNERS entry takes effect.

Both owners are listed on each path because GitHub does not let an author approve their own pull request. With only one name, that owner could never get their own changes reviewed by a code owner.

CODEOWNERS is last-match-wins, so a change under these paths now needs one approval from this line rather than from the `*` line above.