### PR TITLE
ci: let every matrix configuration report its own result

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -66,7 +66,8 @@ jobs:
     # standard_test.yaml rather than the cheap jobs.
     timeout-minutes: 120
     strategy:
-      fail-fast: true
+      # Same reason as standard_test.yaml.
+      fail-fast: false
       matrix:
         include: ${{ fromJson(needs.compute-matrix-jobs.outputs.jobs) }}
     env:

--- a/.github/workflows/conan.yaml
+++ b/.github/workflows/conan.yaml
@@ -45,7 +45,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     strategy:
-      fail-fast: true
+      # Same reason as standard_test.yaml.
+      fail-fast: false
       matrix:
         include: ${{ fromJson(needs.compute-matrix-jobs.outputs.jobs) }}
     env:

--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -43,7 +43,10 @@ jobs:
       # per cent: 20 to 30 minutes, so this is around four times the work.
     timeout-minutes: 120
     strategy:
-      fail-fast: true
+      # One failing configuration used to cancel the others, so a pull request
+      # learned one verdict instead of four and a fix could not be checked until
+      # an unrelated one landed.
+      fail-fast: false
       matrix:
         include: ${{ fromJson(needs.compute-matrix-jobs.outputs.jobs) }}
     env:

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -165,6 +165,13 @@ pre-commit hook, and one of them asserts that every declared job is selected
 by some workflow, so a job that reads as coverage but can never run does not
 survive.
 
+**The matrix does not stop at the first failure.** One configuration failing used
+to cancel the others, so a pull request reported one verdict where four were
+wanted, and a fix could not be checked while an unrelated configuration was
+broken. Every configuration now runs to its own result. The cost is runner time
+spent on a commit that is already failing, which is accepted because the
+alternative is a verdict nobody can act on.
+
 Besides compiler, build type and language standard, each job carries three
 switches: whether it builds the examples, the docker base image for the
 container-based integration tests (empty means the job does not run them;


### PR DESCRIPTION
## What and why

A failing configuration cancelled its siblings, so a pull request reported one
verdict where four were wanted. It also meant a fix for one configuration could
not be checked while an unrelated one was broken: #136's arm result has never
existed for this reason.

All three matrices now run every configuration to its own result — the test
matrix, packaging, and the release build. The release one matters most per
failure, since its later job needs every artifact, so a partial failure blocks the
release anyway and learning about one failure per tag means re-tagging to find the
next.

The cost is runner time on a commit that is already failing.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [x] Tests cover the change where practical
- [x] `conan.lock` was regenerated if `conanfile.py` changed
