### PR TITLE
fix(ci): report the findings the sanitizer summary was missing

### DIFF
--- a/.github/scripts/summarise_sanitizer_reports.py
+++ b/.github/scripts/summarise_sanitizer_reports.py
@@ -8,7 +8,15 @@
 
 A sanitizer prints one block per finding, and a run repeats the same defect
 across every test that reaches it. Raw, that reads as a crisis; grouped by the
-first frame inside sen::, it reads as the handful of sites it actually is.
+sen:: frames that produced it, it reads as the handful of families it actually is.
+
+Two shapes are parsed. Thread, address and leak sanitizers write
+"WARNING/ERROR: <X>Sanitizer: <kind>"; undefined behaviour writes
+"<file>:<line>:<col>: runtime error:" and neither its own name nor a stack.
+
+A race is a pair, so the family is the first sen:: frame on each side: one anchor
+plus whatever the other side happened to be collapses distinct families together.
+Undefined behaviour has no frames to pair, so its location is its identity.
 
 This reports rather than judges: the exit status says whether the summary was
 written, not whether findings were found.
@@ -25,21 +33,86 @@ from pathlib import Path
 # "ERROR: AddressSanitizer: heap-use-after-free on address 0x60300000eff0"
 FINDING = re.compile(r"(?:WARNING|ERROR): (\w+Sanitizer): (.+)")
 
+# "libs/core/include/sen/core/base/checked_conversions.h:92:34: runtime error: nan is ..."
+# UndefinedBehaviorSanitizer says neither WARNING nor its own name on this line.
+UBSAN = re.compile(r"^(?P<where>\S+?):(?P<line>\d+):(?P<col>\d+): runtime error: (?P<kind>.+?)\s*$", re.M)
+
 # "on vptr" is part of the kind; "on address" is not, nor is a pid or an aside.
 KIND_TAIL = re.compile(r"\s+on address\b|\s+on 0x|\s+\(")
 
 # "    #3 sen::impl::WorkQueueImpl::clear() /workspace/libs/core/src/obj/work_queue.cpp:132:5"
 SEN_FRAME = re.compile(r"#\d+ (sen::[A-Za-z0-9_:~]+)")
+FRAME = re.compile(r"^\s*#\d+ ")
+
+# A block is divided into sides by its own headers: "Previous write of size 4 at
+# 0x... by thread T1:", "Mutex M0 previously acquired by the same thread here:".
+# Anything ending in a colon that is not a frame opens a new side.
+SIDE = re.compile(r":\s*$")
 
 # The repository-relative half of a frame's path, which is what a reader can open.
 SOURCE = re.compile(r"((?:libs|apps|components|tools)/[A-Za-z0-9_/.]+\.(?:cpp|h)):(\d+)")
 
+# The same tail without a line number, for paths the sanitizer prints on their own.
+REPO_PATH = re.compile(r"((?:libs|apps|components|tools)/[A-Za-z0-9_/.]+)$")
+
+
+def anchors(block: str) -> list[str]:
+    """First sen:: frame of each side of a finding, in the order they appear.
+
+    A race names two sides and the pair identifies the family. Sides with no
+    sen:: frame contribute nothing: a finding entirely inside third-party code
+    is anchored by whichever side does reach us.
+    """
+    found: list[str] = []
+    current: str | None = None
+
+    for line in block.splitlines():
+        if not FRAME.match(line) and SIDE.search(line):
+            if current:
+                found.append(current)
+            current = None
+            continue
+        match = SEN_FRAME.search(line)
+        if match and current is None:
+            current = match.group(1)
+
+    if current:
+        found.append(current)
+    return found
+
+
+def relative(path: str) -> str:
+    """Trims an absolute build path down to the repository-relative part."""
+    match = REPO_PATH.search(path)
+    return match.group(1) if match else path
+
+
+def undefined_behaviour(text: str) -> list[dict]:
+    """One entry per UBSan diagnostic.
+
+    These carry no stack, so the source location is both the site and the only
+    thing later runs can be matched on.
+    """
+    entries = []
+    for match in UBSAN.finditer(text):
+        site = f"{relative(match.group('where'))}:{match.group('line')}:{match.group('col')}"
+        entries.append(
+            {
+                "tool": "UndefinedBehaviorSanitizer",
+                "kind": match.group("kind"),
+                "sites": [site],
+                "site": site,
+                "sources": [f"{relative(match.group('where'))}:{match.group('line')}"],
+            }
+        )
+    return entries
+
 
 def findings(text: str) -> list[dict]:
