### PR TITLE
ci: match the pre-commit python version across both call sites

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,7 +11,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+      # pre-commit/action puts the interpreter path in its cache key, so this
+      # has to match nightly.yaml or the two keys will not line up.
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: 3.x
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
         with:
           extra_args: --from-ref origin/main --to-ref HEAD

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -499,9 +499,9 @@ stack**, and the pull request it blocks is not necessarily the one being merged.
   lifetime; the first run of a day (or after the cache was removed) is the
   slow one. The arm configuration pays it on every run, because nothing
   writes its cache entry; see the caches paragraph under Dependencies.
-- The pull-request pipeline does not follow the save-on-main rule everywhere.
-  `pre-commit/action` caches the hook environments itself and saves from every
-  pull request, so each open pull request stores its own copy.
+- `pre-commit/action` caches the hook environments itself, and its key includes
+  the interpreter path. Both call sites have to ask `setup-python` for the same
+  version, or a pull request cannot restore what the nightly saved.
 - clang-tidy and the sanitizers run only at night. Planned pull-request
   additions -- a combined ASan+UBSan build, TSan for tests with the
   `threading` label, and clang-tidy on the changed lines -- are tracked in


### PR DESCRIPTION
## What and why

`pre-commit/action` builds its cache key from the interpreter path, and only
`nightly.yaml` was setting a python version. Pull requests got a different key,
and the action sets no `restore-keys`, so they never restored what the nightly
wrote. Each saved its own 122 MB copy: 28 of them, 3.42 GB.

Setting the same version in both places fixes it. On the previous run of this
pull request the lint job restored the 124 MB entry from `main` and saved
nothing.

`3.x` resolves to whatever the runner has, so a runner update will move the key
until `main` runs again. An explicit version in both places would avoid that.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [ ] Tests cover the change where practical
- [x] `conan.lock` was regenerated if `conanfile.py` changed
