### PR TITLE
fix(core,replayer): stop two undefined conversions the sanitizer found

### DIFF
--- a/components/replayer/src/replayed_object.cpp
+++ b/components/replayer/src/replayed_object.cpp
@@ -61,6 +61,17 @@ namespace sen::components::replayer
 namespace
 {
 
+// memcpy is undefined with a null pointer even for a zero-length copy, and an
+// empty span carries one. A function rather than a guard at each site: a
+// destination like writer.advance() must still run when there is nothing to copy.
+void copyBytes(void* destination, const void* source, const size_t size)
+{
+  if (size != 0U)
+  {
+    std::memcpy(destination, source, size);
+  }
+}
+
 class FieldGetterVisitor: public TypeVisitor
 {
 public:
@@ -264,7 +275,7 @@ ReplayedObject::ReplayedObject(const db::Snapshot& snapshot, TimeStamp timeStamp
     if (!span.empty())
     {
       iter->second.resize(span.size());
-      std::memcpy(iter->second.data(), span.data(), span.size());
+      copyBytes(iter->second.data(), span.data(), span.size());
     }
   }
 
@@ -371,7 +382,7 @@ void ReplayedObject::inject(TimeStamp entryTime, const db::PropertyChange& prope
       // save the time, var, and buffer
       changeData->time = entryTime;
       changeData->buffer.resize(span.size());
-      std::memcpy(changeData->buffer.data(), span.data(), span.size());
+      copyBytes(changeData->buffer.data(), span.data(), span.size());
 
       changedProperties_[propertyChange.getProperty()] = std::move(changeData);
       senImplEventEmitted(propertyChange.getProperty()->getId(), {}, EventInfo {entryTime});
@@ -387,7 +398,7 @@ void ReplayedObject::inject(TimeStamp entryTime, const db::Event& event)
       {
         auto span = event.getArgsAsBuffer();
         bufferPtr->resize(span.size());
-        std::memcpy(bufferPtr->data(), span.data(), span.size());
+        copyBytes(bufferPtr->data(), span.data(), span.size());
       }
 
       addWorkToQueue(
@@ -398,7 +409,7 @@ void ReplayedObject::inject(TimeStamp entryTime, const db::Event& event)
           getOutputEventQueue()->push({ev->getId(),
                                        entryTime,
                                        [buf = buffer](OutputStream& out)
-                                       { std::memcpy(out.getWriter().advance(buf->size()), buf->data(), buf->size()); },
+                                       { copyBytes(out.getWriter().advance(buf->size()), buf->data(), buf->size()); },
                                        getId(),
                                        ev->getTransportMode(),
                                        serializedSize});
@@ -448,7 +459,7 @@ void ReplayedObject::inject(TimeStamp entryTime, const db::Snapshot& snapshot)
 
           // copy the buffer
           itr->second->buffer.resize(span.size());
-          std::memcpy(itr->second->buffer.data(), span.data(), span.size());
+          copyBytes(itr->second->buffer.data(), span.data(), span.size());
 
           itr->second->time = entryTime;
         }
@@ -534,7 +545,7 @@ void ReplayedObject::writePropertyToStream(impl::BufferProvider& provider,
   OutputStream out(writer);
   out.writeUInt32(id);
   out.writeUInt32(valueSize);
-  std::memcpy(out.getWriter().advance(valueSize), valueBuffer.data(), valueBuffer.size());
+  copyBytes(out.getWriter().advance(valueSize), valueBuffer.data(), valueBuffer.size());
 }
 
 void ReplayedObject::writePropertyToStream(OutputStream& out,
@@ -543,7 +554,7 @@ void ReplayedObject::writePropertyToStream(OutputStream& out,
 {
   out.writeUInt32(property->getId().get());
   out.writeUInt32(static_cast<uint32_t>(valueBuffer.size()));
-  std::memcpy(out.getWriter().advance(valueBuffer.size()), valueBuffer.data(), valueBuffer.size());
+  copyBytes(out.getWriter().advance(valueBuffer.size()), valueBuffer.data(), valueBuffer.size());
 }
 
 void ReplayedObject::senImplStreamCall(MemberHash methodId, InputStream& in, StreamCallForwarder&& func)

--- a/libs/core/include/sen/core/base/checked_conversions.h
+++ b/libs/core/include/sen/core/base/checked_conversions.h
@@ -77,6 +77,18 @@ ToType conversionImpl(FromType from)
     }
     else
     {
+      // NaN compares false against every bound, so it reaches the cast below,
+      // where converting it to an integer is undefined. A floating-point target
+      // is left alone: there the cast is defined and NaN is worth keeping.
+      if constexpr (!std::is_floating_point_v<ToType>)
+      {
+        if (std::isnan(static_cast<float64_t>(from)))
+        {
+          ReportPolicy::report("Needed to convert `from` to zero as it is not a number.");
+          return ToType {};
+        }
+      }
+
       if (std::isless(static_cast<float64_t>(from), static_cast<float64_t>(std::numeric_limits<ToType>::lowest())))
       {
         ReportPolicy::report("Needed to truncate `from` as it's value was to small for ToType.");

--- a/libs/core/test/base/checked_conversions_test.cpp
+++ b/libs/core/test/base/checked_conversions_test.cpp
@@ -112,7 +112,15 @@ TEST(CheckedConversionsTest, FloatingPointToIntegerTruncation)
 TEST(CheckedConversionsTest, FloatingPointNaNToInteger)
 {
   constexpr double nanValue = std::numeric_limits<double>::quiet_NaN();
-  std::ignore = sen::std_util::ignoredLossyConversion<int32_t>(nanValue);
+
+  // No integer type can represent NaN and the cast to one is undefined, so it
+  // is reported and converted to zero.
+  EXPECT_EQ(sen::std_util::ignoredLossyConversion<int32_t>(nanValue), 0);
+  EXPECT_EQ(sen::std_util::ignoredLossyConversion<uint32_t>(nanValue), 0U);
+  EXPECT_EQ(sen::std_util::ignoredLossyConversion<int64_t>(nanValue), 0);
+
+  // A floating-point target keeps it: that cast is defined.
+  EXPECT_TRUE(std::isnan(sen::std_util::ignoredLossyConversion<float>(nanValue)));
 }
 
 /// @test


### PR DESCRIPTION
## What and why

NaN compares false against every bound in `checkedConversion`, so it reached a cast
that is undefined for integer targets. It now reports and returns zero; a
floating-point target still keeps NaN, where the cast is defined. Its test called the
conversion, discarded the result and asserted nothing.

`memcpy` is undefined with a null pointer even for a zero-length copy, which an empty
span carries. UBSan reported two call sites and the same pattern was at seven, so all
seven go through one helper — a function rather than a guard per site, because three
destinations have a side effect that must still run when nothing is copied.

## Verification

Reproduced red on the pinned toolchain in the CI image, green after. `core_test` and
the replayer build; all 14 `CheckedConversions` tests pass.

Two things a reviewer should weigh. Reverting the NaN guard does not fail the test on
arm, where the undefined cast happens to yield the zero it expects; on x86-64 it
yields `INT_MIN`. And SEN-1054 and SEN-575 are named as the requirements on that test
and I could not read them, so if either specifies something other than zero this is
wrong in a way none of these tests would catch.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [x] Tests cover the change where practical
- [x] `conan.lock` was regenerated if `conanfile.py` changed (unchanged)
