### PR TITLE
ci: publish the build image on merge to main

### DIFF
--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -17,6 +17,12 @@ name: CI Image
 # Off the hour because on-the-hour slots are contended.
 on:
   workflow_call:
+    inputs:
+      publish:
+        description: Push the checked image to the registry. Only true for a merge to main.
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
   schedule:
     - cron: "41 7 * * *"
@@ -139,3 +145,34 @@ jobs:
             test "$(id -un)" = sen || { echo "image runs as $(id -un)"; exit 1; }
             echo "editor tools present"
           '
+
+      # Last, deliberately: an image that failed a tool check above must never
+      # become the one every job pulls. Packages are private -- the organisation
+      # forbids public ones -- so a consumer authenticates or builds from the
+      # pinned Dockerfile instead.
+      - name: Publish the image
+        if: inputs.publish
+        shell: bash
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          SHA: ${{ github.sha }}
+        run: |
+          echo "$TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          ref="ghcr.io/${OWNER}/sen-ci"
+          docker tag sen-ci:probe "$ref:$SHA"
+          docker tag sen-ci:probe "$ref:main"
+          docker push "$ref:$SHA"
+          docker push "$ref:main"
+          # The digest is what a job should pull; the tags are for people.
+          # Matched against our own ref rather than taken by position: an image
+          # carries a digest per repository it has been tagged into, and the
+          # first is not necessarily ours.
+          digest=$(docker inspect --format='{{range .RepoDigests}}{{println .}}{{end}}' \
+            "$ref:$SHA" | grep "^${ref}@" | head -1)
+          test -n "$digest"
+          {
+            echo "Published \`$digest\`"
+            echo ""
+            echo "Pull it with: \`docker pull $digest\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -144,7 +144,16 @@ jobs:
     if: >-
       needs.detect-changes.outputs.image == 'true' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    # Granted here because a called workflow can only narrow the token it is
+    # handed, never widen it.
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/ci-image.yaml
+    # A merge to main that changed the image publishes it; every other event
+    # only checks that it still builds.
+    with:
+      publish: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
   # Packaging is the only check that builds Sen as a package and consumes it
   # from outside, so a pull request runs the shipping configuration; running

--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -19,7 +19,10 @@
 # pinned cmake for the builds themselves. Build `base` explicitly: a plain
 # `docker build` takes the last stage.
 
-FROM ubuntu:22.04 AS base
+# Pinned by digest: the tag moves whenever Canonical republishes it, which made
+# two developers building a fortnight apart hold different toolchains. Update it
+# deliberately; the scheduled cold build is what notices when it should be.
+FROM ubuntu:22.04@sha256:2edbbc5dc405e9612ba3584ce95480277e3eb374407b5505fe26f17df77c7dbc AS base
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LLVM_VERSION=20


### PR DESCRIPTION
The image is built, checked, then discarded: every step sets `push: false`. So
the build environment has three definitions and no way to run a lane locally.

- `Dockerfile`: base pinned by digest. The tag moves when republished.
- `ci-image.yaml`: a `publish` input; push step last, after the tool checks, so
  a failed check cannot become the image everyone pulls. Prints the digest.
- `main.yaml`: grants `packages: write`, passes `publish` only for a merge to
  main.

A pull request still only checks that the image builds.

Packages are private -- this organisation disables changing visibility -- so a
consumer authenticates with `read:packages` or builds from the now-pinned
Dockerfile. A fork's token cannot read them, which matters only if third-party
contributions open.
