### PR TITLE
ci: stop publishing the image until the installation may write packages

### DIFF
--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -17,12 +17,6 @@ name: CI Image
 # Off the hour because on-the-hour slots are contended.
 on:
   workflow_call:
-    inputs:
-      publish:
-        description: Push the checked image to the registry. Only true for a merge to main.
-        required: false
-        default: false
-        type: boolean
   workflow_dispatch:
   schedule:
     - cron: "41 7 * * *"
@@ -145,34 +139,3 @@ jobs:
             test "$(id -un)" = sen || { echo "image runs as $(id -un)"; exit 1; }
             echo "editor tools present"
           '
-
-      # Last, deliberately: an image that failed a tool check above must never
-      # become the one every job pulls. Packages are private -- the organisation
-      # forbids public ones -- so a consumer authenticates or builds from the
-      # pinned Dockerfile instead.
-      - name: Publish the image
-        if: inputs.publish
-        shell: bash
-        env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          SHA: ${{ github.sha }}
-        run: |
-          echo "$TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-          ref="ghcr.io/${OWNER}/sen-ci"
-          docker tag sen-ci:probe "$ref:$SHA"
-          docker tag sen-ci:probe "$ref:main"
-          docker push "$ref:$SHA"
-          docker push "$ref:main"
-          # The digest is what a job should pull; the tags are for people.
-          # Matched against our own ref rather than taken by position: an image
-          # carries a digest per repository it has been tagged into, and the
-          # first is not necessarily ours.
-          digest=$(docker inspect --format='{{range .RepoDigests}}{{println .}}{{end}}' \
-            "$ref:$SHA" | grep "^${ref}@" | head -1)
-          test -n "$digest"
-          {
-            echo "Published \`$digest\`"
-            echo ""
-            echo "Pull it with: \`docker pull $digest\`"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -144,16 +144,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.image == 'true' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    # Granted here because a called workflow can only narrow the token it is
-    # handed, never widen it.
-    permissions:
-      contents: read
-      packages: write
     uses: ./.github/workflows/ci-image.yaml
-    # A merge to main that changed the image publishes it; every other event
-    # only checks that it still builds.
-    with:
-      publish: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
   # Packaging is the only check that builds Sen as a package and consumes it
   # from outside, so a pull request runs the shipping configuration; running


### PR DESCRIPTION
Publishing is refused: `denied: installation not allowed to Write organization package`. Creating the package by hand moved the refusal from Create to Write; granting the repository Write and then Admin under Manage Actions access changed nothing. Both messages name the installation, so it is an organisation policy.

