### PR TITLE
fix(kernel): make @env substitution match its documentation

### DIFF
--- a/libs/kernel/CMakeLists.txt
+++ b/libs/kernel/CMakeLists.txt
@@ -38,6 +38,8 @@ set(detail_headers include/sen/kernel/detail/kernel_fwd.h)
 
 set(sources
     src/bootloader.cpp
+    src/env_substitution.h
+    src/env_substitution.cpp
     src/component_api_impl.cpp
     src/executor.h
     src/executor.cpp

--- a/libs/kernel/src/bootloader.cpp
+++ b/libs/kernel/src/bootloader.cpp
@@ -7,6 +7,9 @@
 
 #include "sen/kernel/bootloader.h"
 
+// kernel
+#include "env_substitution.h"
+
 // sen
 #include "sen/core/base/assert.h"
 #include "sen/core/base/duration.h"
@@ -43,7 +46,6 @@
 #include <iterator>
 #include <map>
 #include <memory>
-#include <regex>
 #include <set>
 #include <string>
 #include <string_view>
@@ -194,8 +196,13 @@ void importYaml(c4::yml::Tree& into, c4::yml::ConstNodeRef from, const std::file
   std::string fileContents;
   readFile(path.parent_path() / fileString, fileContents);
 
-  c4::substr fileData = into.alloc_arena(fileContents.size());
-  fileData.copy_from(c4::to_csubstr(fileContents));
+  // An included file gets the same expansion as the top-level one. Without it a
+  // pattern here reached the tree as literal text and an unset variable passed
+  // silently, both of which the documentation says cannot happen.
+  const std::string expandedContents = impl::replaceEnvPattern(fileContents);
+
+  c4::substr fileData = into.alloc_arena(expandedContents.size());
+  fileData.copy_from(c4::to_csubstr(expandedContents));
   c4::yml::Tree fileTree = c4::yml::parse_in_place(fileData);
 
   into.merge_with(&fileTree, fileTree.root_id(), into.root_id());
@@ -290,82 +297,9 @@ void combineRepeatedElements(c4::yml::NodeRef node, c4::yml::Tree* tree, std::st
   }
 }
 
-[[nodiscard]] std::string replaceEnvPattern(const std::string& content)
-{
-  std::string expandedContent = content;
-  std::regex pattern(R"((\\*)@env\(([a-zA-Z_$][\w]*)(,([\w]+))?\))");
-
-  auto begin = std::sregex_iterator(expandedContent.begin(), expandedContent.end(), pattern);
-  auto end = std::sregex_iterator();
-
-  std::string result;
-  std::string::const_iterator last = expandedContent.begin();
-
-  for (auto i = begin; i != end; ++i)
-  {
-    const std::smatch& match = *i;
-    result.append(last, match[0].first);
-    last = match[0].second;
-
-    // Extract the environment variable name
-    std::string envVar = match[2].str();
-
-    // Get the environment variable value
-    const char* envValue = std::getenv(envVar.c_str());
-    std::string value;
-
-    if (envValue)
-    {
-      value = std::string(envValue);
-    }
-    else if (match[4].matched)
-    {
-      // Use the default value from the second group if the environment variable is not found
-      value = match[4].str();
-    }
-    else
-    {
-      // Replace with VARIABLE_NOT_FOUND string
-      throwRuntimeError("environment variable " + envVar + " not found and no default value provided");
-    }
-
-    // Count the number of backslashes before the match
-    std::string backslashes = match[1].str();
-    size_t backslashCount = backslashes.size();
-    auto halvedBackslashCount = static_cast<int>(std::round(backslashCount * 0.5));  // NOLINT
-    // If there are an even number of backslashes, halve them and resolve the variable
-    if (backslashCount % 2 == 0)
-    {
-      if (backslashCount == 0)
-      {
-        result += value;
-      }
-      else
-      {
-        result += std::string(halvedBackslashCount, '\\') + value;
-      }
-    }
-    else
-    {
-      // If there are an odd number of backslashes, replace the last backslash with the @env pattern
-      result += std::string(halvedBackslashCount - 1, '\\') + "@env(" + envVar;
-      if (match[4].matched)
-      {
-        result += "," + match[4].str();
-      }
-      result += ")";
-    }
-  }
-
-  // Ensure both iterators are of the same type
-  result.append(last, expandedContent.cend());
-  return result;
-}
-
 [[nodiscard]] c4::yml::Tree loadYamlFromString(const std::string& content, const std::filesystem::path& path)
 {
-  // Use std::regex_replace to perform the replacement
-  const std::string expandedContent = replaceEnvPattern(content);
+  const std::string expandedContent = impl::replaceEnvPattern(content);
   c4::yml::Tree root = c4::yml::parse_in_arena(c4::to_csubstr(expandedContent));
 
   bool hasIncludes = false;

--- a/libs/kernel/src/env_substitution.cpp
+++ b/libs/kernel/src/env_substitution.cpp
@@ -1,0 +1,80 @@
+// === env_substitution.cpp ============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#include "env_substitution.h"
+
+// sen
+#include "sen/core/base/assert.h"
+
+// std
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <regex>
+#include <string>
+
+namespace sen::kernel::impl
+{
+
+std::string replaceEnvPattern(const std::string& content)
+{
+  // Horizontal whitespace around the comma is accepted: @env(VAR, fallback) is the
+  // form the documentation shows, and rejecting it left the text in the configuration
+  // with no diagnostic. Spaces only, so a pattern can never span lines.
+  const std::regex pattern(R"((\\*)@env\(([a-zA-Z_$][\w]*)([ \t]*,[ \t]*([\w]+))?[ \t]*\))");
+
+  auto begin = std::sregex_iterator(content.begin(), content.end(), pattern);
+  auto end = std::sregex_iterator();
+
+  std::string result;
+  std::string::const_iterator last = content.begin();
+
+  for (auto i = begin; i != end; ++i)
+  {
+    const std::smatch& match = *i;
+    result.append(last, match[0].first);
+    last = match[0].second;
+
+    const std::string envVar = match[2].str();
+    const std::size_t backslashCount = match[1].str().size();
+    const auto halvedBackslashCount = static_cast<int>(std::round(static_cast<double>(backslashCount) * 0.5));
+
+    // The escape is honoured before the variable is read. Looking it up first made an
+    // unset variable abort startup on text that was going to be reproduced verbatim.
+    if (backslashCount % 2 != 0)
+    {
+      result += std::string(halvedBackslashCount - 1, '\\') + "@env(" + envVar;
+      if (match[4].matched)
+      {
+        result += "," + match[4].str();
+      }
+      result += ")";
+      continue;
+    }
+
+    std::string value;
+    if (const char* envValue = std::getenv(envVar.c_str()); envValue != nullptr)
+    {
+      value = std::string(envValue);
+    }
+    else if (match[4].matched)
+    {
+      value = match[4].str();
+    }
+    else
+    {
+      throwRuntimeError("environment variable " + envVar + " not found and no default value provided");
+    }
+
+    result += std::string(halvedBackslashCount, '\\') + value;
+  }
+
+  result.append(last, content.cend());
+  return result;
+}
+
+}  // namespace sen::kernel::impl

--- a/libs/kernel/src/env_substitution.h
+++ b/libs/kernel/src/env_substitution.h
@@ -1,0 +1,24 @@
+// === env_substitution.h ==============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#ifndef SEN_LIBS_KERNEL_SRC_ENV_SUBSTITUTION_H
+#define SEN_LIBS_KERNEL_SRC_ENV_SUBSTITUTION_H
+
+// std
+#include <string>
+
+namespace sen::kernel::impl
+{
+
+/// Expands every @env(NAME) and @env(NAME, DEFAULT) found in configuration text.
+/// Throws when a variable is unset and carries no default. A backslash escapes the
+/// pattern: an odd number of them leaves the text in place and reads no variable.
+[[nodiscard]] std::string replaceEnvPattern(const std::string& content);
+
+}  // namespace sen::kernel::impl
+
+#endif  // SEN_LIBS_KERNEL_SRC_ENV_SUBSTITUTION_H

--- a/libs/kernel/test/unit/CMakeLists.txt
+++ b/libs/kernel/test/unit/CMakeLists.txt
@@ -8,6 +8,7 @@
 add_sen_unit_test_suite(
   kernel_test
   bus/remote_interest_handler_test.cpp
+  env_substitution_test.cpp
   test_kernel/test_kernel_test.cpp
   LINK_DEPS
   sen::core

--- a/libs/kernel/test/unit/env_substitution_test.cpp
+++ b/libs/kernel/test/unit/env_substitution_test.cpp
@@ -1,0 +1,188 @@
+// === env_substitution_test.cpp =======================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// kernel
+#include "env_substitution.h"
+#include "sen/kernel/bootloader.h"
+
+// sen
+#include "sen/core/base/assert.h"
+#include "sen/core/meta/var.h"
+
+// gtest
+#include <gtest/gtest.h>
+
+// std
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using sen::kernel::impl::replaceEnvPattern;
+
+namespace
+{
+
+// setenv is POSIX and Windows is a supported target, so the two spellings are
+// wrapped here rather than at every call site.
+void setVariable(const char* name, const char* value)
+{
+#ifdef _WIN32
+  _putenv_s(name, value);
+#else
+  setenv(name, value, 1);
+#endif
+}
+
+void clearVariable(const char* name)
+{
+#ifdef _WIN32
+  _putenv_s(name, "");
+#else
+  unsetenv(name);
+#endif
+}
+
+class AnEnvPattern: public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    setVariable("SEN_TEST_VAR", "expanded");
+    clearVariable("SEN_TEST_UNSET");
+  }
+  void TearDown() override
+  {
+    clearVariable("SEN_TEST_VAR");
+    clearVariable("SEN_TEST_UNSET");
+  }
+};
+
+}  // namespace
+
+/// @test
+/// A pattern naming a variable that exists is replaced by its value.
+TEST_F(AnEnvPattern, expandsAVariableThatExists)
+{
+  EXPECT_EQ(replaceEnvPattern("value: @env(SEN_TEST_VAR)"), "value: expanded");
+}
+
+/// @test
+/// Text carrying no pattern is returned unchanged.
+TEST_F(AnEnvPattern, leavesTextWithoutAPatternAlone)
+{
+  EXPECT_EQ(replaceEnvPattern("value: plain@example.com"), "value: plain@example.com");
+}
+
+/// @test
+/// An unset variable falls back to the default given after the comma.
+TEST_F(AnEnvPattern, usesTheDefaultWhenTheVariableIsUnset)
+{
+  EXPECT_EQ(replaceEnvPattern("value: @env(SEN_TEST_UNSET,fallback)"), "value: fallback");
+}
+
+/// @test
+/// The default is ignored when the variable is set.
+TEST_F(AnEnvPattern, prefersTheVariableOverTheDefault)
+{
+  EXPECT_EQ(replaceEnvPattern("value: @env(SEN_TEST_VAR,fallback)"), "value: expanded");
+}
+
+/// @test
+/// Whitespace around the comma is accepted: this is the form the documentation shows,
+/// and it used to leave the pattern in the configuration with no diagnostic.
+TEST_F(AnEnvPattern, acceptsSpacesAroundTheComma)
+{
+  EXPECT_EQ(replaceEnvPattern("value: @env(SEN_TEST_UNSET, fallback)"), "value: fallback");
+  EXPECT_EQ(replaceEnvPattern("value: @env(SEN_TEST_UNSET ,fallback)"), "value: fallback");
+  EXPECT_EQ(replaceEnvPattern("value: @env(SEN_TEST_UNSET\t,\tfallback)"), "value: fallback");
+  EXPECT_EQ(replaceEnvPattern("value: @env(SEN_TEST_VAR )"), "value: expanded");
+}
+
+/// @test
+/// An unset variable with no default stops the load rather than substituting nothing.
+/// The type is only std::exception: throwRuntimeError throws cpptrace::runtime_error
+/// in Debug and std::runtime_error otherwise, and those share no closer base.
+TEST_F(AnEnvPattern, throwsWhenTheVariableIsUnsetAndHasNoDefault)
+{
+  try
+  {
+    static_cast<void>(replaceEnvPattern("value: @env(SEN_TEST_UNSET)"));
+    FAIL() << "expected a throw for an unset variable with no default";
+  }
+  catch (const std::exception& error)
+  {
+    EXPECT_NE(std::string(error.what()).find("SEN_TEST_UNSET"), std::string::npos);
+  }
+}
+
+/// @test
+/// One backslash escapes the pattern: the text is reproduced without the backslash.
+TEST_F(AnEnvPattern, honoursASingleEscape)
+{
+  EXPECT_EQ(replaceEnvPattern(R"(value: \@env(SEN_TEST_VAR))"), "value: @env(SEN_TEST_VAR)");
+  EXPECT_EQ(replaceEnvPattern(R"(value: \@env(SEN_TEST_VAR,fallback))"), "value: @env(SEN_TEST_VAR,fallback)");
+}
+
+/// @test
+/// An escaped pattern never reads the variable, so an unset one is not an error.
+/// The lookup used to run first and abort the load on text meant to be left alone.
+TEST_F(AnEnvPattern, doesNotReadTheVariableOfAnEscapedPattern)
+{
+  EXPECT_EQ(replaceEnvPattern(R"(value: \@env(SEN_TEST_UNSET))"), "value: @env(SEN_TEST_UNSET)");
+}
+
+/// @test
+/// Two backslashes escape each other, so the variable is expanded after one of them.
+TEST_F(AnEnvPattern, expandsAfterAnEvenNumberOfBackslashes)
+{
+  EXPECT_EQ(replaceEnvPattern(R"(value: \\@env(SEN_TEST_VAR))"), R"(value: \expanded)");
+}
+
+/// @test
+/// An odd count above one keeps the pairs and escapes the pattern.
+TEST_F(AnEnvPattern, escapesAfterAnOddNumberOfBackslashes)
+{
+  EXPECT_EQ(replaceEnvPattern(R"(value: \\\@env(SEN_TEST_VAR))"), R"(value: \@env(SEN_TEST_VAR))");
+}
+
+/// @test
+/// Every pattern in the text is handled, not only the first.
+TEST_F(AnEnvPattern, expandsEveryOccurrence)
+{
+  EXPECT_EQ(replaceEnvPattern("a: @env(SEN_TEST_VAR)\nb: @env(SEN_TEST_VAR)"), "a: expanded\nb: expanded");
+}
+
+/// @test
+/// A pattern cannot span lines, so a newline before the comma is not a match.
+TEST_F(AnEnvPattern, doesNotMatchAcrossLines)
+{
+  const std::string text = "value: @env(SEN_TEST_VAR,\nfallback)";
+  EXPECT_EQ(replaceEnvPattern(text), text);
+}
+
+/// @test
+/// An included file gets the same expansion as the top-level one. It used to reach
+/// the tree as literal text, so a pattern there never resolved and an unset variable
+/// raised nothing.
+TEST_F(AnEnvPattern, expandsPatternsInsideAnIncludedFile)
+{
+  const auto directory = std::filesystem::temp_directory_path() / "sen_env_include_test";
+  std::filesystem::create_directories(directory);
+  {
+    std::ofstream included(directory / "included.yaml");
+    included << "includedValue: \"@env(SEN_TEST_VAR)\"\n";
+  }
+
+  const std::string top = "include: included.yaml\ntopValue: \"@env(SEN_TEST_VAR)\"\n";
+  const sen::VarMap config = sen::kernel::getConfigAsVarFromYaml(top, directory / "main.yaml", false);
+
+  EXPECT_EQ(config.at("topValue").getCopyAs<std::string>(), "expanded");
+  EXPECT_EQ(config.at("includedValue").getCopyAs<std::string>(), "expanded");
+
+  std::filesystem::remove_all(directory);
+}


### PR DESCRIPTION
## What and why

A default written after a space was left in the configuration unexpanded, though
`command_line.md:140` shows exactly that form. An included file was never
expanded at all: `importYaml` read, parsed and merged without ever calling the
expander, so a pattern there reached the tree as literal text and an unset
variable raised nothing. An escaped pattern read the variable before the escape
was considered, so `\@env(UNSET)` aborted the load on text it was about to
reproduce verbatim.

The function moves into its own unit so a test can reach it. It sat in an
anonymous namespace with no coverage, which is how three defects accumulated in
sixty lines.

The new tests were run against the implementation they replace: the four
whitespace cases and the escaped-unset case fail there, and the eleven parity
cases pass on both, so the escape rendering is unchanged.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [x] Tests cover the change where practical, and were checked against the old
      code to confirm they fail for the reason they claim
- [x] `conan.lock` was regenerated if `conanfile.py` changed. Not touched.
