### PR TITLE
ci: report what the sanitizers find rather than only pass or fail

### DIFF
--- a/.github/scripts/summarise_sanitizer_reports.py
+++ b/.github/scripts/summarise_sanitizer_reports.py
@@ -1,0 +1,122 @@
+# === summarise_sanitizer_reports.py ===================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Groups the sanitizer reports of a run into something a person can act on.
+
+A sanitizer prints one block per finding, and a run repeats the same defect
+across every test that reaches it. Raw, that reads as a crisis; grouped by the
+first frame inside sen::, it reads as the handful of sites it actually is.
+
+This reports rather than judges: the exit status says whether the summary was
+written, not whether findings were found.
+"""
+
+import argparse
+import os
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+# "WARNING: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) (pid=1)"
+# "ERROR: AddressSanitizer: heap-use-after-free on address 0x60300000eff0"
+FINDING = re.compile(r"(?:WARNING|ERROR): (\w+Sanitizer): (.+)")
+
+# "on vptr" is part of the kind; "on address" is not, nor is a pid or an aside.
+KIND_TAIL = re.compile(r"\s+on address\b|\s+on 0x|\s+\(")
+
+# "    #3 sen::impl::WorkQueueImpl::clear() /workspace/libs/core/src/obj/work_queue.cpp:132:5"
+SEN_FRAME = re.compile(r"#\d+ (sen::[A-Za-z0-9_:~]+)")
+
+# The repository-relative half of a frame's path, which is what a reader can open.
+SOURCE = re.compile(r"((?:libs|apps|components|tools)/[A-Za-z0-9_/.]+\.(?:cpp|h)):(\d+)")
+
+
+def findings(text: str) -> list[dict]:
+    """Splits a sanitizer log into one entry per finding.
+
+    A finding runs from its WARNING/ERROR line to the next one, so the frames
+    in between are the ones that produced it.
+    """
+    starts = [m.start() for m in FINDING.finditer(text)]
+    entries = []
+    for index, start in enumerate(starts):
+        end = starts[index + 1] if index + 1 < len(starts) else len(text)
+        block = text[start:end]
+        match = FINDING.search(block)
+        if match is None:
+            continue
+
+        frame = SEN_FRAME.search(block)
+        entries.append(
+            {
+                "tool": match.group(1),
+                "kind": KIND_TAIL.split(match.group(2))[0].strip(),
+                "site": frame.group(1) if frame else "(no sen:: frame)",
+                "sources": [f"{path}:{line}" for path, line in SOURCE.findall(block)],
+            }
+        )
+    return entries
+
+
+def summarise(entries: list[dict]) -> str:
+    """Renders the grouped findings as markdown."""
+    if not entries:
+        return "No sanitizer findings in this run.\n"
+
+    by_site = Counter((entry["tool"], entry["kind"], entry["site"]) for entry in entries)
+    sources: dict[tuple, Counter] = {}
+    for entry in entries:
+        key = (entry["tool"], entry["kind"], entry["site"])
+        sources.setdefault(key, Counter()).update(entry["sources"])
+
+    lines = [f"{len(entries)} sanitizer findings, {len(by_site)} distinct sites.", ""]
+    lines.append("| count | tool | kind | first sen:: frame |")
+    lines.append("|---|---|---|---|")
+    for (tool, kind, site), count in by_site.most_common():
+        lines.append(f"| {count} | {tool} | {kind} | `{site}` |")
+
+    lines.append("")
+    for key, count in by_site.most_common():
+        common = ", ".join(f"`{where}`" for where, _ in sources[key].most_common(4))
+        if common:
+            lines.append(f"- `{key[2]}` ({count}): {common}")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    """Writes the grouped summary to stdout and to GITHUB_STEP_SUMMARY."""
+    parser = argparse.ArgumentParser(
+        prog="summarise_sanitizer_reports",
+        description="Groups a run's sanitizer findings by the site that produced them.",
+    )
+    parser.add_argument("paths", nargs="+", help="Report files or directories holding them.")
+    args = parser.parse_args()
+
+    text = []
+    for raw in args.paths:
+        path = Path(raw)
+        if path.is_dir():
+            for child in sorted(path.rglob("*")):
+                if child.is_file():
+                    text.append(child.read_text(encoding="utf-8", errors="replace"))
+        elif path.is_file():
+            text.append(path.read_text(encoding="utf-8", errors="replace"))
+
+    report = summarise(findings("\n".join(text)))
+    print(report, end="")
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write(report)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_summarise_sanitizer_reports.py
+++ b/.github/scripts/test_summarise_sanitizer_reports.py
@@ -1,0 +1,85 @@
+# === test_summarise_sanitizer_reports.py ==============================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Pins the grouping that turns a run's sanitizer output into a short report."""
+
+from summarise_sanitizer_reports import findings, summarise
+
+RACE = """\
+WARNING: ThreadSanitizer: data race (pid=118)
+  Write of size 8 at 0x001 by thread T1:
+    #0 memcpy <null>
+    #3 sen::impl::WorkQueueImpl::clear() /workspace/libs/core/src/obj/work_queue.cpp:132:5
+    #5 sen::kernel::impl::Runner::stopThread() /workspace/libs/kernel/src/runner.cpp:428:14
+SUMMARY: ThreadSanitizer: data race work_queue.cpp:132
+"""
+
+VPTR = """\
+WARNING: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) (pid=119)
+  Read of size 8 at 0x002 by thread T1:
+    #3 sen::impl::WorkQueueImpl::clear() /workspace/libs/core/src/obj/work_queue.cpp:132:5
+"""
+
+LEAK = """\
+ERROR: AddressSanitizer: heap-use-after-free on address 0x003
+    #2 sen::kernel::impl::Executor::shutDown() /workspace/libs/kernel/src/executor.cpp:195:15
+"""
+
+
+def test_no_output_means_no_findings():
+    """A clean run says so rather than rendering an empty table."""
+    assert findings("") == []
+    assert "No sanitizer findings" in summarise([])
+
+
+def test_each_warning_is_one_finding():
+    """Findings are split at the WARNING/ERROR line, not at blank lines."""
+    assert len(findings(RACE + VPTR + LEAK)) == 3
+
+
+def test_the_site_is_the_first_sen_frame():
+    """The frames above it are the sanitizer's own and name no owner."""
+    assert findings(RACE)[0]["site"] == "sen::impl::WorkQueueImpl::clear"
+
+
+def test_the_tool_and_kind_are_kept_apart():
+    """A vptr race is a different finding from a plain one at the same site."""
+    entries = findings(RACE + VPTR)
+    assert [entry["kind"] for entry in entries] == ["data race", "data race on vptr"]
+    assert {entry["site"] for entry in entries} == {"sen::impl::WorkQueueImpl::clear"}
+
+
+def test_address_sanitizer_is_recognised_too():
+    """The report is not thread-specific: ASan writes ERROR rather than WARNING."""
+    entry = findings(LEAK)[0]
+    assert entry["tool"] == "AddressSanitizer"
+    assert entry["kind"] == "heap-use-after-free"
+
+
+def test_repeats_of_one_site_collapse_into_a_count():
+    """The point of the report: one defect reached by many tests is one row."""
+    report = summarise(findings(RACE * 5))
+    assert "| 5 |" in report
+    assert report.count("WorkQueueImpl::clear") >= 1
+
+
+def test_distinct_sites_are_counted_separately():
+    """Two different sites are two rows, and the header says how many."""
+    report = summarise(findings(RACE + LEAK))
+    assert "2 sanitizer findings, 2 distinct sites" in report
+
+
+def test_source_locations_are_repository_relative():
+    """A reader opens libs/..., not the runner's absolute build path."""
+    entry = findings(RACE)[0]
+    assert "libs/core/src/obj/work_queue.cpp:132" in entry["sources"]
+    assert not any(where.startswith("/") for where in entry["sources"])
+
+
+def test_a_finding_with_no_sen_frame_is_kept():
+    """Dropping it would hide a finding in third-party or generated code."""
+    entry = findings("WARNING: ThreadSanitizer: data race (pid=1)\n    #0 memcpy <null>\n")[0]
+    assert entry["site"] == "(no sen:: frame)"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -63,15 +63,31 @@ jobs:
         run: |
           conan install . -s "&:build_type=Debug" --build=missing \
             -o "sen/*:with_tests=True" \
