### PR TITLE
fix: reconcile the config schema with the kernel

### DIFF
--- a/apps/cli_gen/src/json/templates/config_schema.j2
+++ b/apps/cli_gen/src/json/templates/config_schema.j2
@@ -52,7 +52,7 @@
         "description": "A component you wish Sen to build",
         "type": "object",
         "allOf": [ { "$ref": "#/$defs/sen.kernel.ComponentConfig" } ],
-        "required": [ "name", "freqHz" ],
+        "required": [ "name" ],
         "properties": {
           "name": {
             "description": "Name of the component",
@@ -62,15 +62,14 @@
           "freqHz": {
             "description": "Cycle frequency in Hertz",
             "type": "number",
-            "minimum": 1,
-            "maximum": 1000
+            "exclusiveMinimum": 0
           },
           "objects": {
             "type": "array",
             "uniqueKeys": [ "/name" ],
             "items": {
               "type": "object",
-              "required": ["name", "class", "bus"],
+              "required": ["name", "class"],
               "properties": {
                 "name": {
                   "description": "The name of the instance",

--- a/libs/kernel/src/bootloader.cpp
+++ b/libs/kernel/src/bootloader.cpp
@@ -645,7 +645,7 @@ void Bootloader::fetchPipelineExecPeriod(KernelConfig::PipelineToLoad& pipelineC
   if (freqItr != map.end())
   {
     const auto freqVal = getCopyAs<float64_t>(freqItr->second);
-    if (freqVal == 0.0)
+    if (freqVal <= 0.0)
     {
       std::string err;
       err.append("invalid frequency value '");

--- a/libs/kernel/test/unit/CMakeLists.txt
+++ b/libs/kernel/test/unit/CMakeLists.txt
@@ -9,6 +9,7 @@ add_sen_unit_test_suite(
   kernel_test
   bus/remote_interest_handler_test.cpp
   env_substitution_test.cpp
+  pipeline_frequency_test.cpp
   test_kernel/test_kernel_test.cpp
   LINK_DEPS
   sen::core

--- a/libs/kernel/test/unit/pipeline_frequency_test.cpp
+++ b/libs/kernel/test/unit/pipeline_frequency_test.cpp
@@ -1,0 +1,60 @@
+// === pipeline_frequency_test.cpp =====================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// kernel
+#include "sen/kernel/bootloader.h"
+#include "sen/kernel/kernel_config.h"
+
+// gtest
+#include <gtest/gtest.h>
+
+// std
+#include <chrono>
+#include <string>
+
+namespace
+{
+
+/// A pipeline with nothing in it, so only the frequency is under test.
+std::string configWith(const std::string& frequencyLine)
+{
+  return "build:\n  - name: p\n    imports: []\n    objects: []\n" + frequencyLine;
+}
+
+}  // namespace
+
+/// @test
+/// Zero is refused.
+TEST(APipelineFrequency, refusesZero)
+{
+  EXPECT_THROW(static_cast<void>(sen::kernel::Bootloader::fromYamlString(configWith("    freqHz: 0\n"), false)),
+               std::exception);
+}
+
+/// @test
+/// A negative frequency is refused; it used to give a negative period.
+TEST(APipelineFrequency, refusesANegativeValue)
+{
+  EXPECT_THROW(static_cast<void>(sen::kernel::Bootloader::fromYamlString(configWith("    freqHz: -5\n"), false)),
+               std::exception);
+}
+
+/// @test
+/// Below one hertz is legal: 0.5 is a two second cycle.
+TEST(APipelineFrequency, acceptsLessThanOneHertz)
+{
+  const auto bootloader = sen::kernel::Bootloader::fromYamlString(configWith("    freqHz: 0.5\n"), false);
+  EXPECT_EQ(bootloader->getConfig().getPipelinesToLoad().front().period, sen::Duration {std::chrono::seconds {2}});
+}
+
+/// @test
+/// Omitting it gives the default rather than an error.
+TEST(APipelineFrequency, defaultsWhenOmitted)
+{
+  const auto bootloader = sen::kernel::Bootloader::fromYamlString(configWith(""), false);
+  EXPECT_EQ(bootloader->getConfig().getPipelinesToLoad().front().period, sen::Duration::fromHertz(30.0F));
+}


### PR DESCRIPTION
## What and why

The schema required `freqHz` and `bus` and capped `freqHz` at 1000. The kernel
defaults an absent `freqHz` to 30 Hz, publishes an object with no bus, and has
no ceiling, so valid configurations were flagged by the editor the documentation
recommends. Separately the kernel accepted a negative frequency and turned it
into a negative period.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [x] Tests cover the change where practical. Four, and the negative one was
      run against the old comparison, where it fails.
- [x] `conan.lock` was regenerated if `conanfile.py` changed. Not touched.
