### PR TITLE
ci: export the image layer cache once per job

### DIFF
--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -29,8 +29,9 @@ jobs:
 
       # Proves the Dockerfile builds; no registry hosts the image, so the
       # devcontainer and any self-hosted machine build it from this file.
-      # Layer caching in the Actions cache keeps unchanged rebuilds fast; only
-      # the final layers are cached, since nothing here builds on this image.
+      # Only the dev build below exports. dev is built on base, so its export
+      # already carries these layers; a second export here would replace that
+      # manifest with one the dev build cannot use.
       - name: Build image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
@@ -43,7 +44,6 @@ jobs:
           load: true
           tags: sen-ci:probe
           cache-from: type=gha
-          cache-to: type=gha,mode=min
 
       # Every tool below has been missing at some point, and a missing tool
       # shows up as a check that silently analysed nothing or a configure step


### PR DESCRIPTION
## What and why

Both builds in the image job export to the same cache scope, so the base build's
export replaces the complete manifest before the dev build reads it. The dev
layer then misses and is re-uploaded on every merge, about 40 MB and 30 seconds.
Dropping the first export leaves the dev build's, which already carries the base
layers because `Dockerfile:129` reads `FROM base AS dev`.

On a pull request the dev build has seven cached steps, on a push six, and the
missing one is the dev layer. Jobs 98714354211 and 98704759829 against
98698586887.

This run writes nothing either way, so it will not show the difference. The
first push to main after merge will.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [ ] Tests cover the change where practical. Nothing tests the workflow's
      cache setup, and asserting a key is absent would not prove the behaviour.
- [x] `conan.lock` was regenerated if `conanfile.py` changed. Not touched.