-            -o "sen/*:sanitizer=${{ matrix.sanitizer }}"
+            -o "sen/*:sanitizer=${{ matrix.sanitizer }}" \
+            -c "tools.cmake.cmaketoolchain:extra_variables={'SEN_SANITIZER_LOG_DIR': '$PWD/sanitizer-reports'}"
           # conan build regenerates the toolchain, so it needs the same options.
           conan build . -s "&:build_type=Debug" \
             -o "sen/*:with_tests=True" \
-            -o "sen/*:sanitizer=${{ matrix.sanitizer }}"
+            -o "sen/*:sanitizer=${{ matrix.sanitizer }}" \
+            -c "tools.cmake.cmaketoolchain:extra_variables={'SEN_SANITIZER_LOG_DIR': '$PWD/sanitizer-reports'}"
 
       - name: Run tests
         shell: bash
         run: cmake --build build/clang/Debug/ --target run_tests
+
+      # Always: a run that failed for an unrelated reason still collected them.
+      - name: Report the ${{ matrix.lane }} findings
+        if: always()
+        shell: bash
+        run: python3 .github/scripts/summarise_sanitizer_reports.py sanitizer-reports
+
+      - name: Archive the ${{ matrix.lane }} reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: sanitizer-reports-${{ matrix.sanitizer }}
+          path: sanitizer-reports/
+          if-no-files-found: ignore
 
   clang-tidy:
     name: "clang-tidy full tree"

