### PR TITLE
ci: run cmake through the environment Conan generates

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -73,7 +73,10 @@ jobs:
 
       - name: Run tests
         shell: bash
-        run: cmake --build build/clang/Debug/ --target run_tests
+        run: |
+          # Same reason as the first of these, in standard_test.yaml.
+          source build/clang/Debug/generators/conanbuild.sh
+          cmake --build build/clang/Debug/ --target run_tests
 
       # Always: a run that failed for an unrelated reason still collected them.
       - name: Report the ${{ matrix.lane }} findings
@@ -152,6 +155,8 @@ jobs:
       - name: Repeat the unit suite until a failure
         shell: bash
         run: |
+          # Same reason as the first of these, in standard_test.yaml.
+          source build/gcc/Release/generators/conanbuild.sh
           ctest --test-dir build/gcc/Release --parallel "$(nproc)" \
               -L unit -LE flaky --repeat until-fail:5 --output-on-failure
 
@@ -189,7 +194,10 @@ jobs:
 
       - name: Run benchmarks
         shell: bash
-        run: cmake --build build/gcc/Release/ --target run_benchmarks
+        run: |
+          # Same reason as the first of these, in standard_test.yaml.
+          source build/gcc/Release/generators/conanbuild.sh
+          cmake --build build/gcc/Release/ --target run_benchmarks
 
       # Result history lives in these artifacts until a baseline comparison
       # exists to fail on.
@@ -344,6 +352,8 @@ jobs:
             -o "sen/*:with_tests=True" -o "sen/*:with_coverage=True"
           conan build . -s "&:build_type=Debug" -s "&:compiler.cppstd=17" \
             -o "sen/*:with_tests=True" -o "sen/*:with_coverage=True"
+          # Same reason as the first of these, in standard_test.yaml.
+          source build/clang/Debug/generators/conanbuild.sh
           cmake --build build/clang/Debug/ --target generate-coverage-report
 
       - name: Publish the coverage report

--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -137,6 +137,10 @@ jobs:
         if: matrix.runtime_base != ''
         shell: bash
         run: |
+          # Conan provides cmake and ninja, and the image ships neither; entering
+          # its environment is what finds them. Harmless on a runner that has its
+          # own cmake, and required the moment a job runs inside the image.
+          source build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/generators/conanbuild.sh
           ctest --test-dir build/${{ matrix.compiler.name }}/${{ matrix.build_type }} \
             -N -L integration | grep -q object_sync
 
@@ -149,6 +153,8 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          # Same reason as the first of these, in standard_test.yaml.
+          source build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/generators/conanbuild.sh
           cmake --build build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/ --target run_tests
 
       # The report target runs the suite itself, so this replaces the step above
@@ -159,6 +165,8 @@ jobs:
         shell: bash
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          # Same reason as the first of these, in standard_test.yaml.
+          source build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/generators/conanbuild.sh
           cmake --build build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/ \
             --target generate-coverage-report
 
@@ -220,6 +228,8 @@ jobs:
         if: matrix.check_package
         shell: bash
         run: |
+          # Same reason as the first of these, in standard_test.yaml.
+          source build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/generators/conanbuild.sh
           cmake --build build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/ --target package
           python .github/scripts/check_package_archive.py build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/
 


### PR DESCRIPTION
Conan provides cmake and ninja; the CI image installs neither. These call sites
ran cmake and ctest without entering the environment Conan generates, so the
runner's own cmake built a tree that Conan's cmake had configured.

Eight sites, in `standard_test.yaml` and `nightly.yaml`. Each already has a
`conan install` earlier in the same job.

`build_release.yaml` is excluded: it builds the Windows release, where that
step's shell has no `source` and Conan writes `.bat`/`.ps1`.

No visible change on a runner. Required once a job runs inside the image, which
has no cmake at all.
