### PR TITLE
ci: stop the packaging jobs writing the shared ccache

### DIFF
--- a/.github/workflows/conan.yaml
+++ b/.github/workflows/conan.yaml
@@ -70,14 +70,6 @@ jobs:
           key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ env.cache_date }}
           restore-keys: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-
 
-      - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
-        if: runner.os == 'Linux'
-        with:
-          key: ${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ matrix.build_type }}
-          max-size: 1G
-          verbose: 1
-          save: ${{ github.ref == 'refs/heads/main' }}
-
       - name: Setup build context
         uses: ./.github/actions/setup_build_context
         with:
@@ -88,7 +80,6 @@ jobs:
       - name: Create conan package
         shell: bash
         run: |
-          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           # build_type applies to the sen package only; dependencies stay at
           # the profiles' Release default, shared across build types and
           # matching what binary remotes serve. Scoped by name rather than &

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -219,10 +219,20 @@ source servers being reachable at that moment.
 
 ccache: one entry per runner, compiler, build type and run. The action that
 writes it puts a timestamp in the key, so every run on main leaves a new entry
-and the previous one stays until it is evicted. The nightly sanitizer runs
-reuse the conan cache (dependencies build without sanitizer flags) but do not
-use ccache: object files built with sanitizer flags must not end up in the
-normal cache entries.
+and the previous one stays until it is evicted.
+
+**Only the test workflow keeps a ccache.** `conan create` compiles in a folder
+whose name changes every run, so its object files never match the ones a test
+build produces, and the two workflows shared a key. Whichever wrote last won, and
+because the nightly runs the packaging workflow without the test workflow, the
+packaging objects won almost every day. Pull requests were then restoring
+hundreds of megabytes that hit on about one compile in five hundred. The
+packaging jobs now compile without ccache.
+
+This is the same rule as the nightly sanitizer runs, which reuse the conan cache
+(dependencies build without sanitizer flags) but do not use ccache: object files
+from a different kind of build must not land in the entries the ordinary builds
+depend on.
 
 ## The build image
 


### PR DESCRIPTION
## What and why

Both workflows wrote the same ccache key, but `conan create` compiles in a folder
whose name changes every run, so neither can use the other's objects. The nightly
runs packaging without the test workflow, so the packaging objects won on most
days and pull requests restored 871 MB for 2 hits out of 928.

Packaging now builds without ccache. Pull requests get the lineage they can use,
and one cache family goes away, freeing about 1.7 GB. The cost is that packaging
on main and in the merge queue builds cold.

The PATH export goes too, since nothing installs ccache there any more.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [x] Tests cover the change where practical
- [x] `conan.lock` was regenerated if `conanfile.py` changed
