### PR TITLE
ci: gate pull requests on the address and undefined-behaviour sanitizers

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -161,6 +161,16 @@ jobs:
     with:
       pull_request_subset: ${{ github.event_name == 'pull_request' }}
 
+  # A pull request only. The tree is clean under both sanitizers, so a finding
+  # is a regression this change introduced; the nightly keeps the wider sweep.
+  pr-sanitizers:
+    needs: detect-changes
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      needs.detect-changes.outputs.code == 'true'
+    uses: ./.github/workflows/pr_sanitizers.yaml
+
   # The only required check: every other job is skipped in some legitimate
   # case, and a required check that never reports blocks the merge forever.
   # test_main_yaml.py keeps the needs list complete.
@@ -185,6 +195,7 @@ jobs:
       - docs-build
       - image-check
       - conan-packaging
+      - pr-sanitizers
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -1,0 +1,107 @@
+# === pr_sanitizers.yaml ===============================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+#
+# The address and undefined-behaviour sanitizers, on every pull request. The tree
+# is clean under both, so a finding here is a regression the change introduced.
+#
+# SEN_SANITIZER_FAIL_FAST is what makes it a verdict: ASan aborts on its own, and
+# UBSan prints and carries on unless it is told otherwise. The nightly leaves the
+# switch off, because there one abort would hide the findings behind it.
+#
+# The thread sanitizer is deliberately not here. Its lane exists to capture an
+# inventory for the concurrency redesign, and gating on defects that work already
+# owns would block every pull request over them.
+
+name: Pull request sanitizers
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  sanitizers:
+    name: "ASan+UBSan"
+    runs-on: ubuntu-24.04
+    # Generous on purpose, as elsewhere: a cold cache builds every dependency
+    # from source. The cap ends a hang, it does not police duration.
+    timeout-minutes: 120
+    env:
+      CC: clang-20
+      CXX: clang++-20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Generate daily cache id
+        shell: bash
+        run: echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_ENV"
+
+      # Restore only, never save. prepare_build would be the obvious thing to
+      # reuse here, but it saves at the end of the job, and a cache written from
+      # a pull request is private to it: every open pull request storing its own
+      # slice puts the repository past GitHub's 10 GB limit. The nightly can use
+      # it because the nightly only runs on main.
+      - name: Restore conan packages
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.conan2/p
+          key: conanp-ubuntu-24.04-clang-20-17-${{ env.cache_date }}
+          restore-keys: conanp-ubuntu-24.04-clang-20-17-
+
+      # No ccache: sanitized object files must not land in the entries the
+      # ordinary builds depend on. Same rule as the nightly's sanitizer lanes.
+      - name: Setup build context
+        uses: ./.github/actions/setup_build_context
+        with:
+          compiler-name: clang
+          compiler-version: 20
+          arch: x86
+
+      - name: Install additional python dependencies
+        shell: bash
+        run: pip install junitparser==5.0.1
+
+      # Debug also compiles the SEN_DEBUG_ASSERT invariant checks, which
+      # RelWithDebInfo builds leave out.
+      - name: Build with the sanitizers
+        shell: bash
+        run: |
+          options='-o sen/*:with_tests=True -o sen/*:sanitizer=address'
+          variables="{'SEN_SANITIZER_LOG_DIR': '$PWD/sanitizer-reports', 'SEN_SANITIZER_FAIL_FAST': 'ON'}"
+          # shellcheck disable=SC2086
+          conan install . -s "&:build_type=Debug" --build=missing $options \
+            -c "tools.cmake.cmaketoolchain:extra_variables=$variables"
+          # conan build regenerates the toolchain, so it needs the same options.
+          # shellcheck disable=SC2086
+          conan build . -s "&:build_type=Debug" $options \
+            -c "tools.cmake.cmaketoolchain:extra_variables=$variables"
+
+      - name: Run tests
+        shell: bash
+        run: |
+          # Conan provides cmake and ninja; entering its environment is what finds
+          # them, and the image the jobs are moving into ships neither.
+          source build/clang/Debug/generators/conanbuild.sh
+          cmake --build build/clang/Debug/ --target run_tests
+
+      # Always: the findings are what the failure is about, so they have to be
+      # reported on the run that failed.
+      - name: Report the findings
+        if: always()
+        shell: bash
+        run: python3 .github/scripts/summarise_sanitizer_reports.py sanitizer-reports
+
+      - name: Archive the reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: pr-sanitizer-reports
+          path: sanitizer-reports/
+          if-no-files-found: ignore

--- a/cmake/util/sanitizers.cmake
+++ b/cmake/util/sanitizers.cmake
@@ -11,6 +11,13 @@ if(NOT DEFINED SEN_SANITIZER_LOG_DIR)
   set(SEN_SANITIZER_LOG_DIR "")
 endif()
 
+# UBSan prints a finding and lets the process continue, so a lane that gates has
+# to be told to stop. Off by default: the nightly wants the whole sweep, where
+# one abort would hide the findings behind it.
+if(NOT DEFINED SEN_SANITIZER_FAIL_FAST)
+  set(SEN_SANITIZER_FAIL_FAST OFF)
+endif()
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fasynchronous-unwind-tables")
 
@@ -23,6 +30,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
     add_compile_options(-fsanitize=address,undefined)
     add_link_options(-fsanitize=address,undefined)
+
+    if(SEN_SANITIZER_FAIL_FAST)
+      add_compile_options(-fno-sanitize-recover=all)
+    endif()
   elseif(SEN_USE_SANITIZER STREQUAL Thread)
     message(STATUS "Enabling sanitizers: Thread")
 


### PR DESCRIPTION
## What and why

The tree is clean under ASan and UBSan, so a finding on a pull request is a
regression that change introduced. `SEN_SANITIZER_FAIL_FAST` is what turns a finding
into a verdict: ASan aborts on its own, UBSan prints and carries on unless told
otherwise. The nightly leaves the switch off, where one abort would hide the findings
behind it.

The thread sanitizer stays out. That lane exists to capture an inventory for the
concurrency redesign, and gating on defects that work already owns would block every
pull request over them.

The lane restores the conan cache without saving it, as the other pull-request lanes
do — a cache written from a pull request is private to it, and every open one storing
a slice passes GitHub's 10 GB limit.

## Verification

Shown red then green on real code: with a known undefined-behaviour fix reverted, the
lane's configuration fails the test and archives a report naming the reason; restored,
it passes. The red appeared on arm, where the unit test alone provably cannot fail,
which is the point of gating on the sanitizer rather than the test.

A dispatched nightly on current main found the whole suite clean under both
sanitizers, read from the raw artifact rather than the summary line, so this starts
green rather than red.

This pull request runs the lane on itself.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [x] Tests cover the change where practical
- [x] `conan.lock` was regenerated if `conanfile.py` changed (unchanged)