-    """Splits a sanitizer log into one entry per finding.
+    """Splits sanitizer output into one entry per finding.
 
-    A finding runs from its WARNING/ERROR line to the next one, so the frames
-    in between are the ones that produced it.
+    A block runs from its header line to the next one, so the frames in between
+    are the ones that produced it.
     """
     starts = [m.start() for m in FINDING.finditer(text)]
     entries = []
@@ -50,40 +123,60 @@ def findings(text: str) -> list[dict]:
         if match is None:
             continue
 
-        frame = SEN_FRAME.search(block)
+        sites = anchors(block)
         entries.append(
             {
                 "tool": match.group(1),
                 "kind": KIND_TAIL.split(match.group(2))[0].strip(),
-                "site": frame.group(1) if frame else "(no sen:: frame)",
+                "sites": sites,
+                "site": sites[0] if sites else "(no sen:: frame)",
                 "sources": [f"{path}:{line}" for path, line in SOURCE.findall(block)],
             }
         )
-    return entries
+
+    return entries + undefined_behaviour(text)
 
 
 def summarise(entries: list[dict]) -> str:
-    """Renders the grouped findings as markdown."""
+    """Renders the grouped findings as markdown.
+
+    Grouped by family -- tool, kind and the pair of sen:: frames -- because that
+    is the unit a later run can be matched against. Line numbers move; symbols
+    survive a refactor.
+    """
     if not entries:
         return "No sanitizer findings in this run.\n"
 
-    by_site = Counter((entry["tool"], entry["kind"], entry["site"]) for entry in entries)
+    def family(entry: dict) -> tuple:
+        return (entry["tool"], entry["kind"], tuple(entry["sites"]))
+
+    by_family = Counter(family(entry) for entry in entries)
     sources: dict[tuple, Counter] = {}
     for entry in entries:
-        key = (entry["tool"], entry["kind"], entry["site"])
-        sources.setdefault(key, Counter()).update(entry["sources"])
+        sources.setdefault(family(entry), Counter()).update(entry["sources"])
 
-    lines = [f"{len(entries)} sanitizer findings, {len(by_site)} distinct sites.", ""]
-    lines.append("| count | tool | kind | first sen:: frame |")
-    lines.append("|---|---|---|---|")
-    for (tool, kind, site), count in by_site.most_common():
-        lines.append(f"| {count} | {tool} | {kind} | `{site}` |")
+    def count_of(number: int, one: str, many: str) -> str:
+        return f"{number} {one if number == 1 else many}"
+
+    lines = [
+        f"{count_of(len(entries), 'sanitizer finding', 'sanitizer findings')}, "
+        f"{count_of(len(by_family), 'distinct family', 'distinct families')}.",
+        "",
+    ]
+    lines.append("| count | tool | kind | first sen:: frame | other side |")
+    lines.append("|---|---|---|---|---|")
+    for (tool, kind, sites), count in by_family.most_common():
+        first = f"`{sites[0]}`" if sites else "_(no sen:: frame)_"
+        other = f"`{sites[1]}`" if len(sites) > 1 else "_(one side only)_"
+        lines.append(f"| {count} | {tool} | {kind} | {first} | {other} |")
 
     lines.append("")
-    for key, count in by_site.most_common():
+    for key, count in by_family.most_common():
         common = ", ".join(f"`{where}`" for where, _ in sources[key].most_common(4))
-        if common:
-            lines.append(f"- `{key[2]}` ({count}): {common}")
+        if not common:
+            continue
+        _, kind, sites = key
+        lines.append(f"- `{sites[0] if sites else kind}` ({count}): {common}")
 
     return "\n".join(lines) + "\n"
 

--- a/.github/scripts/test_summarise_sanitizer_reports.py
+++ b/.github/scripts/test_summarise_sanitizer_reports.py
@@ -66,10 +66,14 @@ def test_repeats_of_one_site_collapse_into_a_count():
     assert report.count("WorkQueueImpl::clear") >= 1
 
 
-def test_distinct_sites_are_counted_separately():
-    """Two different sites are two rows, and the header says how many."""
+def test_distinct_families_are_counted_separately():
+    """Two different families are two rows, and the header says how many.
+
+    The unit is the family rather than the site: a race is identified by the
+    pair of frames, so two findings sharing one anchor can still be distinct.
+    """
     report = summarise(findings(RACE + LEAK))
-    assert "2 sanitizer findings, 2 distinct sites" in report
+    assert "2 sanitizer findings, 2 distinct families" in report
 
 
 def test_source_locations_are_repository_relative():
@@ -83,3 +87,107 @@ def test_a_finding_with_no_sen_frame_is_kept():
     """Dropping it would hide a finding in third-party or generated code."""
     entry = findings("WARNING: ThreadSanitizer: data race (pid=1)\n    #0 memcpy <null>\n")[0]
     assert entry["site"] == "(no sen:: frame)"
+
+
+# Real output, kept verbatim. UBSan carries no stack frames at all unless
+# print_stacktrace is on, so there is no sen:: frame to group these by; the
+# source location is the only identity they have.
+# From run 33289456516, artifact sanitizer-reports-address.
+UBSAN = """\
+/home/runner/work/sen/sen/components/replayer/src/replayed_object.cpp:374:19: runtime error: null pointer passed as argument 1, which is declared to never be null
+/usr/include/string.h:44:28: note: nonnull attribute specified here
+SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/runner/work/sen/sen/components/replayer/src/replayed_object.cpp:374:19
+/home/runner/work/sen/sen/libs/core/include/sen/core/base/checked_conversions.h:92:34: runtime error: nan is outside the range of representable values of type 'int'
+SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/runner/work/sen/sen/libs/core/include/sen/core/base/checked_conversions.h:92:34
+"""
+
+# A race is a pair, and the pair is what identifies the family: one anchor plus
+# "whatever the other side was" collapses distinct families together.
+# Generated in the CI image, clang 20.1.8, trimmed to the two access sections.
+PAIR = """\
+WARNING: ThreadSanitizer: data race (pid=12)
+  Write of size 4 at 0xffffdc139a78 by thread T2:
+    #0 sen::impl::WorkQueueImpl::clear() /work/pair.cpp:3:73 (pair+0xfbbf8)
+    #1 main::$_1::operator()() const /work/pair.cpp:8:26 (pair+0xfb304)
+
+  Previous write of size 4 at 0xffffdc139a78 by thread T1:
+    #0 sen::impl::WorkQueueImpl::push() /work/pair.cpp:3:50 (pair+0xfb6c4)
+    #1 main::$_0::operator()() const /work/pair.cpp:7:26 (pair+0xfadac)
+
+  Location is stack of main thread.
+"""
+
+INVERSION = """\
+WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock) (pid=30)
+  Cycle in lock order graph: M0 (0xaaaabeb1b5a0) => M1 (0xaaaabeb1b5d0) => M0
+
+  Mutex M1 acquired here while holding mutex M0 in thread T1:
+    #0 pthread_mutex_lock <null> (dd+0x6d8bc)
+    #3 sen::kernel::impl::Session::lock() /workspace/libs/kernel/src/session.cpp:41:3
+
+  Mutex M0 previously acquired by the same thread here:
+    #0 pthread_mutex_lock <null> (dd+0x6d8bc)
+    #3 sen::kernel::impl::Bus::isObjectNameUsedLocally() /workspace/libs/kernel/src/bus.cpp:88:5
+"""
+
+# What a clean run writes when suppressions matched. Not a finding.
+SUPPRESSIONS = """\
+-----------------------------------------------------
+Suppressions used:
+  count      bytes template
+    111       4113 strdup
+     30     127448 sen::ObjectProvider::addListener
+-----------------------------------------------------
+"""
+
+
+def test_undefined_behaviour_is_a_finding():
+    """UBSan writes 'runtime error:', not 'WARNING: XSanitizer:'."""
+    found = findings(UBSAN)
+    assert len(found) == 2, "UBSan findings are invisible to the parser"
+    assert {entry["tool"] for entry in found} == {"UndefinedBehaviorSanitizer"}
+
+
+def test_undefined_behaviour_is_identified_by_its_source_location():
+    """With no frames to group by, the location is the only identity."""
+    found = findings(UBSAN)
+    sites = {entry["site"] for entry in found}
+    assert "components/replayer/src/replayed_object.cpp:374:19" in sites
+    assert "libs/core/include/sen/core/base/checked_conversions.h:92:34" in sites
+
+
+def test_undefined_behaviour_reaches_the_summary():
+    """The lane reported 'no findings' over four of these."""
+    report = summarise(findings(UBSAN))
+    assert "No sanitizer findings" not in report
+    assert "replayed_object.cpp" in report
+
+
+def test_a_race_records_both_sides_of_the_pair():
+    """A race is a pair; one anchor collapses distinct families together."""
+    entry = findings(PAIR)[0]
+    assert entry["sites"] == [
+        "sen::impl::WorkQueueImpl::clear",
+        "sen::impl::WorkQueueImpl::push",
+    ]
+
+
+def test_an_inversion_records_both_mutex_sites():
+    """The same pairing rule holds for lock-order inversions."""
+    entry = findings(INVERSION)[0]
+    assert entry["kind"] == "lock-order-inversion"
+    assert entry["sites"] == [
+        "sen::kernel::impl::Session::lock",
+        "sen::kernel::impl::Bus::isObjectNameUsedLocally",
+    ]
+
+
+def test_kinds_do_not_merge():
+    """A vptr race and a plain race at the same site are different families."""
+    kinds = {entry["kind"] for entry in findings(RACE + VPTR)}
+    assert len(kinds) == 2
+
+
+def test_a_suppressions_block_is_not_a_finding():
+    """Every clean report file contains one; none of them is a finding."""
+    assert findings(SUPPRESSIONS) == []

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -36,3 +36,6 @@ convention = "google"
 [lint.per-file-ignores]
 # Tutorial scripts wrap their whole demo in one try block for error output.
 "examples/**" = ["PLW0717"]
+# Sanitizer output is quoted verbatim as test input. Reflowing a line would
+# change the thing being parsed, so these fixtures are exempt from the width.
+".github/scripts/test_summarise_sanitizer_reports.py" = ["E501"]


### PR DESCRIPTION
## What and why

The summary said "No sanitizer findings in this run." over four real ones in nightly
33289456516. UBSan writes `<file>:<line>:<col>: runtime error:`, which the pattern
never matched, so its findings parsed to nothing.

Races were also keyed on one frame. A race is a pair, and one anchor plus whatever the
other side happened to be collapses distinct families together. They are now keyed on
the first `sen::` frame of each side, which is what a later run can be matched
against: symbols survive a refactor, line numbers do not.

## Verification

Five tests written against real output, red before the change and green after. Against
that nightly's artifact the parser now reports the four findings the run called none.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [x] Tests cover the change where practical
- [x] `conan.lock` was regenerated if `conanfile.py` changed (unchanged)
