### PR TITLE
fix(py): initialise the default wait timeout

### DIFF
--- a/components/py/src/component_api.h
+++ b/components/py/src/component_api.h
@@ -68,7 +68,9 @@ private:
   Duration updatePeriod_;
   kernel::PackageManager* packageManager_;
   bool syncCalls_ = false;
-  std::chrono::nanoseconds defaultTimeout_;
+  // Zero means wait forever, which is what waitUntilCpp does with it. Without
+  // this the constructor left it indeterminate.
+  std::chrono::nanoseconds defaultTimeout_ {};
 };
 
 }  // namespace sen::components::py


### PR DESCRIPTION
## What and why

`defaultTimeout_` had no initialiser and the constructor does not list it, so
it was indeterminate. `waitUntilCpp` substitutes it whenever the caller passes
zero, which the default argument always does, so every wait taking the default
read it. `getDefaultTimeout` is a Python property, so scripts observed it too.

In practice it reads zero and waits forever, which is what the documentation
describes. A non-zero value gives up after an arbitrary interval, presenting
as a flaky script.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [ ] Tests cover the change where practical. Neither sanitizer available here
      detects an uninitialised read, so a test would assert zero and pass on
      the old code too.
- [x] `conan.lock` was regenerated if `conanfile.py` changed. Not touched.
