### PR TITLE
fix(cli_sen): drop the term shortcut

### DIFF
--- a/apps/cli_sen/main.cpp
+++ b/apps/cli_sen/main.cpp
@@ -166,7 +166,6 @@ void configureShortcut(CLI::App& app, const char* preset, int argc, char* argv[]
 void configureShortcuts(CLI::App& app, int argc, char* argv[])
 {
   configureShortcut(app, "shell", argc, argv);
-  configureShortcut(app, "term", argc, argv);
   configureShortcut(app, "explorer", argc, argv);
   configureShortcut(app, "replay", argc, argv);
 


### PR DESCRIPTION
## What and why

`configureShortcut` shells out to `cli_run --preset term`, and `cli_run` has no
such preset under any build configuration, so `sen term` always failed with
`invalid preset 'term'`. It reached the documentation as well, through the
`sen --help` snippet generated at `docs/CMakeLists.txt:36`.

Removed rather than implemented, since a `term` component would be a feature.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [ ] Tests cover the change where practical. `cli_sen` has no test target and
      asserting help text would be brittle. Checked by hand on the built
      binary: `term` is gone, `shell`, `explorer` and `replay` remain.
- [x] `conan.lock` was regenerated if `conanfile.py` changed. Not touched.
