### PR TITLE
fix(influx): write the deletion point

### DIFF
--- a/components/influx/src/recorder.cpp
+++ b/components/influx/src/recorder.cpp
@@ -233,6 +233,7 @@ void Recorder::sendDeletion(const TimeStamp& time, const Object* object) const
   DataPoint point("deleted", time);
   point.addTag("object", object->getName());
   point.addTag("payload_type", "deletion");
+  database_->write(std::move(point));
 }
 
 }  // namespace sen::components::influx


### PR DESCRIPTION
## What and why

`sendDeletion` built the point and added its tags, then returned without
writing it, so the `deleted` measurement documented at `influx.md:103` has
never been populated and a panel on it stays empty. The three sibling
handlers all end with the same `database_->write`.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [ ] Tests cover the change where practical. The component has no test target
      and writing one needs a running InfluxDB, so this is not covered.
- [x] `conan.lock` was regenerated if `conanfile.py` changed. Not touched.