--- a/cmake/util/sanitizers.cmake
+++ b/cmake/util/sanitizers.cmake
@@ -5,6 +5,12 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 
+# Empty by default, so a local run still sees findings on stderr. Not a cache
+# entry: the toolchain injects this as an ordinary variable, which one deletes.
+if(NOT DEFINED SEN_SANITIZER_LOG_DIR)
+  set(SEN_SANITIZER_LOG_DIR "")
+endif()
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fasynchronous-unwind-tables")
 

--- a/cmake/util/test.cmake
+++ b/cmake/util/test.cmake
@@ -14,12 +14,19 @@ if(NOT SEN_BUILD_TESTS)
   set(BUILD_TESTING OFF) # Signal to ctest that no tests should be build
 endif()
 
-set(CMAKE_COMMON_CTEST_ARGUMENTS
-    "--stop-on-failure"
-    "--output-on-failure"
-    "--timeout"
-    "20"
-    ${CMAKE_COMMON_CTEST_ARGUMENTS}
+# Not on a sanitizer build: those lanes exist to report what is wrong, and
+# stopping early hides it.
+set(CMAKE_COMMON_CTEST_ARGUMENTS)
+if(SEN_USE_SANITIZER STREQUAL None)
+  list(APPEND CMAKE_COMMON_CTEST_ARGUMENTS "--stop-on-failure")
+endif()
+
+list(
+  APPEND
+  CMAKE_COMMON_CTEST_ARGUMENTS
+  "--output-on-failure"
+  "--timeout"
+  "20"
 )
 if(${SEN_CTEST_RANDOMIZE_TESTS})
   list(APPEND CMAKE_COMMON_CTEST_ARGUMENTS "--schedule-random")
@@ -59,6 +66,13 @@ set(CMAKE_FLAKY_CTEST_ARGUMENTS
     "--no-tests=ignore"
     ${CMAKE_COMMON_CTEST_ARGUMENTS}
 )
+
+# Appended to every sanitizer's options below, so findings can be collected.
+set(SEN_SANITIZER_LOG_OPTION "")
+if(SEN_SANITIZER_LOG_DIR)
+  file(MAKE_DIRECTORY "${SEN_SANITIZER_LOG_DIR}")
+  set(SEN_SANITIZER_LOG_OPTION ":log_path=${SEN_SANITIZER_LOG_DIR}/report")
+endif()
 
 enable_testing()
 
@@ -153,15 +167,15 @@ function(add_sen_unit_test_suite test_name)
 
   set(environment "")
   if(LSAN_SUPPRESSION_FILE)
-    list(APPEND environment "LSAN_OPTIONS=suppressions=${LSAN_SUPPRESSION_FILE}")
+    list(APPEND environment "LSAN_OPTIONS=suppressions=${LSAN_SUPPRESSION_FILE}${SEN_SANITIZER_LOG_OPTION}")
   endif()
 
   if(ASAN_SUPPRESSION_FILE)
-    list(APPEND environment "ASAN_OPTIONS=suppressions=${ASAN_SUPPRESSION_FILE}")
+    list(APPEND environment "ASAN_OPTIONS=suppressions=${ASAN_SUPPRESSION_FILE}${SEN_SANITIZER_LOG_OPTION}")
   endif()
 
   if(TSAN_SUPPRESSION_FILE)
-    list(APPEND environment "TSAN_OPTIONS=suppressions=${TSAN_SUPPRESSION_FILE}")
+    list(APPEND environment "TSAN_OPTIONS=suppressions=${TSAN_SUPPRESSION_FILE}${SEN_SANITIZER_LOG_OPTION}")
   endif()
 
   gtest_discover_tests(
@@ -229,14 +243,15 @@ function(add_sen_integration_test test_name)
 
   if(LSAN_SUPPRESSION_FILE)
     append_test_env_modification(
-      ${test_name} "LSAN_OPTIONS=set:suppressions=${_lsan_suppressions}:report_objects=1"
+      ${test_name}
+      "LSAN_OPTIONS=set:suppressions=${_lsan_suppressions}:report_objects=1${SEN_SANITIZER_LOG_OPTION}"
     )
   endif()
 
   if(ASAN_SUPPRESSION_FILE)
     append_test_env_modification(
       ${test_name}
-      "ASAN_OPTIONS=set:suppressions=${_asan_suppressions}:fast_unwind_on_malloc=0:malloc_context_size=100"
+      "ASAN_OPTIONS=set:suppressions=${_asan_suppressions}:fast_unwind_on_malloc=0:malloc_context_size=100${SEN_SANITIZER_LOG_OPTION}"
     )
   endif()
 
@@ -245,7 +260,9 @@ function(add_sen_integration_test test_name)
   endif()
 
   if(TSAN_SUPPRESSION_FILE)
-    append_test_env_modification(${test_name} "TSAN_OPTIONS=set:suppressions=${_tsan_suppressions}")
+    append_test_env_modification(
+      ${test_name} "TSAN_OPTIONS=set:suppressions=${_tsan_suppressions}${SEN_SANITIZER_LOG_OPTION}"
+    )
   endif()
 
   add_dependencies(run_integration_tests ${_arg_REQ_COMPONENTS} ${_arg_REQ_DEPS})
@@ -324,15 +341,21 @@ function(add_sen_run_smoke_test test_name)
   endif()
 
   if(LSAN_SUPPRESSION_FILE)
-    append_test_env_modification(${test_name} "LSAN_OPTIONS=set:suppressions=${LSAN_SUPPRESSION_FILE}")
+    append_test_env_modification(
+      ${test_name} "LSAN_OPTIONS=set:suppressions=${LSAN_SUPPRESSION_FILE}${SEN_SANITIZER_LOG_OPTION}"
+    )
   endif()
 
   if(ASAN_SUPPRESSION_FILE)
-    append_test_env_modification(${test_name} "ASAN_OPTIONS=set:suppressions=${ASAN_SUPPRESSION_FILE}")
+    append_test_env_modification(
+      ${test_name} "ASAN_OPTIONS=set:suppressions=${ASAN_SUPPRESSION_FILE}${SEN_SANITIZER_LOG_OPTION}"
+    )
   endif()
 
   if(TSAN_SUPPRESSION_FILE)
-    append_test_env_modification(${test_name} "TSAN_OPTIONS=set:suppressions=${TSAN_SUPPRESSION_FILE}")
+    append_test_env_modification(
+      ${test_name} "TSAN_OPTIONS=set:suppressions=${TSAN_SUPPRESSION_FILE}${SEN_SANITIZER_LOG_OPTION}"
+    )
   endif()
 
 endfunction()


### PR DESCRIPTION
## What and why

**The TSan lane cannot fail for the reason it exists.** `TSAN_OPTIONS` carries
only a suppressions path -- no `halt_on_error`, no `exitcode` -- so a race is
printed and the test exits zero. Verified: a racing test passed with status 0.
`tsan_ignorelist.txt` is decorative while that holds.

**Sanitizer builds no longer stop at the first failure**, which hid everything
scheduled after it. Pull-request lanes are unchanged.

**`SEN_SANITIZER_LOG_DIR`, empty by default**, appends `log_path` to the TSan,
ASan, LSan and UBSan options. Unset, a local run still shows findings inline.

**The summariser** groups a run by the first frame inside `sen::`, turning 28 raw
warnings from a real capture into three rows.

**No `halt_on_error`**: a report is wanted, not a verdict, and the shape it would
fail on is registered against the concurrency redesign.

## Verification

In the image from `tools/ci/Dockerfile --target dev`: the suite runs to
completion on a sanitizer build, findings land in files and no longer reach
stdout, and the summariser renders them. Nine unit tests cover the grouping.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [x] Tests cover the change where practical
- [x] `conan.lock` was regenerated if `conanfile.py` changed (not applicable)
