### PR TITLE
ci: classify the change set on every event that has a base

### DIFF
--- a/.github/scripts/classify_changes.py
+++ b/.github/scripts/classify_changes.py
@@ -6,9 +6,10 @@
 # ======================================================================================================================
 """Classifies a change set so the orchestrator can gate the heavy lanes.
 
-Docs-only pull requests stop after the cheap checks. Without a base commit
-to diff against (pushes, manual dispatch), everything counts as code, and the
-image is rebuilt and checked.
+Docs-only changes stop after the cheap checks. Every event that carries a base
+is classified: a pull request against its base, a push against the commit main
+moved from, a merge queue entry against the queue's base. Without one, every
+flag fails open and says so.
 """
 
 import argparse
@@ -73,16 +74,14 @@ def is_image_change(paths: list[str]) -> bool:
     """Returns True when the image has to be rebuilt and checked.
 
     Documentation is excluded even under tools/ci: the Dockerfile copies
-    nothing out of the repository, so a paragraph cannot change the image. An
-    empty change set fails open, as the other classifications do.
+    nothing out of the repository, so a paragraph cannot change the image. The
+    exclusion is per path; per change set, one source file promoted a paragraph
+    into an image build. An empty change set fails open, as the others do.
     """
     if not paths:
         return True
 
-    if not is_code_change(paths):
-        return False
-
-    return any(affects_image(path) for path in paths)
+    return any(affects_image(path) and not is_docs_path(path) for path in paths)
 
 
 def is_code_change(paths: list[str]) -> bool:
@@ -97,16 +96,63 @@ def is_code_change(paths: list[str]) -> bool:
     return any(not is_docs_path(path) for path in paths)
 
 
-def changed_paths(base_sha: str) -> list[str]:
-    """Lists the paths that changed since the merge base with base_sha."""
+def announce(message: str) -> None:
+    """Reports a classification decision in the log and on the run page."""
+    print(message)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write(f"Change classification: {message}\n")
+
+
+def commit_exists(sha: str) -> bool:
+    """Returns True when the checkout can resolve the sha to a commit."""
+    result = subprocess.run(["git", "cat-file", "-e", f"{sha}^{{commit}}"], capture_output=True, check=False)
+    return result.returncode == 0
+
+
+def resolve_base(base_sha: str) -> str:
+    """Returns a base that can be diffed, or empty when there is none to use.
+
+    Every rejection is announced: failing open runs everything, which is also
+    what a successful classification can produce.
+    """
+    if not base_sha:
+        announce("no base commit for this event, so every lane runs")
+        return ""
+
+    # A ref created by the push carries no previous commit.
+    if set(base_sha) == {"0"}:
+        announce(f"base {base_sha} is all zeros, so every lane runs")
+        return ""
+
+    # A rewritten history leaves a base that the checkout cannot reach.
+    if not commit_exists(base_sha):
+        announce(f"base {base_sha} is not in this checkout, so every lane runs")
+        return ""
+
+    return base_sha
+
+
+def changed_paths(base_sha: str, head: str = "HEAD") -> list[str] | None:
+    """Lists the paths that changed since the merge base with base_sha, or None.
+
+    A three-dot diff needs a merge base, so a base resolve_base accepts can
+    still share no history with head. That fails open here rather than raising.
+    """
     # --no-renames: a rename reports only its destination, so moving a source
     # file into docs/ would otherwise read as a documentation change.
     result = subprocess.run(
-        ["git", "diff", "--no-renames", "--name-only", f"{base_sha}...HEAD"],
-        check=True,
+        ["git", "diff", "--no-renames", "--name-only", f"{base_sha}...{head}"],
+        check=False,
         capture_output=True,
         text=True,
     )
+
+    if result.returncode != 0:
+        announce(f"base {base_sha} cannot be diffed against {head}, so every lane runs")
+        return None
 
     return [line for line in result.stdout.splitlines() if line]
 
@@ -117,19 +163,21 @@ def main() -> int:
         prog="classify_changes",
         description="Classifies the change set for workflow gating.",
     )
-    parser.add_argument(
-        "--base-sha", default="", help="Base commit of the pull request; empty means not a pull request."
-    )
+    parser.add_argument("--base-sha", default="", help="Commit to diff against; empty means classify nothing.")
     args = parser.parse_args()
 
     code = True
     docs = True
     image = True
