### PR TITLE
perf(util)!: speed up dead reckoning and fix the orientation conversions

### DIFF
--- a/libs/util/CMakeLists.txt
+++ b/libs/util/CMakeLists.txt
@@ -74,3 +74,7 @@ sen_internal_install(util)
 if(SEN_BUILD_TESTS)
   add_subdirectory(test)
 endif()
+
+if(SEN_BUILD_BENCHMARKS)
+  add_subdirectory(benchmark)
+endif()

--- a/libs/util/benchmark/CMakeLists.txt
+++ b/libs/util/benchmark/CMakeLists.txt
@@ -1,0 +1,16 @@
+# === CMakeLists.txt ==================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# =====================================================================================================================
+
+add_sen_benchmark(
+  util_benchmark
+  dr/dead_reckoner_benchmark.cpp
+  LINK_DEPS
+  sen::core
+  sen::util
+)
+
+target_include_directories(util_benchmark PRIVATE ${CMAKE_SOURCE_DIR}/libs/util/src/dr)

--- a/libs/util/benchmark/dr/dead_reckoner_benchmark.cpp
+++ b/libs/util/benchmark/dr/dead_reckoner_benchmark.cpp
@@ -1,0 +1,477 @@
+// === dead_reckoner_benchmark.cpp =====================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// sen
+#include "sen/core/base/checked_conversions.h"
+#include "sen/util/dr/algorithms.h"
+#include "sen/util/dr/detail/dead_reckoner_base.h"
+#include "sen/util/dr/detail/dead_reckoner_impl.h"
+
+// implementation
+#include "utils.h"
+
+// 3rd party
+#include <benchmark/benchmark.h>
+
+// std
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+
+namespace sen::util
+{
+namespace
+{
+
+// Several positions rather than one: a fixed input is hoisted out of the loop, and the equator and
+// the poles take different branches through toEcef.
+constexpr std::size_t positionCount = 4U;
+
+const std::array<GeodeticWorldLocation, positionCount> geodeticPositions {{
+  {48.8566, 2.3522, 35.0},
+  {-33.8688, 151.2093, 120.0},
+  {0.0, 0.0, 0.0},
+  {78.2232, -15.6267, 11000.0},
+}};
+
+const std::array<Location, positionCount> ecefPositions {{
+  {4200946.0, 172458.0, 4780110.0},
+  {-4646050.0, 2553454.0, -3534640.0},
+  {6378137.0, 0.0, 0.0},
+  {1252172.0, -350090.0, 6237633.0},
+}};
+
+const Orientation orientation {0.4, -0.2, 1.1};
+const Velocity velocity {120.0, -45.0, 8.0};
+const Acceleration acceleration {1.5, 0.25, -0.75};
+
+// The same inputs as whole situations, for the shared-rotation cases below.
+const std::array<Situation, positionCount> ecefSituations {{
+  {false, {}, ecefPositions[0], orientation, velocity, {}, acceleration, {}},
+  {false, {}, ecefPositions[1], orientation, velocity, {}, acceleration, {}},
+  {false, {}, ecefPositions[2], orientation, velocity, {}, acceleration, {}},
+  {false, {}, ecefPositions[3], orientation, velocity, {}, acceleration, {}},
+}};
+
+const std::array<GeodeticSituation, positionCount> geodeticSituations {{
+  {false, {}, geodeticPositions[0], orientation, velocity, {}, acceleration, {}},
+  {false, {}, geodeticPositions[1], orientation, velocity, {}, acceleration, {}},
+  {false, {}, geodeticPositions[2], orientation, velocity, {}, acceleration, {}},
+  {false, {}, geodeticPositions[3], orientation, velocity, {}, acceleration, {}},
+}};
+
+//----------------------------------------------------------------------------------------------------------------
+// Whole conversions
+//----------------------------------------------------------------------------------------------------------------
+
+// One rotation built per vector, which is the shape the callers had.
+void geodeticSituationConversion(benchmark::State& state)
+{
+  std::size_t index = 0U;
+
+  for (auto _: state)
+  {
+    const auto& ecefPosition = ecefPositions[index];
+    index = (index + 1U) % positionCount;
+
+    auto geoLocation = impl::toLla(ecefPosition);
+    benchmark::DoNotOptimize(geoLocation);
+    auto convertedOrientation = impl::ecefToNed(orientation, geoLocation);
+    benchmark::DoNotOptimize(convertedOrientation);
+    auto convertedVelocity = impl::ecefToNed(velocity, geoLocation);
+    benchmark::DoNotOptimize(convertedVelocity);
+    auto convertedAcceleration = impl::ecefToNed(acceleration, geoLocation);
+    benchmark::DoNotOptimize(convertedAcceleration);
+  }
+}
+
+BENCHMARK(geodeticSituationConversion);
+
+// The same in reverse.
+void ecefSituationConversion(benchmark::State& state)
+{
+  std::size_t index = 0U;
+
+  for (auto _: state)
+  {
+    const auto& geoLocation = geodeticPositions[index];
+    index = (index + 1U) % positionCount;
+
+    auto ecefPosition = impl::toEcef(geoLocation);
+    benchmark::DoNotOptimize(ecefPosition);
+    auto convertedOrientation = impl::nedToEcef(orientation, geoLocation);
+    benchmark::DoNotOptimize(convertedOrientation);
+    auto convertedVelocity = impl::nedToEcef(velocity, geoLocation);
+    benchmark::DoNotOptimize(convertedVelocity);
+    auto convertedAcceleration = impl::nedToEcef(acceleration, geoLocation);
+    benchmark::DoNotOptimize(convertedAcceleration);
+  }
+}
+
+BENCHMARK(ecefSituationConversion);
+
+// The same conversions with one rotation shared across the vectors.
+void geodeticSituationShared(benchmark::State& state)
+{
+  std::size_t index = 0U;
+
+  for (auto _: state)
+  {
+    auto result = impl::toGeodeticSituation(ecefSituations[index]);
+    index = (index + 1U) % positionCount;
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(geodeticSituationShared);
+
+void ecefSituationShared(benchmark::State& state)
+{
+  std::size_t index = 0U;
+
+  for (auto _: state)
+  {
+    auto result = impl::toSituation(geodeticSituations[index]);
+    index = (index + 1U) % positionCount;
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(ecefSituationShared);
+
+//----------------------------------------------------------------------------------------------------------------
+// The pieces underneath
+//----------------------------------------------------------------------------------------------------------------
+
+void toLla(benchmark::State& state)
+{
+  std::size_t index = 0U;
+
+  for (auto _: state)
+  {
+    auto result = impl::toLla(ecefPositions[index]);
+    benchmark::DoNotOptimize(result);
+    index = (index + 1U) % positionCount;
+  }
+}
+
+BENCHMARK(toLla);
+
+void toEcef(benchmark::State& state)
+{
+  std::size_t index = 0U;
+
+  for (auto _: state)
+  {
+    auto result = impl::toEcef(geodeticPositions[index]);
+    benchmark::DoNotOptimize(result);
+    index = (index + 1U) % positionCount;
+  }
+}
+
+BENCHMARK(toEcef);
+
+// Velocity and acceleration both reach this.
+void ecefToNedVector(benchmark::State& state)
+{
+  std::size_t index = 0U;
+
+  for (auto _: state)
+  {
+    auto result = impl::ecefToNed(velocity, geodeticPositions[index]);
+    benchmark::DoNotOptimize(result);
+    index = (index + 1U) % positionCount;
+  }
+}
+
+BENCHMARK(ecefToNedVector);
+
+// The orientation overload.
+void ecefToNedOrientation(benchmark::State& state)
+{
+  std::size_t index = 0U;
+
+  for (auto _: state)
+  {
+    auto result = impl::ecefToNed(orientation, geodeticPositions[index]);
+    benchmark::DoNotOptimize(result);
+    index = (index + 1U) % positionCount;
+  }
+}
+
+BENCHMARK(ecefToNedOrientation);
+
+// The rotation alone, with no vector applied.
+void buildRotation(benchmark::State& state)
+{
+  std::size_t index = 0U;
+
+  for (auto _: state)
+  {
+    const auto& position = geodeticPositions[index];
+    index = (index + 1U) % positionCount;
+
+    auto rotation = Quatd {toRad(position.longitude), -halfPi - toRad(position.latitude), 0.0};
+    benchmark::DoNotOptimize(rotation);
+  }
+}
+
+BENCHMARK(buildRotation);
+
+//----------------------------------------------------------------------------------------------------------------
+// Inside the orientation conversion
+//----------------------------------------------------------------------------------------------------------------
+
+void nedTrihedron(benchmark::State& state)
+{
+  std::size_t index = 0U;
+
+  for (auto _: state)
+  {
+    auto result = getNedTrihedron(geodeticPositions[index]);
+    index = (index + 1U) % positionCount;
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(nedTrihedron);
+
+void eulerFromTrihedrons(benchmark::State& state)
+{
+  const auto trihedron = getNedTrihedron(geodeticPositions[1]);
+  const Quatd input {orientation.psi, orientation.theta, orientation.phi};
+  const auto xf = input * Vec3d {1, 0, 0};
+  const auto yf = input * Vec3d {0, 1, 0};
+
+  for (auto _: state)
+  {
+    auto result = eulerAnglesFromTrihedrons(trihedron[0], trihedron[1], trihedron[2], xf, yf);
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(eulerFromTrihedrons);
+
+// One quaternion applied to one vector.
+void rotateVector(benchmark::State& state)
+{
+  const Quatd rotation {orientation.psi, orientation.theta, orientation.phi};
+  const Vec3d input {1.0, 2.0, 3.0};
+
+  for (auto _: state)
+  {
+    auto result = rotation * input;
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(rotateVector);
+
+// A bare atan2, for scale against the three in the Euler recovery.
+void atan2Call(benchmark::State& state)
+{
+  double numerator = 0.7;
+
+  for (auto _: state)
+  {
+    auto result = std::atan2(numerator, 1.3);
+    numerator += 1e-9;
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(atan2Call);
+
+// Angles are f32 and reach the quaternion through a checked conversion each. Against
+// buildRotation, which takes f64 directly, the pair prices those conversions.
+void orientationToQuat(benchmark::State& state)
+{
+  for (auto _: state)
+  {
+    auto result = fromOrientationToQuat(orientation);
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(orientationToQuat);
+
+// Widening cannot lose a value, so both range guards inside are dead.
+void checkedWidening(benchmark::State& state)
+{
+  float input = 1.25F;
+
+  for (auto _: state)
+  {
+    auto result = std_util::checkedConversion<double>(input);
+    input += 1e-6F;
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(checkedWidening);
+
+void plainWidening(benchmark::State& state)
+{
+  float input = 1.25F;
+
+  for (auto _: state)
+  {
+    auto result = static_cast<double>(input);
+    input += 1e-6F;
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(plainWidening);
+
+//----------------------------------------------------------------------------------------------------------------
+// The rest of the per cycle work
+//----------------------------------------------------------------------------------------------------------------
+
+const Situation extrapolationInput {false,
+                                    sen::TimeStamp {std::chrono::seconds(0)},
+                                    ecefPositions[1],
+                                    orientation,
+                                    velocity,
+                                    AngularVelocity {0.05, -0.02, 0.01},
+                                    acceleration,
+                                    AngularAcceleration {0.001, 0.002, -0.001}};
+
+// The lightest algorithm.
+void extrapolateFpw(benchmark::State& state)
+{
+  const sen::TimeStamp at {std::chrono::milliseconds(16)};
+
+  for (auto _: state)
+  {
+    auto result = drFpw(extrapolationInput, at);
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(extrapolateFpw);
+
+// The heaviest algorithm.
+void extrapolateRvb(benchmark::State& state)
+{
+  const sen::TimeStamp at {std::chrono::milliseconds(16)};
+
+  for (auto _: state)
+  {
+    auto result = drRvb(extrapolationInput, at);
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(extrapolateRvb);
+
+// The algorithm the reckoner base uses.
+void extrapolateRvw(benchmark::State& state)
+{
+  const sen::TimeStamp at {std::chrono::milliseconds(16)};
+
+  for (auto _: state)
+  {
+    auto result = drRvw(extrapolationInput, at);
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(extrapolateRvw);
+
+//----------------------------------------------------------------------------------------------------------------
+// A whole reckoner: the conversions plus the cache, the smoothing and the dispatch
+//----------------------------------------------------------------------------------------------------------------
+
+const GeodeticSituation publishInput {false,
+                                      sen::TimeStamp {std::chrono::seconds(0)},
+                                      geodeticPositions[1],
+                                      orientation,
+                                      velocity,
+                                      AngularVelocity {0.05, -0.02, 0.01},
+                                      acceleration,
+                                      AngularAcceleration {0.001, 0.002, -0.001}};
+
+// The publish side of a cycle.
+void reckonerUpdate(benchmark::State& state)
+{
+  DeadReckonerBase reckoner {DrConfig {}};
+
+  for (auto _: state)
+  {
+    reckoner.updateGeodeticSituation(publishInput);
+  }
+}
+
+BENCHMARK(reckonerUpdate);
+
+// Timestamp advancing, so every query misses the cache.
+void reckonerReadFresh(benchmark::State& state)
+{
+  DrConfig config {};
+  config.smoothing = state.range(0) != 0;
+  if (state.range(0) == 2)
+  {
+    // Forces smooth() down its early return, isolating the smoothing cost.
+    config.maxDeltaTime = sen::Duration {0};
+  }
+  DeadReckonerBase reckoner {config};
+  reckoner.updateGeodeticSituation(publishInput);
+
+  int64_t tick = 1;
+
+  for (auto _: state)
+  {
+    auto result = reckoner.geodeticSituation(sen::TimeStamp {std::chrono::milliseconds(16 * tick)});
+    ++tick;
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(reckonerReadFresh)->Arg(0)->Arg(1)->Arg(2);
+
+// The same query repeated, answered by the cache.
+void reckonerReadCached(benchmark::State& state)
+{
+  DeadReckonerBase reckoner {DrConfig {}};
+  reckoner.updateGeodeticSituation(publishInput);
+  const sen::TimeStamp at {std::chrono::milliseconds(16)};
+  auto warm = reckoner.geodeticSituation(at);
+  benchmark::DoNotOptimize(warm);
+
+  for (auto _: state)
+  {
+    auto result = reckoner.geodeticSituation(at);
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(reckonerReadCached);
+
+// Smoothing steps from the last smoothed time to the query in smoothingInterval increments, so its
+// cost follows the gap between queries. The argument is that gap in milliseconds.
+void reckonerReadByInterval(benchmark::State& state)
+{
+  DeadReckonerBase reckoner {DrConfig {}};
+  reckoner.updateGeodeticSituation(publishInput);
+
+  const auto gap = std::chrono::milliseconds(state.range(0));
+  int64_t tick = 1;
+
+  for (auto _: state)
+  {
+    auto result = reckoner.geodeticSituation(sen::TimeStamp {gap * tick});
+    ++tick;
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(reckonerReadByInterval)->Arg(16)->Arg(40)->Arg(100)->Arg(200)->Arg(500)->Arg(1000);
+
+}  // namespace
+}  // namespace sen::util

--- a/libs/util/include/sen/util/dr/dead_reckoner.h
+++ b/libs/util/include/sen/util/dr/dead_reckoner.h
@@ -101,32 +101,11 @@ private:
 /// Transform a Situation to a GeodeticSituation
 [[nodiscard]] inline GeodeticSituation toGeodeticSituation(const Situation& value)
 {
-  const auto geoLocation = impl::toLla(value.worldLocation);
-  return GeodeticSituation {value.isFrozen,
-                            value.timeStamp,
-                            geoLocation,
-                            impl::ecefToNed(value.orientation, geoLocation),
-                            impl::ecefToNed(value.velocityVector, geoLocation),
-                            value.angularVelocity,
-                            impl::ecefToNed(value.accelerationVector, geoLocation),
-                            value.angularAcceleration};
+  return impl::toGeodeticSituation(value);
 }
 
 /// Transforms a GeodeticSituation to a Situation
-[[nodiscard]] inline Situation toSituation(const GeodeticSituation& value)
-{
-  // translate input geodetic situation to standard reference system
-  const auto ecefPosition = impl::toEcef(value.worldLocation);
-  const auto ecefOrientation = impl::nedToEcef(value.orientation, value.worldLocation);
-
-  return Situation {value.isFrozen,
-                    value.timeStamp,
-                    ecefPosition,
-                    ecefOrientation,
-                    impl::nedToEcef(value.velocityVector, value.worldLocation),
-                    value.angularVelocity,
-                    impl::nedToEcef(value.accelerationVector, value.worldLocation)};
-}
+[[nodiscard]] inline Situation toSituation(const GeodeticSituation& value) { return impl::toSituation(value); }
 
 //-------------------------------------------------------------------------------------------------------------------
 // Inline implementation
@@ -298,19 +277,7 @@ typename DeadReckoner<T>::GeodeticSituationProcessor DeadReckoner<T>::getGeodeti
     };
   }
 
-  return [this](sen::TimeStamp time)
-  {
-    const auto situation = processSituation_(time);
-    const auto geoLocation = impl::toLla(situation.worldLocation);
-    return GeodeticSituation {situation.isFrozen,
-                              situation.timeStamp,
-                              geoLocation,
-                              impl::ecefToNed(situation.orientation, geoLocation),
-                              impl::ecefToNed(situation.velocityVector, geoLocation),
-                              situation.angularVelocity,
-                              impl::ecefToNed(situation.accelerationVector, geoLocation),
-                              situation.angularAcceleration};
-  };
+  return [this](sen::TimeStamp time) { return impl::toGeodeticSituation(processSituation_(time)); };
 }
 
 template <typename T>

--- a/libs/util/include/sen/util/dr/detail/dead_reckoner_impl.h
+++ b/libs/util/include/sen/util/dr/detail/dead_reckoner_impl.h
@@ -81,6 +81,18 @@ template <typename T>
 /// Translates an Acceleration vector from NED to ECEF coordinates
 [[nodiscard]] Acceleration nedToEcef(const Acceleration& value, const GeodeticWorldLocation& location) noexcept;
 
+/// Converts a situation from ECEF to geodetic, building the position rotation once for all three
+/// quantities that need it.
+[[nodiscard]] GeodeticSituation toGeodeticSituation(const Situation& value) noexcept;
+
+/// Converts a situation from geodetic to ECEF.
+[[nodiscard]] Situation toSituation(const GeodeticSituation& value) noexcept;
+
+/// Overload for callers that already hold the converted position and orientation.
+[[nodiscard]] Situation toSituation(const GeodeticSituation& value,
+                                    const Location& ecefPosition,
+                                    const Orientation& ecefOrientation) noexcept;
+
 /// Translates Velocity vectors expressed in body coordinates to NED coordinates
 [[nodiscard]] Velocity bodyToNed(const Velocity& value, const Orientation& orientationNed) noexcept;
 

--- a/libs/util/include/sen/util/dr/settable_dead_reckoner.h
+++ b/libs/util/include/sen/util/dr/settable_dead_reckoner.h
@@ -32,14 +32,16 @@ enum class ReferenceSystem : u32
   body
 };
 
-/// Threshold configuration structure with the position error threshold (maximum distance between extrapolation and
-/// data) and the entity dynamics (speed and changes of direction)
+// --8<-- [start:dr_threshold]
+/// How far the extrapolation may drift from the data before the Spatial is written: a distance per axis, an angle
+/// between orientations, and the reference system both are measured in.
 struct DrThreshold
 {
   LengthMeters distanceThreshold {1.0};
   AngleRadians orientationThreshold {0.05f};
   ReferenceSystem referenceSystem {ReferenceSystem::world};
 };
+// --8<-- [end:dr_threshold]
 
 /// Allows the user to get the extrapolated situation of an object and to set the Spatial when the error of the
 /// extrapolation exceeds a configurable threshold.
@@ -76,13 +78,13 @@ public:
   [[nodiscard]] const T& object() const noexcept;
 
 public:
-  /// Updates the spatial property of the object if the update period is exceeded or if the extrapolation error
-  /// exceeds the threshold.
-  void setSpatial(const Situation& situation);
+  /// Updates the spatial property of the object when the extrapolation error exceeds the threshold.
+  /// Returns true if the spatial was updated.
+  bool setSpatial(const Situation& situation);
 
-  /// Updates the spatial property of the object from a Geodetic Situation input if the update period is exceeded or
-  /// if the extrapolation error exceeds the threshold.
-  void setSpatial(const GeodeticSituation& situation);
+  /// Updates the spatial property of the object from a Geodetic Situation input when the extrapolation
+  /// error exceeds the threshold. Returns true if the spatial was updated.
+  bool setSpatial(const GeodeticSituation& situation);
 
   /// Directly sets the frozen state of the object's spatial to true/false. The timestamp is needed to coherently
   /// apply the new frozen state to the current extrapolated situation.
@@ -127,7 +129,7 @@ inline const T& SettableDeadReckoner<T>::object() const noexcept
 }
 
 template <typename T>
-inline void SettableDeadReckoner<T>::setSpatial(const Situation& situation)
+inline bool SettableDeadReckoner<T>::setSpatial(const Situation& situation)
 {
   const auto extrapolation = Parent::extrapolate(obj_.getSpatial(), situation.timeStamp, lastTimeStamp_);
   if (impl::maxDistanceExceeded(situation.worldLocation, extrapolation.worldLocation, threshold_.distanceThreshold) ||
@@ -135,11 +137,14 @@ inline void SettableDeadReckoner<T>::setSpatial(const Situation& situation)
   {
     lastTimeStamp_ = situation.timeStamp;
     obj_.setNextSpatial(toSpatialVariant(situation, threshold_));
+    return true;
   }
+
+  return false;
 }
 
 template <typename T>
-inline void SettableDeadReckoner<T>::setSpatial(const GeodeticSituation& situation)
+inline bool SettableDeadReckoner<T>::setSpatial(const GeodeticSituation& situation)
 {
   // translate input geodetic situation to standard reference system
   const auto ecefPosition = impl::toEcef(situation.worldLocation);
@@ -149,15 +154,11 @@ inline void SettableDeadReckoner<T>::setSpatial(const GeodeticSituation& situati
       impl::maxRotationExceeded(ecefOrientation, extrapolation.orientation, orientationThresholdCos))
   {
     lastTimeStamp_ = situation.timeStamp;
-    obj_.setNextSpatial(toSpatialVariant({situation.isFrozen,
-                                          situation.timeStamp,
-                                          ecefPosition,
-                                          ecefOrientation,
-                                          impl::nedToEcef(situation.velocityVector, situation.worldLocation),
-                                          situation.angularVelocity,
-                                          impl::nedToEcef(situation.accelerationVector, situation.worldLocation)},
-                                         threshold_));
+    obj_.setNextSpatial(toSpatialVariant(impl::toSituation(situation, ecefPosition, ecefOrientation), threshold_));
+    return true;
   }
+
+  return false;
 }
 
 template <typename T>

--- a/libs/util/src/dr/dead_reckoner_base.cpp
+++ b/libs/util/src/dr/dead_reckoner_base.cpp
@@ -25,8 +25,15 @@ Situation DeadReckonerBase::situation(sen::TimeStamp timeStamp)
   if (!isSituationCached(timeStamp))
   {
     const auto update = drRvw(lastSituation_, timeStamp);
+
+    if (!config_.smoothing)
+    {
+      setCachedSituation(update);
+      return cachedSituation_;
+    }
+
     smooth(update);
-    setCachedSituation(config_.smoothing ? smoothSituation_ : update);
+    setCachedSituation(smoothSituation_);
   }
 
   return cachedSituation_;
@@ -36,16 +43,7 @@ GeodeticSituation DeadReckonerBase::geodeticSituation(sen::TimeStamp timeStamp)
 {
   if (!isGeodeticSituationCached(timeStamp))
   {
-    const auto sitVal = situation(timeStamp);
-    const auto geoLocation = impl::toLla(sitVal.worldLocation);
-    setCachedGeodeticSituation(GeodeticSituation {sitVal.isFrozen,
-                                                  sitVal.timeStamp,
-                                                  geoLocation,
-                                                  impl::ecefToNed(sitVal.orientation, geoLocation),
-                                                  impl::ecefToNed(sitVal.velocityVector, geoLocation),
-                                                  sitVal.angularVelocity,
-                                                  impl::ecefToNed(sitVal.accelerationVector, geoLocation),
-                                                  sitVal.angularAcceleration});
+    setCachedGeodeticSituation(impl::toGeodeticSituation(situation(timeStamp)));
   }
 
   return cachedGeodeticSituation_;
@@ -59,14 +57,7 @@ void DeadReckonerBase::updateSituation(const Situation& value)
 
 void DeadReckonerBase::updateGeodeticSituation(const GeodeticSituation& value)
 {
-  lastSituation_ = Situation {value.isFrozen,
-                              value.timeStamp,
-                              impl::toEcef(value.worldLocation),
-                              impl::nedToEcef(value.orientation, value.worldLocation),
-                              impl::nedToEcef(value.velocityVector, value.worldLocation),
-                              value.angularVelocity,
-                              impl::nedToEcef(value.accelerationVector, value.worldLocation),
-                              value.angularAcceleration};
+  lastSituation_ = impl::toSituation(value);
   invalidateCache();
 }
 

--- a/libs/util/src/dr/dead_reckoner_impl.cpp
+++ b/libs/util/src/dr/dead_reckoner_impl.cpp
@@ -115,23 +115,19 @@ Location toEcef(const GeodeticWorldLocation& latLonAlt) noexcept
   return result;
 }
 
+namespace
+{
+
+Quatd nedRotation(const GeodeticWorldLocation& latLonAlt) noexcept
+{
+  return Quatd {toRad(latLonAlt.longitude), -halfPi - toRad(latLonAlt.latitude), 0.0};
+}
+
+}  // namespace
+
 Orientation ecefToNed(const Orientation& value, const GeodeticWorldLocation& latLonAlt) noexcept
 {
-  // compute the NED trihedron at the point with the input latLonAlt
-  const auto [x0, y0, z0] = getNedTrihedron(latLonAlt);
-
-  // quaternion containing the orientation with respect to the ECEF coordinates
-  const Quatd inputOrientation {std_util::checkedConversion<double>(value.psi),
-                                std_util::checkedConversion<double>(value.theta),
-                                std_util::checkedConversion<double>(value.phi)};
-
-  // i and j unit vectors transformed with the input orientation quaternion
-  const auto xf = inputOrientation * Vec3d {1, 0, 0};
-  const auto yf = inputOrientation * Vec3d {0, 1, 0};
-
-  // calculate euler angles of the orientation with respect to NED using the transformed unit vectors and
-  // trigonometry
-  return eulerAnglesFromTrihedrons(x0, y0, z0, xf, yf);
+  return toOrientation((fromOrientationToQuat(value) * nedRotation(latLonAlt).inverse()).getRotateInEulerYPB());
 }
 
 Velocity ecefToNed(const Velocity& value, const GeodeticWorldLocation& geodeticPosition) noexcept
@@ -146,22 +142,7 @@ Acceleration ecefToNed(const Acceleration& value, const GeodeticWorldLocation& g
 
 Orientation nedToEcef(const Orientation& value, const GeodeticWorldLocation& latLonAlt) noexcept
 {
-  // compute the NED trihedron at the point with the input lat and lon
-  const auto [x0, y0, z0] = getNedTrihedron(latLonAlt);
-
-  // compute final x and y vectors resulting from the transformation of the orientation with respect to NED
-  const auto xf = Quatd {std_util::checkedConversion<double>(value.theta), y0} *
-                  Quatd {std_util::checkedConversion<double>(value.psi), z0} * x0;
-  const auto yf = Quatd {std_util::checkedConversion<double>(value.phi), x0} *
-                  Quatd {std_util::checkedConversion<double>(value.psi), z0} * y0;
-
-  // ECEF unit vectors
-  const Vec3d xi {1, 0, 0};
-  const Vec3d yi {0, 1, 0};
-  const Vec3d zi {0, 0, 1};
-
-  // euler angles to transform the ECEF trihedron to the final vectors
-  return eulerAnglesFromTrihedrons(xi, yi, zi, xf, yf);
+  return toOrientation((fromOrientationToQuat(value) * nedRotation(latLonAlt)).getRotateInEulerYPB());
 }
 
 Velocity nedToEcef(const Velocity& value, const GeodeticWorldLocation& location) noexcept
@@ -172,6 +153,43 @@ Velocity nedToEcef(const Velocity& value, const GeodeticWorldLocation& location)
 Acceleration nedToEcef(const Acceleration& value, const GeodeticWorldLocation& location) noexcept
 {
   return toAcceleration(nedToEcef(fromAcceleration(value), location));
+}
+
+GeodeticSituation toGeodeticSituation(const Situation& value) noexcept
+{
+  const auto geoLocation = toLla(value.worldLocation);
+
+  const auto rotation = nedRotation(geoLocation).inverse();
+
+  return GeodeticSituation {value.isFrozen,
+                            value.timeStamp,
+                            geoLocation,
+                            toOrientation((fromOrientationToQuat(value.orientation) * rotation).getRotateInEulerYPB()),
+                            toVelocity(rotation * fromVelocity(value.velocityVector)),
+                            value.angularVelocity,
+                            toAcceleration(rotation * fromAcceleration(value.accelerationVector)),
+                            value.angularAcceleration};
+}
+
+Situation toSituation(const GeodeticSituation& value,
+                      const Location& ecefPosition,
+                      const Orientation& ecefOrientation) noexcept
+{
+  const auto rotation = nedRotation(value.worldLocation);
+
+  return Situation {value.isFrozen,
+                    value.timeStamp,
+                    ecefPosition,
+                    ecefOrientation,
+                    toVelocity(rotation * fromVelocity(value.velocityVector)),
+                    value.angularVelocity,
+                    toAcceleration(rotation * fromAcceleration(value.accelerationVector)),
+                    value.angularAcceleration};
+}
+
+Situation toSituation(const GeodeticSituation& value) noexcept
+{
+  return toSituation(value, toEcef(value.worldLocation), nedToEcef(value.orientation, value.worldLocation));
 }
 
 Velocity bodyToNed(const Velocity& value, const Orientation& orientationNed) noexcept
@@ -239,12 +257,12 @@ void smoothImpl(Situation& situation, const Situation& update, const DrConfig& c
       // compute the delta rotation in angle/axis format
       f64 rotationAngle = 0;
       Vec3d rotationAxis {};
-      const auto q0 = fromOrientationToQuat(situation.orientation);
-      const auto q1 = fromOrientationToQuat(update.orientation);
-      const auto q01 = q0.inverse() * q1;
+      // worldToBody would rebuild this from the same angles, across a translation unit boundary.
+      const auto fromSmoothed = fromOrientationToQuat(situation.orientation).inverse();
+      const auto q01 = fromSmoothed * fromOrientationToQuat(update.orientation);
       q01.getRotate(rotationAngle, rotationAxis);
 
-      const auto deltaTheta = worldToBody(rotationAxis * rotationAngle, situation.orientation);
+      const auto deltaTheta = fromSmoothed * (rotationAxis * rotationAngle);
       const auto omega0 = fromAngularVelocity(situation.angularVelocity);
       const auto omega1 = fromAngularVelocity(update.angularVelocity);
 

--- a/libs/util/src/dr/quat.h
+++ b/libs/util/src/dr/quat.h
@@ -15,6 +15,10 @@
 #include "sen/core/base/compiler_macros.h"
 #include "sen/core/base/numbers.h"
 
+// std
+#include <algorithm>
+#include <cmath>
+
 namespace sen::util
 {
 
@@ -116,6 +120,9 @@ public:  // quaternion rotations
 
   void makeRotate(const Vec3<T>& from, const Vec3<T>& to) noexcept;
 
+  /// Returns the quaternion for a rotation of an angle about an axis.
+  [[nodiscard]] static Quat makeAxisRotation(T angle, const Vec3<T>& axis) noexcept;
+
   void makeRotate(T angle1,
                   const Vec3<T>& axis1,
                   T angle2,
@@ -164,12 +171,7 @@ inline Quat<T>::Quat(T x, T y, T z, T w) noexcept
 template <typename T>
 inline Quat<T>::Quat(T angle, const Vec3<T>& axis) noexcept
 {
-  v_[0] = static_cast<T>(0.0);
-  v_[1] = static_cast<T>(0.0);
-  v_[2] = static_cast<T>(0.0);
-  v_[3] = static_cast<T>(1.0);
-
-  makeRotate(angle, axis);
+  *this = makeAxisRotation(angle, axis);
 }
 
 template <typename T>
@@ -552,14 +554,36 @@ inline void Quat<T>::makeRotate(T angle1,
                                 T angle3,
                                 const Vec3<T>& axis3) noexcept
 {
-  Quat q1;
-  q1.makeRotate(angle1, axis1);
-  Quat q2;
-  q2.makeRotate(angle2, axis2);
-  Quat q3;
-  q3.makeRotate(angle3, axis3);
+  *this = makeAxisRotation(angle1, axis1) * makeAxisRotation(angle2, axis2) * makeAxisRotation(angle3, axis3);
+}
 
-  *this = q1 * q2 * q3;
+template <typename T>
+inline Quat<T> Quat<T>::makeAxisRotation(T angle, const Vec3<T>& axis) noexcept
+{
+  constexpr T epsilon = 0.0000001;
+
+  const T length2 = axis.getX() * axis.getX() + axis.getY() * axis.getY() + axis.getZ() * axis.getZ();
+
+  if (length2 < epsilon * epsilon)
+  {
+    return {};
+  }
+
+  const T cosHalfAngle = cos(0.5 * angle);
+  const T sinHalfAngle = sin(0.5 * angle);
+
+  // Unit axes need no normalisation, so the square root and the divisions are skipped.
+  if (length2 == T {1})
+  {
+    return {axis.getX() * sinHalfAngle, axis.getY() * sinHalfAngle, axis.getZ() * sinHalfAngle, cosHalfAngle};
+  }
+
+  const T length = std::sqrt(length2);
+
+  return {axis.getX() * sinHalfAngle / length,
+          axis.getY() * sinHalfAngle / length,
+          axis.getZ() * sinHalfAngle / length,
+          cosHalfAngle};
 }
 
 template <typename T>
@@ -619,14 +643,28 @@ inline void Quat<T>::getRotate(T& angle, T& x, T& y, T& z) const noexcept
 template <typename T>
 inline Vec3<T> Quat<T>::getRotateInEulerYPB() const noexcept
 {
-  T sqw = v_[3] * v_[3];
-  T sqx = v_[0] * v_[0];
-  T sqy = v_[1] * v_[1];
-  T sqz = v_[2] * v_[2];
+  const T sqw = v_[3] * v_[3];
+  const T sqx = v_[0] * v_[0];
+  const T sqy = v_[1] * v_[1];
+  const T sqz = v_[2] * v_[2];
 
-  T yaw = atan2(2.0 * (v_[0] * v_[1] + v_[2] * v_[3]), (sqx - sqy - sqz + sqw));
-  T pitch = asin(-2.0 * (v_[0] * v_[2] - v_[1] * v_[3]) / (sqx + sqy + sqz + sqw));
-  T bank = atan2(2.0 * (v_[1] * v_[2] + v_[0] * v_[3]), (-sqx - sqy + sqz + sqw));
+  const T sine = -2.0 * (v_[0] * v_[2] - v_[1] * v_[3]) / (sqx + sqy + sqz + sqw);
+
+  // At a right-angle pitch, yaw and bank turn about one axis and both arcs below lose all
+  // precision. The whole turn is reported as yaw. Folding a bank of up to pi costs about
+  // bank * cos(pitch), so this bound holds the error under 1e-6 rad. The pitch is not rounded.
+  constexpr T gimbalLimit = static_cast<T>(1) - static_cast<T>(1e-14);
+
+  if (std::abs(sine) > gimbalLimit)
+  {
+    return {static_cast<T>(2) * atan2(v_[2], v_[3]),
+            asin(std::clamp(sine, static_cast<T>(-1), static_cast<T>(1))),
+            static_cast<T>(0)};
+  }
+
+  const T yaw = atan2(2.0 * (v_[0] * v_[1] + v_[2] * v_[3]), (sqx - sqy - sqz + sqw));
+  const T pitch = asin(std::clamp(sine, static_cast<T>(-1), static_cast<T>(1)));
+  const T bank = atan2(2.0 * (v_[1] * v_[2] + v_[0] * v_[3]), (-sqx - sqy + sqz + sqw));
 
   return {yaw, pitch, bank};
 }

--- a/libs/util/src/dr/utils.cpp
+++ b/libs/util/src/dr/utils.cpp
@@ -191,11 +191,13 @@ Orientation extrapolateOrientation(const Orientation& value,
 
   // compute equivalent angular velocity in world coordinates (equivalent to ang vel and angular acceleration in the
   // delta extrapolated)
-  const auto eqOmega = bodyToWorld(fromAngularVelocity(angularVelocity), value) +
-                       bodyToWorld(fromAngularAcceleration(angularAcceleration), value) * 0.5 * deltaSeconds;
-
-  // compute orientation quaternion and rotate it
+  // bodyToWorld rebuilds this rotation on each call.
   auto orientationQuat = fromOrientationToQuat(value);
+
+  // compute equivalent angular velocity in world coordinates (equivalent to ang vel and angular acceleration in the
+  // delta extrapolated)
+  const auto eqOmega = orientationQuat * fromAngularVelocity(angularVelocity) +
+                       orientationQuat * fromAngularAcceleration(angularAcceleration) * 0.5 * deltaSeconds;
   orientationQuat.makeRotate(eqOmega.length() * deltaSeconds, eqOmega);
 
   return toOrientation(orientationQuat.getRotateInEulerYPB());

--- a/libs/util/test/dead_reckoner_test.cpp
+++ b/libs/util/test/dead_reckoner_test.cpp
@@ -20,6 +20,9 @@
 
 // std
 #include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
 
 namespace sen::util
 {
@@ -332,6 +335,313 @@ TEST(DeadReckonerTest, geodeticSituationCacheInvalidatedOnUpdate)
   dr.updateGeodeticSituation(input2);
 
   EXPECT_FALSE(dr.isGeodeticSituationCached(queryTime));
+}
+
+namespace
+{
+
+// The conversions as they read before the rotation was shared, so bit exactness is checked.
+GeodeticSituation referenceGeodeticSituation(const Situation& value)
+{
+  const auto geoLocation = impl::toLla(value.worldLocation);
+  return GeodeticSituation {value.isFrozen,
+                            value.timeStamp,
+                            geoLocation,
+                            impl::ecefToNed(value.orientation, geoLocation),
+                            impl::ecefToNed(value.velocityVector, geoLocation),
+                            value.angularVelocity,
+                            impl::ecefToNed(value.accelerationVector, geoLocation),
+                            value.angularAcceleration};
+}
+
+Situation referenceSituation(const GeodeticSituation& value)
+{
+  return Situation {value.isFrozen,
+                    value.timeStamp,
+                    impl::toEcef(value.worldLocation),
+                    impl::nedToEcef(value.orientation, value.worldLocation),
+                    impl::nedToEcef(value.velocityVector, value.worldLocation),
+                    value.angularVelocity,
+                    impl::nedToEcef(value.accelerationVector, value.worldLocation),
+                    value.angularAcceleration};
+}
+
+// Equator, two mid latitudes and both poles beside the date line, to take both branches in toEcef.
+const GeodeticSituation geodeticSamples[] = {
+  {false,
+   initialTimeStamp,
+   {0.0, 0.0, 0.0},
+   {0.1, 0.2, 0.3},
+   {10, -20, 35},
+   {0.01, 0.02, 0.03},
+   {1.0, -2.0, 0.5},
+   {0.001, 0.002, 0.003}},
+  {false,
+   initialTimeStamp,
+   {48.8566, 2.3522, 35.0},
+   {1.2, -0.4, 2.9},
+   {-120, 45, -8},
+   {0.2, 0.0, -0.1},
+   {-1.5, 0.25, 3.0},
+   {0.03, -0.01, 0.0}},
+  {false,
+   initialTimeStamp,
+   {-33.8688, 151.2093, 120.0},
+   {-2.0, 0.9, -1.1},
+   {300, 0, 12},
+   {0.0, 0.5, 0.0},
+   {0.0, 0.0, -9.81},
+   {0.0, 0.2, 0.0}},
+  {false,
+   initialTimeStamp,
+   {89.5, -179.5, 11000.0},
+   {0.5, 0.5, 0.5},
+   {5, 5, 5},
+   {0.1, 0.1, 0.1},
+   {1.0, 1.0, 1.0},
+   {0.01, 0.01, 0.01}},
+  {false,
+   initialTimeStamp,
+   {-89.9, 179.9, -50.0},
+   {3.0, -1.5, 0.2},
+   {-7, 3, 90},
+   {-0.3, 0.0, 0.4},
+   {2.0, -2.0, 0.0},
+   {0.0, -0.05, 0.02}},
+};
+
+void expectSameOrientation(const Orientation& expected, const Orientation& actual)
+{
+  EXPECT_EQ(expected.psi.get(), actual.psi.get());
+  EXPECT_EQ(expected.theta.get(), actual.theta.get());
+  EXPECT_EQ(expected.phi.get(), actual.phi.get());
+}
+
+void expectSameSituation(const Situation& expected, const Situation& actual)
+{
+  EXPECT_EQ(expected.isFrozen, actual.isFrozen);
+  EXPECT_EQ(expected.timeStamp, actual.timeStamp);
+  EXPECT_EQ(expected.worldLocation.x.get(), actual.worldLocation.x.get());
+  EXPECT_EQ(expected.worldLocation.y.get(), actual.worldLocation.y.get());
+  EXPECT_EQ(expected.worldLocation.z.get(), actual.worldLocation.z.get());
+  expectSameOrientation(expected.orientation, actual.orientation);
+  EXPECT_EQ(expected.velocityVector.x.get(), actual.velocityVector.x.get());
+  EXPECT_EQ(expected.velocityVector.y.get(), actual.velocityVector.y.get());
+  EXPECT_EQ(expected.velocityVector.z.get(), actual.velocityVector.z.get());
+  EXPECT_EQ(expected.accelerationVector.x.get(), actual.accelerationVector.x.get());
+  EXPECT_EQ(expected.accelerationVector.y.get(), actual.accelerationVector.y.get());
+  EXPECT_EQ(expected.accelerationVector.z.get(), actual.accelerationVector.z.get());
+  EXPECT_EQ(expected.angularVelocity.x.get(), actual.angularVelocity.x.get());
+  EXPECT_EQ(expected.angularVelocity.y.get(), actual.angularVelocity.y.get());
+  EXPECT_EQ(expected.angularVelocity.z.get(), actual.angularVelocity.z.get());
+  EXPECT_EQ(expected.angularAcceleration.x.get(), actual.angularAcceleration.x.get());
+  EXPECT_EQ(expected.angularAcceleration.y.get(), actual.angularAcceleration.y.get());
+  EXPECT_EQ(expected.angularAcceleration.z.get(), actual.angularAcceleration.z.get());
+}
+
+void expectSameGeodeticSituation(const GeodeticSituation& expected, const GeodeticSituation& actual)
+{
+  EXPECT_EQ(expected.isFrozen, actual.isFrozen);
+  EXPECT_EQ(expected.timeStamp, actual.timeStamp);
+  EXPECT_EQ(expected.worldLocation.latitude.get(), actual.worldLocation.latitude.get());
+  EXPECT_EQ(expected.worldLocation.longitude.get(), actual.worldLocation.longitude.get());
+  EXPECT_EQ(expected.worldLocation.altitude.get(), actual.worldLocation.altitude.get());
+  expectSameOrientation(expected.orientation, actual.orientation);
+  EXPECT_EQ(expected.velocityVector.x.get(), actual.velocityVector.x.get());
+  EXPECT_EQ(expected.velocityVector.y.get(), actual.velocityVector.y.get());
+  EXPECT_EQ(expected.velocityVector.z.get(), actual.velocityVector.z.get());
+  EXPECT_EQ(expected.accelerationVector.x.get(), actual.accelerationVector.x.get());
+  EXPECT_EQ(expected.accelerationVector.y.get(), actual.accelerationVector.y.get());
+  EXPECT_EQ(expected.accelerationVector.z.get(), actual.accelerationVector.z.get());
+  EXPECT_EQ(expected.angularVelocity.x.get(), actual.angularVelocity.x.get());
+  EXPECT_EQ(expected.angularVelocity.y.get(), actual.angularVelocity.y.get());
+  EXPECT_EQ(expected.angularVelocity.z.get(), actual.angularVelocity.z.get());
+  EXPECT_EQ(expected.angularAcceleration.x.get(), actual.angularAcceleration.x.get());
+  EXPECT_EQ(expected.angularAcceleration.y.get(), actual.angularAcceleration.y.get());
+  EXPECT_EQ(expected.angularAcceleration.z.get(), actual.angularAcceleration.z.get());
+}
+
+}  // namespace
+
+/// @test
+/// Tests that sharing the rotation leaves every field of the geodetic conversion bit for bit equal
+/// @requirements(SEN-1058)
+TEST(DeadReckonerTest, geodeticConversionUnchangedBySharedRotation)
+{
+  for (const auto& sample: geodeticSamples)
+  {
+    const auto ecefSample = referenceSituation(sample);
+    expectSameGeodeticSituation(referenceGeodeticSituation(ecefSample), impl::toGeodeticSituation(ecefSample));
+  }
+}
+
+/// @test
+/// Tests the same for the conversion to ECEF, through both overloads
+/// @requirements(SEN-1058)
+TEST(DeadReckonerTest, ecefConversionUnchangedBySharedRotation)
+{
+  for (const auto& sample: geodeticSamples)
+  {
+    const auto expected = referenceSituation(sample);
+    expectSameSituation(expected, impl::toSituation(sample));
+    expectSameSituation(
+      expected,
+      impl::toSituation(
+        sample, impl::toEcef(sample.worldLocation), impl::nedToEcef(sample.orientation, sample.worldLocation)));
+  }
+}
+
+/// @test
+/// Tests that the angular acceleration of a geodetic situation survives the conversion to ECEF
+/// @requirements(SEN-1058)
+TEST(DeadReckonerTest, angularAccelerationSurvivesEcefConversion)
+{
+  const GeodeticSituation input {
+    false, initialTimeStamp, {40.741895, -73.989308, 30.0}, {}, {10, -20, 35}, {}, {}, {0.25, -0.5, 0.75}};
+
+  const auto result = impl::toSituation(input);
+
+  EXPECT_EQ(0.25, result.angularAcceleration.x.get());
+  EXPECT_EQ(-0.5, result.angularAcceleration.y.get());
+  EXPECT_EQ(0.75, result.angularAcceleration.z.get());
+}
+
+namespace
+{
+
+// The orientation conversions as they read before becoming a quaternion composition.
+Orientation referenceEcefToNed(const Orientation& value, const GeodeticWorldLocation& latLonAlt)
+{
+  const auto [x0, y0, z0] = getNedTrihedron(latLonAlt);
+  const Quatd inputOrientation {
+    static_cast<double>(value.psi.get()), static_cast<double>(value.theta.get()), static_cast<double>(value.phi.get())};
+  const auto xf = inputOrientation * Vec3d {1, 0, 0};
+  const auto yf = inputOrientation * Vec3d {0, 1, 0};
+  return eulerAnglesFromTrihedrons(x0, y0, z0, xf, yf);
+}
+
+Orientation referenceNedToEcef(const Orientation& value, const GeodeticWorldLocation& latLonAlt)
+{
+  const auto [x0, y0, z0] = getNedTrihedron(latLonAlt);
+  const auto xf =
+    Quatd {static_cast<double>(value.theta.get()), y0} * Quatd {static_cast<double>(value.psi.get()), z0} * x0;
+  const auto yf =
+    Quatd {static_cast<double>(value.phi.get()), x0} * Quatd {static_cast<double>(value.psi.get()), z0} * y0;
+  return eulerAnglesFromTrihedrons(Vec3d {1, 0, 0}, Vec3d {0, 1, 0}, Vec3d {0, 0, 1}, xf, yf);
+}
+
+// Euler angles are degenerate at a right-angle pitch, so two correct answers can differ there. The
+// rotation they denote must not: this is the angle between two of them.
+double rotationGap(const Orientation& lhs, const Orientation& rhs)
+{
+  const Quatd a {
+    static_cast<double>(lhs.psi.get()), static_cast<double>(lhs.theta.get()), static_cast<double>(lhs.phi.get())};
+  const Quatd b {
+    static_cast<double>(rhs.psi.get()), static_cast<double>(rhs.theta.get()), static_cast<double>(rhs.phi.get())};
+  return 2.0 * std::acos(std::min(1.0, std::abs(a.dot(b))));
+}
+
+// A millimetre at a kilometre of lever arm, and sixteen times the last bit of the f32 storing it.
+constexpr double orientationTolerance = 1e-6;
+
+}  // namespace
+
+/// @test
+/// Tests that the quaternion composition reproduces the trihedron construction it replaced, away
+/// from the pitch limit where yaw and bank cannot be separated
+/// @requirements(SEN-1058)
+TEST(DeadReckonerTest, orientationConversionMatchesTrihedronConstruction)
+{
+  double worst = 0.0;
+
+  for (int lat = -90; lat <= 90; lat += 15)
+  {
+    for (int lon = -180; lon <= 180; lon += 45)
+    {
+      for (int yaw = -180; yaw <= 180; yaw += 45)
+      {
+        for (const double pitch: {-85.0, -60.0, -30.0, 0.0, 30.0, 60.0, 85.0})
+        {
+          for (int bank = -180; bank <= 180; bank += 90)
+          {
+            const GeodeticWorldLocation position {static_cast<double>(lat), static_cast<double>(lon), 250.0};
+            const Orientation input {static_cast<float>(yaw * M_PI / 180.0),
+                                     static_cast<float>(pitch * M_PI / 180.0),
+                                     static_cast<float>(bank * M_PI / 180.0)};
+
+            const auto converted = impl::ecefToNed(input, position);
+            ASSERT_FALSE(std::isnan(converted.psi.get()) || std::isnan(converted.theta.get()) ||
+                         std::isnan(converted.phi.get()));
+            worst = std::max(worst, rotationGap(referenceEcefToNed(input, position), converted));
+          }
+        }
+      }
+    }
+  }
+
+  EXPECT_LT(worst, orientationTolerance);
+}
+
+/// @test
+/// Tests that converting an orientation to NED and back returns the rotation it started from
+/// @requirements(SEN-1058)
+TEST(DeadReckonerTest, orientationConversionRoundTrips)
+{
+  double worst = 0.0;
+
+  for (int lat = -90; lat <= 90; lat += 15)
+  {
+    for (int lon = -180; lon <= 180; lon += 45)
+    {
+      for (int yaw = -180; yaw <= 180; yaw += 45)
+      {
+        for (const double pitch: {-90.0, -89.99, -45.0, 0.0, 45.0, 89.99, 90.0})
+        {
+          for (int bank = -180; bank <= 180; bank += 90)
+          {
+            const GeodeticWorldLocation position {static_cast<double>(lat), static_cast<double>(lon), 0.0};
+            const Orientation input {static_cast<float>(yaw * M_PI / 180.0),
+                                     static_cast<float>(pitch * M_PI / 180.0),
+                                     static_cast<float>(bank * M_PI / 180.0)};
+
+            const auto back = impl::nedToEcef(impl::ecefToNed(input, position), position);
+            ASSERT_FALSE(std::isnan(back.psi.get()) || std::isnan(back.theta.get()) || std::isnan(back.phi.get()));
+            worst = std::max(worst, rotationGap(input, back));
+          }
+        }
+      }
+    }
+  }
+
+  EXPECT_LT(worst, orientationTolerance);
+}
+
+/// @test
+/// Tests that extrapolating with no rotation to apply returns the orientation it was given
+/// @requirements(SEN-1058)
+TEST(DeadReckonerTest, orientationExtrapolationHoldsStillAtThePitchLimit)
+{
+  const sen::Duration step {std::chrono::milliseconds(16)};
+
+  for (const double pitchDeg: {-90.0, -89.999, -45.0, 0.0, 45.0, 89.999, 90.0})
+  {
+    for (int yawDeg = -180; yawDeg <= 180; yawDeg += 45)
+    {
+      for (int bankDeg = -165; bankDeg <= 165; bankDeg += 35)
+      {
+        const Orientation input {static_cast<float>(yawDeg * M_PI / 180.0),
+                                 static_cast<float>(pitchDeg * M_PI / 180.0),
+                                 static_cast<float>(bankDeg * M_PI / 180.0)};
+
+        const auto held = extrapolateOrientation(input, step, AngularVelocity {});
+
+        ASSERT_FALSE(std::isnan(held.psi.get()) || std::isnan(held.theta.get()) || std::isnan(held.phi.get()))
+          << "yaw " << yawDeg << " pitch " << pitchDeg << " bank " << bankDeg;
+        EXPECT_LT(rotationGap(input, held), orientationTolerance)
+          << "yaw " << yawDeg << " pitch " << pitchDeg << " bank " << bankDeg;
+      }
+    }
+  }
 }
 
 }  // namespace sen::util

--- a/libs/util/test/quat_test.cpp
+++ b/libs/util/test/quat_test.cpp
@@ -20,6 +20,9 @@
 // gtest
 #include <gtest/gtest.h>
 
+// std
+#include <cmath>
+
 using namespace sen::util;  // NOLINT
 
 /// @test
@@ -181,4 +184,31 @@ TEST(QuaternionTest, slerp)
   ASSERT_NEAR(toDeg(eulerAngles.getX()), 0, 0.001);
   ASSERT_NEAR(toDeg(eulerAngles.getY()), 0, 0.001);
   ASSERT_NEAR(toDeg(eulerAngles.getZ()), 23, 0.001);
+}
+
+/// @test
+/// Check that Euler angles recovered from a quaternion rebuild the same rotation at a right-angle
+/// pitch, where yaw and bank turn about one axis
+/// @requirements(SEN-1060)
+TEST(QuaternionTest, eulerRecoveryAtThePitchLimit)
+{
+  for (const double pitchDeg: {-90.0, -89.999, -89.0, 89.0, 89.999, 90.0})
+  {
+    for (int yawDeg = -180; yawDeg <= 180; yawDeg += 30)
+    {
+      for (int bankDeg = -180; bankDeg <= 180; bankDeg += 45)
+      {
+        const Quatd built {toRad(yawDeg), toRad(pitchDeg), toRad(bankDeg)};
+        const auto recovered = built.getRotateInEulerYPB();
+
+        ASSERT_FALSE(std::isnan(recovered.getX()) || std::isnan(recovered.getY()) || std::isnan(recovered.getZ()));
+
+        const Quatd rebuilt {recovered.getX(), recovered.getY(), recovered.getZ()};
+
+        // The angles may differ where the pair is degenerate. The rotation they denote may not.
+        EXPECT_LT(2.0 * std::acos(std::min(1.0, std::abs(built.dot(rebuilt)))), 1e-6)
+          << "yaw " << yawDeg << " pitch " << pitchDeg << " bank " << bankDeg;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Measured with google-benchmark, gcc-12 Release, six interleaved rounds of eight repetitions:

| | before | after | |
|---|---|---|---|
| publish, `updateGeodeticSituation` | 206 ns | 100 ns | -51% |
| read, smoothing disabled | 637 ns | 238 ns | -63% |
| read, smoothing enabled | 645 ns | 490 ns | -24% |
| `ecefToNed` on an orientation | 116 ns | 58 ns | -50% |

`toLla` and `toEcef` are untouched by this change and moved 1.5% and 1.0%. A background process was running on the host during the run, and those two numbers are how we know it did not affect the result: another process taking CPU would have moved all six, not four. The absolute figures were taken with it running, so a clean machine should show the same ratios at lower numbers.

The composition is the only part that changes results, and the bar set for it is agreement to under 1e-6 rad with the old code, away from the pitch limit. These angles are stored as f32, whose last bit near one radian is 6e-08, so the bar is about sixteen times the storage granularity. Whether that is the right bar is a judgement and worth a second opinion.

Where the pitch reaches a right angle, yaw and bank turn about the same axis and both lose precision. Inside a band at `1 - 1e-14` on the sine, the whole turn is reported as yaw and the bank is set to zero. The band comes from the cost of folding one into the other: a cosine near 1.4e-7 keeps the error under a part in a million of a radian.

`nedToEcef` was wrong, not only slow. It omitted the pitch rotation when building the body Y axis, so anything that set a geodetic situation and read the roll back got a wrong number whenever pitch and bank were both non-zero. Code may have been written around that.

#140 also changes `smoothImpl`, for a different reason. The two are compatible: one line collides, and a wrong resolution does not compile.