### PR TITLE
ci: keep the run of every merge to main

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,11 +20,14 @@ on:
 permissions:
   contents: read
 
-# One run per branch and trigger kind; a new push cancels the running one.
+# One run per branch and trigger kind; a new event cancels the running one.
 # event_name is in the key so the nightly cannot cancel a push to main.
+#
+# Not on a push, which here is only a merge to main: each run classifies from
+# the commit main moved from, so a cancelled run's range falls into no other.
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   detect-changes:

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -145,11 +145,13 @@ Only one run per branch and trigger kind exists at a time (the
 still in progress. The event name is part of the group key, so a manual run
 and a push to main do not collide.
 
-Cancellation is not limited to pull requests. Two merges landing minutes
-apart share one group, so the second cancels the first and the earlier commit
-keeps no post-merge result. A draft toggle does the same on a single commit,
-because converting to draft and back fires two events into the same group;
-what the cancelled run leaves behind is described under "Landing a change".
+Merges to main are the exception: their runs are never cancelled. Each one
+classifies against the commit main moved from, so a cancelled run's range would
+fall into no other run's, and the merge would go unbuilt with nothing to show
+it. Two merges landing minutes apart therefore both run to a result. A draft
+toggle still cancels, on a single commit, because converting to draft and back
+fires two events into the same group; what that leaves behind is described
+under "Landing a change".
 
 **Packaging on a pull request builds one configuration.** Packaging is the
 only check that builds Sen as a package and then builds a consumer against
@@ -530,10 +532,6 @@ stack**, and the pull request it blocks is not necessarily the one being merged.
   `.cmake-format.py`, `.conan/test_packages/` and `apps/cli_gen/test/test20/`.
   The last is excluded because duplicate test module names there break the
   run.
-- A cancelled push run leaves its range unclassified. Two merges landing close
-  together share one concurrency group, so the second cancels the first and then
-  classifies from the first's head. If the first carried code and the second
-  only documentation, the matrix runs for neither on main.
 - A fresh runner builds all dependencies from source once per cache
   lifetime; the first run of a day (or after the cache was removed) is the
   slow one. The arm configuration pays it on every run, because nothing


### PR DESCRIPTION
## What and why

Since #164, a merge's run classifies against the commit `main` moved from. The
concurrency group cancels a running merge when the next one lands, so the
cancelled run's range falls into no other run's -- the next one starts from the
commit that cancelled it.

The failure that produces: merge A carries code, merge B carries only
documentation and lands inside A's run. B cancels A, classifies its own range as
documentation-only, and skips the matrix. A's code is built by neither run, and
both report green.

Pull requests still cancel, which is where the saving is -- a busy branch can
supersede its run several times an hour. The cost is a duplicated run when two
merges land within about thirteen minutes of each other, which is rare here and
free on a public repository.

`architecture.md` loses the limitation added in #164, since it no longer holds,
and its cancellation paragraph is corrected.

It cannot be demonstrated on this pull request: it only shows the next time two
merges land close together.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [x] Tests cover the change where practical
- [x] `conan.lock` was regenerated if `conanfile.py` changed (not applicable)
