### PR TITLE
test(ci): stop the fixtures writing git configuration

### DIFF
--- a/.github/scripts/conftest.py
+++ b/.github/scripts/conftest.py
@@ -13,8 +13,18 @@ the one running the hook instead.
 
 import pytest
 
-# Each of these redirects git on its own, whether or not a hook sets it.
-REDIRECTING_VARIABLES = ("GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE", "GIT_COMMON_DIR")
+# Anything inherited that tells git where the repository is, whether or not a hook
+# set it. GIT_DIR and GIT_OBJECT_DIRECTORY are the two that move a write: the first
+# takes precedence over -C, the second sends the objects somewhere else entirely.
+REDIRECTING_VARIABLES = (
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CEILING_DIRECTORIES",
+)
 
 
 @pytest.fixture(autouse=True)

--- a/.github/scripts/test_classify_changes.py
+++ b/.github/scripts/test_classify_changes.py
@@ -6,6 +6,7 @@
 # ======================================================================================================================
 """Pins the docs-only classification that gates the heavy workflow lanes."""
 
+import os
 import subprocess
 import sys
 
@@ -185,11 +186,19 @@ def test_a_base_with_no_common_history_classifies_nothing(tmp_path, monkeypatch,
     """
 
     def git(*args: str) -> None:
-        subprocess.run(["git", "-C", str(tmp_path), *args], check=True, capture_output=True)
+        """Runs git with the identity per invocation and its config inside tmp_path.
+
+        Contained the same way as test_create_changelog.py, where the reason is.
+        """
+        env = {
+            **os.environ,
+            "GIT_CONFIG_GLOBAL": str(tmp_path / "gitconfig-global"),
+            "GIT_CONFIG_SYSTEM": str(tmp_path / "gitconfig-system"),
+        }
+        identity = ["-c", "user.name=Test", "-c", "user.email=test@example.com"]
+        subprocess.run(["git", "-C", str(tmp_path), *identity, *args], check=True, capture_output=True, env=env)
 
     git("init", "-q", "-b", "one")
-    git("config", "user.email", "test@example.com")
-    git("config", "user.name", "Test")
     (tmp_path / "file.txt").write_text("one")
     git("add", "file.txt")
     git("-c", "commit.gpgsign=false", "commit", "-qm", "one")

--- a/.github/scripts/test_create_changelog.py
+++ b/.github/scripts/test_create_changelog.py
@@ -7,6 +7,7 @@
 """Pins the grouping and breaking-change extraction of the changelog."""
 
 import configparser
+import os
 import subprocess
 from pathlib import Path
 
@@ -16,8 +17,20 @@ GITLINT_FILE = Path(__file__).resolve().parents[2] / ".gitlint"
 
 
 def git(repo: Path, *args: str) -> None:
-    """Runs a git command in the test repository."""
-    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+    """Runs a git command in the test repository.
+
+    The identity goes in per invocation and the global and system config files
+    point inside the test's own directory, so a call that resolves somewhere
+    unexpected writes nothing real. One that ran `git config` left
+    `test@example.com` on a working clone, and two commits reached GitHub with it.
+    """
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": str(repo.parent / "gitconfig-global"),
+        "GIT_CONFIG_SYSTEM": str(repo.parent / "gitconfig-system"),
+    }
+    identity = ["-c", "user.name=Test", "-c", "user.email=test@example.com"]
+    subprocess.run(["git", "-C", str(repo), *identity, *args], check=True, capture_output=True, env=env)
 
 
 def commit(repo: Path, subject: str) -> None:
@@ -108,8 +121,6 @@ def test_the_previous_release_line_is_chosen_from_a_detached_head(tmp_path, monk
     repo = tmp_path / "repo"
     repo.mkdir()
     git(repo, "init", "-q", "-b", "main")
-    git(repo, "config", "user.email", "test@example.com")
-    git(repo, "config", "user.name", "Test")
     commit(repo, "feat: the 0.5 work")
     git(repo, "branch", "release/0.5.x")
     commit(repo, "feat: the 0.6 work")


### PR DESCRIPTION
Two fixtures ran `git -C <tmp> config user.email`, so nothing but -C resolving as intended kept the write inside the test. Somewhere it did not: thirteen commits across these clones are authored Test <test@example.com>, two of them on GitHub.

They now pass the identity per invocation and never call git config, and the global and system config files point inside the test's own directory.