-    if args.base_sha:
-        paths = changed_paths(args.base_sha)
-        code = is_code_change(paths)
-        docs = is_docs_build_change(paths)
-        image = is_image_change(paths)
+    if base_sha := resolve_base(args.base_sha):
+        if (paths := changed_paths(base_sha)) is not None:
+            code = is_code_change(paths)
+            docs = is_docs_build_change(paths)
+            image = is_image_change(paths)
+
+    # A fallback also runs everything, so only a skipped lane is worth naming.
+    if skipped := [name for name, run in (("tests", code), ("docs", docs), ("image", image)) if not run]:
+        announce(f"skipping {', '.join(skipped)}")
 
     output_file = os.environ.get("GITHUB_OUTPUT")
     if not output_file:

--- a/.github/scripts/conftest.py
+++ b/.github/scripts/conftest.py
@@ -1,0 +1,24 @@
+# === conftest.py ======================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Keeps the tests that shell out to git inside their own temporary repositories.
+
+Committing from a linked worktree hands the hook an absolute GIT_DIR and
+GIT_INDEX_FILE, so a test that builds a fixture repository would reinitialise
+the one running the hook instead.
+"""
+
+import pytest
+
+# Each of these redirects git on its own, whether or not a hook sets it.
+REDIRECTING_VARIABLES = ("GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE", "GIT_COMMON_DIR")
+
+
+@pytest.fixture(autouse=True)
+def keep_git_inside_the_test_repository(monkeypatch):
+    """Drops the inherited repository location from every test's environment."""
+    for name in REDIRECTING_VARIABLES:
+        monkeypatch.delenv(name, raising=False)

--- a/.github/scripts/test_classify_changes.py
+++ b/.github/scripts/test_classify_changes.py
@@ -6,7 +6,22 @@
 # ======================================================================================================================
 """Pins the docs-only classification that gates the heavy workflow lanes."""
 
-from classify_changes import is_code_change, is_docs_build_change, is_image_change
+import subprocess
+import sys
+
+import classify_changes
+import pytest
+from classify_changes import changed_paths, is_code_change, is_docs_build_change, is_image_change, resolve_base
+
+
+@pytest.fixture(autouse=True)
+def keep_out_of_the_live_summary(monkeypatch):
+    """Stops announce() writing into the job summary of the run testing it.
+
+    python-checks runs inside Actions, where GITHUB_STEP_SUMMARY is always set,
+    so without this every run published its own test messages as real ones.
+    """
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
 
 
 def test_docs_directory_only_is_not_code():
@@ -113,3 +128,92 @@ def test_documentation_never_triggers_an_image_build():
 def test_an_empty_change_set_checks_the_image():
     """Without diff information the image is checked, like every other lane."""
     assert is_image_change([])
+
+
+def test_prose_under_tools_ci_does_not_ride_in_on_an_unrelated_change():
+    """The exclusion is per path, not per change set.
+
+    This repository updates architecture.md in the same commit as the pipeline
+    change it describes, so per change set it fired almost every time.
+    """
+    assert not is_image_change(["tools/ci/architecture.md", ".github/workflows/nightly.yaml"])
+    assert not is_image_change(["tools/ci/architecture.md", "libs/core/src/base/hash32.cpp"])
+    # A real input alongside the prose still counts.
+    assert is_image_change(["tools/ci/architecture.md", "tools/ci/Dockerfile"])
+    assert is_image_change(["tools/ci/architecture.md", "tools/ci/CMakeLists.txt"])
+
+
+def test_no_base_classifies_nothing(capsys):
+    """An event without a base runs everything, and says so."""
+    assert not resolve_base("")
+    assert "every lane runs" in capsys.readouterr().out
+
+
+def test_an_all_zero_base_classifies_nothing(capsys):
+    """A ref created by the push carries no previous commit."""
+    assert not resolve_base("0" * 40)
+    assert "all zeros" in capsys.readouterr().out
+
+
+def test_a_base_the_checkout_cannot_reach_classifies_nothing(monkeypatch, capsys):
+    """A rewritten history leaves a base that git cannot resolve."""
+    monkeypatch.setattr(classify_changes, "commit_exists", lambda _sha: False)
+    assert not resolve_base("a" * 40)
+    assert "not in this checkout" in capsys.readouterr().out
+
+
+def test_a_reachable_base_is_used(monkeypatch):
+    """The ordinary case: the base is returned and the diff is taken."""
+    monkeypatch.setattr(classify_changes, "commit_exists", lambda _sha: True)
+    assert resolve_base("a" * 40) == "a" * 40
+
+
+def test_a_rejection_reaches_the_job_summary(tmp_path, monkeypatch):
+    """The summary write is the half that matters, so it is asserted here."""
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+
+    assert not resolve_base("")
+
+    assert "every lane runs" in summary.read_text(encoding="utf-8")
+
+
+def test_a_base_with_no_common_history_classifies_nothing(tmp_path, monkeypatch, capsys):
+    """A base can resolve and still share no history, which the three-dot diff needs.
+
+    resolve_base cannot see this: the commit is there and reachable.
+    """
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", "-C", str(tmp_path), *args], check=True, capture_output=True)
+
+    git("init", "-q", "-b", "one")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    (tmp_path / "file.txt").write_text("one")
+    git("add", "file.txt")
+    git("-c", "commit.gpgsign=false", "commit", "-qm", "one")
+
+    # An orphan branch has no parent, so the two lines share no commit at all.
+    git("checkout", "-q", "--orphan", "two")
+    (tmp_path / "other.txt").write_text("two")
+    git("add", "other.txt")
+    git("-c", "commit.gpgsign=false", "commit", "-qm", "two")
+    monkeypatch.chdir(tmp_path)
+
+    assert changed_paths("one", head="two") is None
+    assert "cannot be diffed" in capsys.readouterr().out
+
+
+def test_the_skipped_lanes_reach_the_job_summary(tmp_path, monkeypatch):
+    """A lane that did not run is what the run page cannot otherwise show."""
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "output.txt"))
+    monkeypatch.setattr(classify_changes, "resolve_base", lambda _sha: "a base")
+    monkeypatch.setattr(classify_changes, "changed_paths", lambda _base: ["docs/index.md"])
+    monkeypatch.setattr(sys, "argv", ["classify_changes", "--base-sha", "a base"])
+
+    assert classify_changes.main() == 0
+
+    assert "skipping tests, image" in summary.read_text(encoding="utf-8")

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,8 +42,12 @@ jobs:
       - id: filter
         name: Classify changed paths
         shell: bash
