### PR TITLE
ci: install the cmake and ninja Conan pins in the image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,10 @@
     "name": "sen",
     // The Dockerfile has no COPY steps; a repo-root context would tar the
     // whole checkout on every rebuild.
-    // The dev stage is the CI image plus what an editor needs to recognise a
-    // toolchain: cmake, ninja and gdb. The builds themselves still use the
-    // cmake and ninja Conan pins.
+    // The dev stage is the CI image plus what an editor needs on top of the
+    // toolchain it already carries: a debugger, and graphviz for the
+    // dependency-graph target. The builds themselves still use the cmake and
+    // ninja Conan pins.
     "build": {
         "dockerfile": "../tools/ci/Dockerfile",
         "context": "../tools/ci",

--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -81,6 +81,9 @@ jobs:
           # The action that installs the toolchain on runners pins the same
           # conan version; the image is the definition, so read it from there.
           conan_version=$(sed -n 's/^ARG CONAN_VERSION=//p' tools/ci/Dockerfile)
+          cmake_version=$(sed -n 's/^ARG CMAKE_VERSION=//p' tools/ci/Dockerfile)
+          ninja_version=$(sed -n 's/^ARG NINJA_VERSION=//p' tools/ci/Dockerfile)
+          test -n "$conan_version" && test -n "$cmake_version" && test -n "$ninja_version"
           docker run --rm sen-ci:probe bash -lc '
             set -e
             for tool in conan python3 pip3 ccache git make g++-12 gcc-12 \
@@ -99,11 +102,11 @@ jobs:
             # --no-install-recommends leaves out unless it is asked for.
             printf "int main(){return 0;}" > /tmp/probe.cpp
             clang++-20 -fsanitize=address -o /tmp/probe /tmp/probe.cpp
-            # cmake and ninja must come from Conan, so that every build uses
-            # the pinned versions; finding them here would defeat that.
-            for tool in cmake ninja; do
-                ! command -v "$tool" > /dev/null || { echo "unexpected: $tool"; exit 1; }
-            done
+            # A package built from source in here uses these, so they must report
+            # the versions Conan pins rather than merely be present. ninja appends the
+            # packager patch level to what it reports, so compare only the release.
+            cmake --version | head -1 | grep -Fx "cmake version '"$cmake_version"'"
+            test "$(ninja --version | cut -d. -f1-3)" = "'"$ninja_version"'"
             test "$(id -un)" = sen || { echo "image runs as $(id -un)"; exit 1; }
             echo "all expected tools present"
           '

--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -86,8 +86,8 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          # Conan provides cmake and ninja; entering its environment is what finds
-          # them, and the image the jobs are moving into ships neither.
+          # Conan provides cmake and ninja; entering its environment is what puts
+          # them ahead of whatever else is on PATH, the image's own pair included.
           source build/clang/Debug/generators/conanbuild.sh
           cmake --build build/clang/Debug/ --target run_tests
 

--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -137,9 +137,8 @@ jobs:
         if: matrix.runtime_base != ''
         shell: bash
         run: |
-          # Conan provides cmake and ninja, and the image ships neither; entering
-          # its environment is what finds them. Harmless on a runner that has its
-          # own cmake, and required the moment a job runs inside the image.
+          # Conan provides cmake and ninja; entering its environment is what puts
+          # them ahead of whatever else is on PATH, the runner's own copies included.
           source build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/generators/conanbuild.sh
           ctest --test-dir build/${{ matrix.compiler.name }}/${{ matrix.build_type }} \
             -N -L integration | grep -q object_sync

--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -9,15 +9,15 @@
 # .github/actions/setup_build_context installs the same toolchain directly
 # on runners; keep the two in sync.
 #
-# cmake, ninja and node are not installed: Conan tool_requires provide them.
-# Steps that call cmake directly must source the generated conanbuild.sh
-# first.
+# cmake and ninja are installed at the versions conanfile.py tool-requires. A Conan
+# tool_requires reaches the sen package only, so a package built from source in here
+# finds neither. Sen's own build still uses Conan's copies: a step calling cmake or
+# ninja directly must source the generated conanbuild.sh first.
 #
 # Two stages. `base` is what CI validates and what the pipeline is described
-# against. `dev` adds what an editor needs to recognise a toolchain, and is
-# what the devcontainer builds; keeping those tools out of `base` keeps one
-# pinned cmake for the builds themselves. Build `base` explicitly: a plain
-# `docker build` takes the last stage.
+# against. `dev` adds what an editor needs to recognise a toolchain, and is what
+# the devcontainer builds. Build `base` explicitly: a plain `docker build` takes
+# the last stage.
 
 # Pinned by digest: the tag moves whenever Canonical republishes it, which made
 # two developers building a fortnight apart hold different toolchains. Update it
@@ -29,8 +29,10 @@ ARG LLVM_VERSION=20
 ARG CONAN_VERSION=2.28.1
 ARG JUNITPARSER_VERSION=5.0.1
 ARG PYTEST_VERSION=9.1.1
-# For the dev stage only: the editors need a cmake that reads Conan's presets.
+# Both must equal the versions conanfile.py tool-requires, and nothing checks that
+# they do. The header says why the image carries them at all.
 ARG CMAKE_VERSION=3.28.1
+ARG NINJA_VERSION=1.13.2
 
 LABEL org.opencontainers.image.source="https://github.com/airbus/sen" \
       org.opencontainers.image.description="Sen CI build environment" \
@@ -95,11 +97,14 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     && rm -rf /var/lib/apt/lists/*
 
 
-# cmake/util/test.cmake invokes junitparser from the run_tests targets;
-# pytest runs the python test suites.
+# cmake/util/test.cmake invokes junitparser from the run_tests targets; pytest runs
+# the python test suites. cmake comes from pip because Ubuntu 22.04 ships 3.22, which
+# cannot read the CMakeUserPresets.json Conan writes at version 4.
 RUN pip3 install --no-cache-dir \
+        cmake==${CMAKE_VERSION} \
         conan==${CONAN_VERSION} \
         junitparser==${JUNITPARSER_VERSION} \
+        ninja==${NINJA_VERSION} \
         pytest==${PYTEST_VERSION}
 
 # Work as a normal user: on a Linux host the editor remaps this user's ids to
@@ -123,12 +128,10 @@ USER sen
 WORKDIR /workspace
 
 
-# CLion, VS Code and Visual Studio detect a toolchain by looking for cmake, a
-# build tool and a debugger inside the environment, so an editor cannot drive
-# the container without them. cmake comes from pip rather than apt because
-# Ubuntu 22.04 ships 3.22, which cannot read the CMakeUserPresets.json that
-# Conan writes (it declares version 4). graphviz is here for the
-# cmake_target_graph target, which otherwise warns that 'dot' is missing.
+# CLion, VS Code and Visual Studio detect a toolchain by looking for cmake, a build
+# tool and a debugger inside the environment; base carries the first two, so this
+# stage adds the debugger. graphviz is here for the cmake_target_graph target, which
+# otherwise warns that 'dot' is missing.
 FROM base AS dev
 
 # Names again, for the same reason as in the base stage: this user exists in
@@ -138,8 +141,6 @@ USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gdb \
         graphviz \
-        ninja-build \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip3 install --no-cache-dir cmake==${CMAKE_VERSION}
+    && rm -rf /var/lib/apt/lists/*
 # hadolint ignore=DL3066
 USER sen

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -257,27 +257,30 @@ depend on.
 [`Dockerfile`](Dockerfile) defines the build environment: gcc-12, clang-20
 and clang-tidy-20 from a pinned apt.llvm.org repository, ccache, pinned
 versions of conan, junitparser and pytest, and the coverage tools
-(gcovr, lcov and the LLVM equivalents). cmake, ninja and node are not
-installed in the image: Conan provides them as tool_requires. Anything that calls cmake
-directly must source the generated `conanbuild.sh` first.
+(gcovr, lcov and the LLVM equivalents), and cmake and ninja at the versions
+`conanfile.py` tool-requires. Those last two are there for the dependencies. A
+Conan `tool_requires` applies to the sen package alone, so a package built from
+source in the image finds neither, and the profiles select the Ninja generator
+everywhere, so even building ninja needs one. Sen's own build is unaffected:
+anything that calls cmake directly must still source the generated
+`conanbuild.sh` first, which is what puts Conan's copies on PATH.
 `setup_build_context` installs the same toolchain directly on hosted
 runners; keep the two in sync.
 
 The Dockerfile has two stages. `base` is the image described above, the one
-the pipeline is measured against. `dev` adds cmake, ninja, gdb and graphviz,
-because an editor detects a toolchain by looking for the first three and the
-dependency-graph target needs the fourth, and the devcontainer builds that
-stage. Its cmake comes from pip rather than the distribution:
-Conan writes `CMakeUserPresets.json` at version 4, which Ubuntu 22.04's cmake
-3.22 refuses to read. Builds still use the cmake and ninja that Conan pins, so
-the rule above is unchanged; the editor tools exist for the editor.
+the pipeline is measured against. `dev` adds gdb and graphviz, because an
+editor detects a toolchain by looking for cmake, a build tool and a debugger,
+and the dependency-graph target needs `dot`; the devcontainer builds that
+stage. `base` installs cmake from pip rather than from the distribution
+because Conan writes `CMakeUserPresets.json` at version 4, which Ubuntu
+22.04's cmake 3.22 refuses to read.
 
 `ci-image.yaml` builds both stages and then checks what is inside them. For
-`base`: the expected tools are present, cmake and ninja are absent, clang can
-link a sanitizer binary, and the image does not run as root. For `dev`: cmake,
-ninja, gdb and dot are present and cmake is new enough to read the presets. A Dockerfile
-that still builds but lost a tool therefore fails in the pull request that
-broke it. `main.yaml` calls it when a change touches the build environment,
+`base`: the expected tools are present, cmake and ninja report the versions
+`conanfile.py` tool-requires, clang can link a sanitizer binary, and the image
+does not run as root. For `dev`: cmake, ninja, gdb and dot are present and
+cmake is new enough to read the presets. A Dockerfile that still builds but
+lost a tool therefore fails in the pull request that broke it. `main.yaml` calls it when a change touches the build environment,
 and `ci-ok` needs it, so a broken image blocks the merge instead of showing up
 as a red mark beside it. Documentation under `tools/ci/` does not trigger it:
 the Dockerfile copies nothing out of the repository. Docker layer caching in the Actions cache keeps
@@ -336,11 +339,13 @@ runner builds for its own architecture, so the multi-architecture problem does n
 arise.
 
 **One cmake, not two.** Conan provides cmake and ninja as tool requirements,
-so they stay out of the image. The rule that follows is that any step
-invoking cmake must do so inside the environment Conan generates. When a step
-calls the cmake that happens to be installed on the runner instead, it
-disagrees with the one that configured the build, and the whole project
-relinks; that is a real cost that was measured, not a theoretical concern.
+and the rule that follows is that any step invoking cmake must do so inside
+the environment Conan generates. When a step calls the cmake that happens to
+be installed on the runner instead, it disagrees with the one that configured
+the build, and the whole project relinks; that is a real cost that was
+measured, not a theoretical concern. The image carries the same versions for
+the builds a tool requirement cannot reach, which is its own dependencies, so
+the rule holds there too.
 
 **One compiler version across the Linux configurations.** All of them build
 with gcc-12, including the arm configuration, so the profiles no longer
@@ -518,11 +523,6 @@ stack**, and the pull request it blocks is not necessarily the one being merged.
   compile: `apps/cli_run` defines a helper whose only callers sit behind the explorer
   preset, so with the explorer off it is an unused function and `-Werror` stops the
   build.
-- **A dependency cannot be built from source inside the CI image.** cmake is a
-  tool requirement of the sen package only, while the profiles inject ninja for every
-  package and cmake for none, and the image ships no cmake. On a hosted runner the
-  dependency build silently picks up the runner's own cmake, so this only appears when
-  a job runs inside the image with a cold cache.
 - MSVC jobs build but do not run tests (SEN-1725). Uploading coverage to an
   external service is wired but disabled (SEN-1726); the published report and
   the floor cover the same ground without sending anything outside.


### PR DESCRIPTION
A Conan tool_requires reaches the sen package only, so a package built from source in the image found no cmake, and the profiles select the Ninja generator everywhere, so building ninja found no ninja. On a hosted runner those builds pick up the runner's own cmake instead.

Sen's own build is unchanged: after sourcing conanbuild.sh both tools resolve to Conan's copies. The image check now asserts the pinned versions rather than their absence.