+        # One of these is set per event: the pull request's base, the queue
+        # entry's, and on a push the commit main moved from. A push used to
+        # pass nothing here, so nothing was ever classified after a merge.
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: >-
+            ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
         run: python3 .github/scripts/classify_changes.py --base-sha "$BASE_SHA"
 
   # Not on a push: after the merge the hook range is empty, so every hook

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -50,6 +50,15 @@ matrix only runs when it is needed:
   described below.
 - Every other pull request runs the matrix from `generate_matrix_jobs.py`.
 
+The same classification runs on a merge and on a merge queue entry, against the
+commit main moved from and against the queue's base.
+
+When there is no usable base -- a manual dispatch, a newly created ref, a base
+that is unreachable or shares no history -- every lane runs and the job says
+why. It also names the lanes it skips. Both go to the log and the run summary:
+running everything is also what a successful classification can produce, and a
+skipped lane leaves no other trace.
+
 The matrix jobs build the examples together with the production code and
 run the example smoke tests. The shipping job (Linux gcc Release) also
 builds the CPack archive and checks that it still holds the binaries, the
@@ -512,6 +521,10 @@ stack**, and the pull request it blocks is not necessarily the one being merged.
   `.cmake-format.py`, `.conan/test_packages/` and `apps/cli_gen/test/test20/`.
   The last is excluded because duplicate test module names there break the
   run.
+- A cancelled push run leaves its range unclassified. Two merges landing close
+  together share one concurrency group, so the second cancels the first and then
+  classifies from the first's head. If the first carried code and the second
+  only documentation, the matrix runs for neither on main.
 - A fresh runner builds all dependencies from source once per cache
   lifetime; the first run of a day (or after the cache was removed) is the
   slow one. The arm configuration pays it on every run, because nothing


### PR DESCRIPTION
## What and why

**Classification never ran on a merge.** `main.yaml` passed
`github.event.pull_request.base.sha`, which is empty on a push, so every flag
failed open. It now passes the base each event carries. A base that is missing,
all zeros, unreachable or shares no history fails open and prints why -- the
last of those used to raise and fail the job. Skipped lanes are printed too.

**The image gate fired on prose.** `is_image_change` applied the documentation
exclusion to the change set rather than per path, so any unrelated source file
promoted a paragraph under `tools/ci` into an image build.

**`conftest.py` clears the repository location git exports into a hook
environment.** Committing from a linked worktree passes an absolute `GIT_DIR`,
so the two tests that build a fixture repository reinitialised the real one and
wrote `core.bare` into its shared config. An ordinary clone is unaffected.

Checked against three merges: #154 classifies as documentation, #158 as image,
#163 as code. All four fallbacks reach the run summary.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [x] Tests cover the change where practical
- [x] `conan.lock` was regenerated if `conanfile.py` changed (not applicable)
