### PR TITLE
ci: run a named CI lane locally, from one definition

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,10 @@
     "name": "sen",
     // The Dockerfile has no COPY steps; a repo-root context would tar the
     // whole checkout on every rebuild.
-    // The dev stage is the CI image plus what an editor needs to recognise a
-    // toolchain: cmake, ninja and gdb. The builds themselves still use the
-    // cmake and ninja Conan pins.
+    // The dev stage is the CI image plus what an editor needs on top of the
+    // toolchain it already carries: a debugger, and graphviz for the
+    // dependency-graph target. The builds themselves still use the cmake and
+    // ninja Conan pins.
     "build": {
         "dockerfile": "../tools/ci/Dockerfile",
         "context": "../tools/ci",

--- a/.github/scripts/lanes.py
+++ b/.github/scripts/lanes.py
@@ -1,0 +1,331 @@
+# === lanes.py =========================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""The CI lanes, defined once and runnable without pushing.
+
+A lane is a compiler, a build type and a set of conan options, followed by one cmake
+target. That is the whole shape, and every lane in the workflows fits it.
+
+The definitions here are the ones the workflows run: test_lanes.py compares each lane
+against the workflow that carries it, so a lane that drifts from CI fails a test rather
+than reporting a verdict that CI would not give.
+
+A lane runs inside the CI image, built from tools/ci/Dockerfile, as the invoking user.
+That is what makes a local answer comparable to CI's. It is not the same answer: the
+runners are x86 and a developer machine may not be.
+"""
+
+import argparse
+import dataclasses
+import os
+import platform
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+IMAGE = "sen-ci:base"
+
+# Kept out of the checkout and out of the devcontainer's volumes. Those are owned by the
+# image's user, and a container running as the invoking uid cannot write to them.
+STATE = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "sen-lanes"
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Lane:
+    """One CI lane, and where it runs today."""
+
+    name: str
+    summary: str
+    # The workflow and job that carry this lane now. test_lanes.py reads them.
+    workflow: str
+    job: str
+    compiler: str
+    compiler_version: int
+    build_type: str
+    cppstd: int | None = None
+    # Conan options, without the -o that introduces each of them.
+    options: tuple[str, ...] = ()
+    # cmake cache variables passed through conan, in the order the workflow writes them.
+    extra_variables: tuple[tuple[str, str], ...] = ()
+    # The target built after conan. A lane whose whole work is the compile has none.
+    target: str | None = None
+    # A script under .github/scripts run afterwards, whatever the build did.
+    report: tuple[str, ...] = ()
+
+    @property
+    def build_dir(self) -> str:
+        """Where conan puts this lane's build, from build_folder_vars in the profiles."""
+        return f"build/{self.compiler}/{self.build_type}"
+
+    @property
+    def cc(self) -> str:
+        """The C compiler the workflow sets for this lane."""
+        return (
+            f"{self.compiler}-{self.compiler_version}" if self.compiler == "clang" else f"gcc-{self.compiler_version}"
+        )
+
+    @property
+    def cxx(self) -> str:
+        """The C++ compiler the workflow sets for this lane."""
+        return f"clang++-{self.compiler_version}" if self.compiler == "clang" else f"g++-{self.compiler_version}"
+
+
+# The standard test matrix is absent: its legs are data in generate_matrix_jobs.py
+# already, and its steps carry matrix expressions this would have to evaluate.
+LANES = (
+    Lane(
+        name="asan-ubsan",
+        summary="the address and undefined-behaviour gate that every pull request runs",
+        workflow="pr_sanitizers.yaml",
+        job="sanitizers",
+        compiler="clang",
+        compiler_version=20,
+        build_type="Debug",
+        options=("sen/*:with_tests=True", "sen/*:sanitizer=address"),
+        extra_variables=(("SEN_SANITIZER_LOG_DIR", "$PWD/sanitizer-reports"), ("SEN_SANITIZER_FAIL_FAST", "ON")),
+        target="run_tests",
+        report=("summarise_sanitizer_reports.py", "sanitizer-reports"),
+    ),
+    Lane(
+        name="tsan",
+        summary="the nightly thread-sanitizer lane, which collects rather than gates",
+        workflow="nightly.yaml",
+        job="sanitizers",
+        compiler="clang",
+        compiler_version=20,
+        build_type="Debug",
+        options=("sen/*:with_tests=True", "sen/*:sanitizer=thread"),
+        extra_variables=(("SEN_SANITIZER_LOG_DIR", "$PWD/sanitizer-reports"),),
+        target="run_tests",
+        report=("summarise_sanitizer_reports.py", "sanitizer-reports"),
+    ),
+    Lane(
+        name="clang-tidy",
+        summary="the nightly analysis of the targets that opted in",
+        workflow="nightly.yaml",
+        job="clang-tidy",
+        compiler="clang",
+        compiler_version=20,
+        build_type="Release",
+        options=("sen/*:with_tests=True", "sen/*:with_clang_tidy=True"),
+    ),
+    Lane(
+        name="coverage",
+        summary="the nightly coverage report, which runs the suite as it measures it",
+        workflow="nightly.yaml",
+        job="coverage",
+        compiler="clang",
+        compiler_version=20,
+        build_type="Debug",
+        cppstd=17,
+        options=("sen/*:with_tests=True", "sen/*:with_coverage=True"),
+        target="generate-coverage-report",
+    ),
+)
+
+BY_NAME = {lane.name: lane for lane in LANES}
+
+
+def _settings(lane: Lane) -> list[str]:
+    """The settings both conan commands take, applied to the sen package alone."""
+    settings = ["-s", f"&:build_type={lane.build_type}"]
+    if lane.cppstd is not None:
+        settings += ["-s", f"&:compiler.cppstd={lane.cppstd}"]
+    return settings
+
+
+def _options_and_conf(lane: Lane) -> list[str]:
+    """The options and cmake variables both conan commands take."""
+    arguments = [argument for option in lane.options for argument in ("-o", option)]
+    if lane.extra_variables:
+        body = ", ".join(f"'{name}': '{value}'" for name, value in lane.extra_variables)
+        arguments += ["-c", f"tools.cmake.cmaketoolchain:extra_variables={{{body}}}"]
+    return arguments
+
+
+def commands(lane: Lane) -> list[list[str]]:
+    """Everything the lane runs, in order, as argument lists.
+
+    conan build takes the same options as conan install because it regenerates the
+    toolchain; without them it would do so from the defaults, which build no tests.
+    The argument order is the workflows' own, so test_lanes.py can compare literally.
+    """
+    settings, rest = _settings(lane), _options_and_conf(lane)
+    result = [
+        ["conan", "install", ".", *settings, "--build=missing", *rest],
+        ["conan", "build", ".", *settings, *rest],
+    ]
+    if lane.target is not None:
+        result.append(["source", f"{lane.build_dir}/generators/conanbuild.sh"])
+        result.append(["cmake", "--build", f"{lane.build_dir}/", "--target", lane.target])
+    if lane.report:
+        script, *report_arguments = lane.report
+        result.append(["python3", f".github/scripts/{script}", *report_arguments])
+    return result
+
+
+def profile_name(lane: Lane) -> str:
+    """The repository profile this lane installs as the conan default.
+
+    There is a per-architecture profile for gcc only, and the architecture-free ones
+    detect it themselves, so clang falls back to the base profile.
+    """
+    architecture = "arm" if platform.machine() in ("aarch64", "arm64") else "x86"
+    specific = ROOT / ".conan" / "profiles" / f"sen_{lane.compiler}_{architecture}"
+    return specific.name if specific.exists() else f"sen_{lane.compiler}"
+
+
+def setup_commands(lane: Lane) -> list[str]:
+    """Installs the repository profiles and selects this lane's, as CI does.
+
+    setup_build_context does this on a runner and the devcontainer's postCreateCommand
+    does it again, so this is a third copy of it.
+    """
+    commands = [
+        # The image gives a foreign uid no home of its own, and conan wants one.
+        'mkdir -p "$HOME"',
+        "conan profile detect --force -vquiet",
+        'conan config install .conan/profiles/ --target-folder "$CONAN_HOME"/profiles/',
+        f'cp .conan/profiles/{profile_name(lane)} "$CONAN_HOME"/profiles/default',
+    ]
+    # A runner reports on a fresh checkout; here the directory survives between runs,
+    # and the summariser reads whatever is in it.
+    for name, value in lane.extra_variables:
+        if name.endswith("_LOG_DIR"):
+            prefix, _, tail = value.partition("/")
+            if prefix != "$PWD" or not tail.replace("-", "").replace("_", "").isalnum():
+                raise ValueError(f"cannot clear a report directory spelled {value!r}")
+            commands.append(f'rm -rf "$PWD"/{tail}')
+    return commands
+
+
+def script_for(lane: Lane) -> str:
+    """The whole lane as one shell script, which is how the commands share an environment."""
+    rendered = [" ".join(_quote(part) for part in command) for command in commands(lane)]
+    lines = ["set -e", *setup_commands(lane)]
+    if lane.report:
+        # The workflow reports with `if: always()`, because a lane that failed is when
+        # the findings are worth reading. The verdict stays the build's either way:
+        # the summariser reports and never gates.
+        *rendered, report = rendered
+        lines += [f"report() {{ {report}; }}", "trap report EXIT"]
+    return "\n".join([*lines, *rendered])
+
+
+def _quote(part: str) -> str:
+    """Quotes one argument, leaving a shell expansion inside it able to expand.
+
+    extra_variables carries $PWD, which the workflows let the shell resolve, so that
+    argument takes double quotes instead of going through shlex.
+    """
+    if "$" not in part:
+        return shlex.quote(part)
+    if any(character in part for character in '"\\`'):
+        raise ValueError(f"cannot quote an argument that expands and also quotes: {part}")
+    return f'"{part}"'
+
+
+def _docker_arguments(lane: Lane) -> list[str]:
+    """Runs the image as the invoking user, with the variables it cannot inherit.
+
+    The image bakes CCACHE_DIR into another user's home, where a foreign uid cannot
+    write, and ccache then degrades to a silent total miss rather than an error.
+    """
+    build_state = STATE / "build" / lane.name
+    for directory in (STATE / "conan", STATE / "ccache", build_state):
+        directory.mkdir(parents=True, exist_ok=True)
+    mounts = {
+        ROOT: "/workspace",
+        # Over the checkout's own build folder. A build configured in a container
+        # cannot be built on the host, so this leaves the developer's one alone.
+        build_state: "/workspace/build",
+        STATE / "conan": "/conan",
+        STATE / "ccache": "/ccache",
+    }
+    environment = {"HOME": "/tmp/sen", "CONAN_HOME": "/conan", "CCACHE_DIR": "/ccache"}
+    environment |= {"CC": lane.cc, "CXX": lane.cxx}
+    if lane.compiler == "gcc":
+        # The gcc profile reads this; without it the version reaches nothing.
+        environment["SEN_GCC_VERSION"] = str(lane.compiler_version)
+
+    arguments = ["docker", "run", "--rm", "-i", "--user", f"{os.getuid()}:{os.getgid()}"]
+    for source, target in mounts.items():
+        arguments += ["-v", f"{source}:{target}"]
+    for name, value in environment.items():
+        arguments += ["-e", f"{name}={value}"]
+    return [*arguments, "-w", "/workspace", IMAGE, "bash", "-l", "-s"]
+
+
+def build_image() -> None:
+    """Builds the CI image from the Dockerfile that defines it."""
+    print(f"building {IMAGE} from tools/ci/Dockerfile", file=sys.stderr)
+    subprocess.run(
+        ["docker", "build", "--target", "base", "-t", IMAGE, "-f", "tools/ci/Dockerfile", "tools/ci"],
+        cwd=ROOT,
+        check=True,
+    )
+
+
+def run_in_container(lane: Lane) -> int:
+    """Runs the lane inside the CI image, leaving the checkout as it found it.
+
+    conan install rewrites CMakeUserPresets.json beside the conanfile, and its paths
+    belong to whichever environment configured the build, so a lane would replace the
+    entries a developer's editor reads with ones pointing into the container.
+    """
+    build_image()
+    presets = ROOT / "CMakeUserPresets.json"
+    saved = presets.read_bytes() if presets.exists() else None
+    try:
+        script = script_for(lane)
+        return subprocess.run(_docker_arguments(lane), input=script, text=True, cwd=ROOT, check=False).returncode
+    finally:
+        if saved is None:
+            presets.unlink(missing_ok=True)
+        else:
+            presets.write_bytes(saved)
+
+
+def main() -> int:
+    """Runs one lane, or says which there are."""
+    parser = argparse.ArgumentParser(prog="lanes", description=__doc__.splitlines()[0])
+    parser.add_argument("lane", nargs="?", help="the lane to run")
+    parser.add_argument("--list", action="store_true", help="list the lanes and stop")
+    parser.add_argument("--print", action="store_true", help="print what the lane would run and stop")
+    arguments = parser.parse_args()
+
+    if arguments.list or arguments.lane is None:
+        for lane in LANES:
+            print(f"  {lane.name:<12} {lane.summary}")
+            print(f"  {'':<12} runs today as {lane.job} in .github/workflows/{lane.workflow}")
+        return 0 if arguments.list else 2
+
+    if arguments.lane not in BY_NAME:
+        parser.error(f"unknown lane {arguments.lane!r}; --list shows them")
+    lane = BY_NAME[arguments.lane]
+
+    if arguments.print:
+        print(script_for(lane))
+        return 0
+
+    # Listing and printing work anywhere; running needs the Linux image, and the uid
+    # handling below is POSIX. Windows is built by its own workflow leg.
+    if os.name != "posix":
+        print("a lane runs in the Linux CI image, which this platform cannot host", file=sys.stderr)
+        return 1
+
+    if os.getuid() == 0:
+        # Artefacts would belong to root, which is what breaks the host steps that
+        # follow a container job and what leaves a checkout nobody else can write.
+        print("refusing to run as root: the build would own its output as root", file=sys.stderr)
+        return 1
+    return run_in_container(lane)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_lanes.py
+++ b/.github/scripts/test_lanes.py
@@ -1,0 +1,148 @@
+# === test_lanes.py ====================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Checks every lane definition against what its workflow actually runs.
+
+lanes.py exists so that a developer runs what CI runs, which holds only while the two
+agree. A definition that had drifted would answer confidently and wrongly.
+
+The comparison is literal, token for token. Anything in a modelled job that is not a
+lane command has to be named below, so a step added to a workflow fails here rather
+than being left out of the local run.
+"""
+
+import dataclasses
+import re
+import shlex
+
+import lanes
+import pytest
+import yaml
+
+WORKFLOWS = lanes.ROOT / ".github" / "workflows"
+
+# Run lines that are not part of a lane, matched whole rather than by their first word:
+# a step that installed something a lane needed would otherwise be excused by looking
+# like one that does not.
+NOT_LANE_COMMANDS = {
+    # The runner installs what the image already carries.
+    ("pip", "install", "junitparser==5.0.1"),
+    # Writes a cache key into the job environment. There is no cache to key locally.
+    ("echo", "cache_date=$(/bin/date -u +%Y%m%d)", ">>", "$GITHUB_ENV"),
+}
+
+EXPRESSION = re.compile(r"\$\{\{([^}]*)\}\}")
+ASSIGNMENT = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+
+
+def run_lines(workflow: str, job: str) -> list[str]:
+    """Every line of every run step of one job, continuations joined, comments dropped."""
+    document = yaml.safe_load((WORKFLOWS / workflow).read_text(encoding="utf-8"))
+    jobs = document["jobs"]
+    assert job in jobs, f"{workflow} has no job {job!r}; a lane names it, so one of the two was renamed"
+    body = "\n".join(step["run"] for step in jobs[job]["steps"] if "run" in step)
+    body = body.replace("\\\n", " ")
+    return [line.strip() for line in body.splitlines() if line.strip() and not line.strip().startswith("#")]
+
+
+def substitute(line: str, values: dict[str, str]) -> str:
+    """Resolves the workflow expressions in one line, refusing any it was not given.
+
+    An unknown expression would otherwise be compared as literal text.
+    """
+
+    def replace(match: re.Match) -> str:
+        name = match.group(1).strip()
+        if name not in values:
+            raise AssertionError(f"no value for the workflow expression {name!r} in: {line}")
+        return values[name]
+
+    return EXPRESSION.sub(replace, line)
+
+
+def expand(lines: list[str]) -> list[str]:
+    """Resolves the shell variables a step assigns to itself, and drops the assignments."""
+    assigned: dict[str, str] = {}
+    expanded = []
+    for line in lines:
+        match = ASSIGNMENT.match(line)
+        if match and not line.startswith("export "):
+            name, raw = match.groups()
+            # A whole-line assignment quotes its value; shlex gives the value back.
+            assigned[name] = shlex.split(raw)[0] if raw else ""
+            continue
+        resolved = line
+        for name, value in assigned.items():
+            resolved = resolved.replace(f"${name}", value)
+        expanded.append(resolved)
+    return expanded
+
+
+def workflow_commands(lane: lanes.Lane) -> list[list[str]]:
+    """The lane commands the workflow runs, as argument lists.
+
+    Every line that is not one has to be accounted for by NOT_LANE_COMMANDS, so a new
+    step cannot go unnoticed by being unrecognised.
+    """
+    # The nightly runs both sanitizer lanes from one job, so the lane picks the leg.
+    sanitizer = [option for option in lane.options if option.startswith("sen/*:sanitizer=")]
+    values = {"matrix.sanitizer": sanitizer[0].split("=", 1)[1]} if sanitizer else {}
+
+    commands = []
+    for line in expand(run_lines(lane.workflow, lane.job)):
+        tokens = shlex.split(substitute(line, values))
+        if not tokens:
+            continue
+        if tuple(tokens) in NOT_LANE_COMMANDS:
+            continue
+        assert tokens[0] in ("conan", "cmake", "source", "python3"), (
+            f"{lane.workflow}:{lane.job} runs {tokens[0]!r}, which lanes.py does not model "
+            f"and NOT_LANE_COMMANDS does not excuse: {line}"
+        )
+        commands.append(tokens)
+    return commands
+
+
+@pytest.mark.parametrize("lane", lanes.LANES, ids=lambda lane: lane.name)
+def test_the_lane_runs_what_its_workflow_runs(lane):
+    """A lane definition and the job it names have to be the same commands."""
+    assert lanes.commands(lane) == workflow_commands(lane)
+
+
+@pytest.mark.parametrize("lane", lanes.LANES, ids=lambda lane: lane.name)
+def test_the_job_the_lane_names_exists(lane):
+    """Without this, a renamed job would empty the comparison above rather than fail it."""
+    document = yaml.safe_load((WORKFLOWS / lane.workflow).read_text(encoding="utf-8"))
+    assert lane.job in document["jobs"], f"{lane.workflow} has no job {lane.job!r}"
+    assert workflow_commands(lane), f"{lane.workflow}:{lane.job} contributed no commands to compare"
+
+
+@pytest.mark.parametrize("lane", lanes.LANES, ids=lambda lane: lane.name)
+def test_the_lane_uses_the_compiler_its_job_sets(lane):
+    """The compiler version reaches the commands nowhere, so compare it separately.
+
+    build/<compiler>/<build_type> carries the name and not the version, so a lane
+    naming the wrong version would generate commands that match and then build with a
+    compiler CI does not use.
+    """
+    document = yaml.safe_load((WORKFLOWS / lane.workflow).read_text(encoding="utf-8"))
+    environment = document["jobs"][lane.job].get("env", {})
+    assert (environment.get("CC"), environment.get("CXX")) == (lane.cc, lane.cxx)
+
+
+def test_the_comparison_can_fail():
+    """Without this, a comparison that always succeeded would read as agreement."""
+    lane = lanes.BY_NAME["coverage"]
+    drifted = dataclasses.replace(lane, target="run_tests")
+    assert lanes.commands(drifted) != workflow_commands(lane)
+
+
+def test_no_two_lanes_are_the_same_lane():
+    """A duplicate name loses a lane in BY_NAME, and duplicate commands hide a mistake."""
+    for index, lane in enumerate(lanes.LANES):
+        for other in lanes.LANES[index + 1 :]:
+            assert lane.name != other.name
+            assert lanes.commands(lane) != lanes.commands(other), f"{lane.name} and {other.name} are one lane"

--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -81,6 +81,9 @@ jobs:
           # The action that installs the toolchain on runners pins the same
           # conan version; the image is the definition, so read it from there.
           conan_version=$(sed -n 's/^ARG CONAN_VERSION=//p' tools/ci/Dockerfile)
+          cmake_version=$(sed -n 's/^ARG CMAKE_VERSION=//p' tools/ci/Dockerfile)
+          ninja_version=$(sed -n 's/^ARG NINJA_VERSION=//p' tools/ci/Dockerfile)
+          test -n "$conan_version" && test -n "$cmake_version" && test -n "$ninja_version"
           docker run --rm sen-ci:probe bash -lc '
             set -e
             for tool in conan python3 pip3 ccache git make g++-12 gcc-12 \
@@ -99,11 +102,11 @@ jobs:
             # --no-install-recommends leaves out unless it is asked for.
             printf "int main(){return 0;}" > /tmp/probe.cpp
             clang++-20 -fsanitize=address -o /tmp/probe /tmp/probe.cpp
-            # cmake and ninja must come from Conan, so that every build uses
-            # the pinned versions; finding them here would defeat that.
-            for tool in cmake ninja; do
-                ! command -v "$tool" > /dev/null || { echo "unexpected: $tool"; exit 1; }
-            done
+            # A package built from source in here uses these, so they must report
+            # the versions Conan pins rather than merely be present. ninja appends the
+            # packager patch level to what it reports, so compare only the release.
+            cmake --version | head -1 | grep -Fx "cmake version '"$cmake_version"'"
+            test "$(ninja --version | cut -d. -f1-3)" = "'"$ninja_version"'"
             test "$(id -un)" = sen || { echo "image runs as $(id -un)"; exit 1; }
             echo "all expected tools present"
           '

--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -86,8 +86,8 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          # Conan provides cmake and ninja; entering its environment is what finds
-          # them, and the image the jobs are moving into ships neither.
+          # Conan provides cmake and ninja; entering its environment is what puts
+          # them ahead of whatever else is on PATH, the image's own pair included.
           source build/clang/Debug/generators/conanbuild.sh
           cmake --build build/clang/Debug/ --target run_tests
 

--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -137,9 +137,8 @@ jobs:
         if: matrix.runtime_base != ''
         shell: bash
         run: |
-          # Conan provides cmake and ninja, and the image ships neither; entering
-          # its environment is what finds them. Harmless on a runner that has its
-          # own cmake, and required the moment a job runs inside the image.
+          # Conan provides cmake and ninja; entering its environment is what puts
+          # them ahead of whatever else is on PATH, the runner's own copies included.
           source build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/generators/conanbuild.sh
           ctest --test-dir build/${{ matrix.compiler.name }}/${{ matrix.build_type }} \
             -N -L integration | grep -q object_sync

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .cache
 .scannerwork
 __pycache__
+sanitizer-reports
 
 # ======================================================================================================================
 # generated build-related files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,27 @@ are retried until they pass. While working on one library, `run_unit_tests` is q
 If your editor supports devcontainers, the one under `.devcontainer/` already has the compilers,
 Conan and the test tools installed.
 
+### Running a CI lane
+
+The build above is not what the pipeline does to your change: the sanitizer lanes build with
+different options, the coverage lane measures the suite as it runs it, and clang-tidy analyses.
+
+```shell
+python .github/scripts/lanes.py --list       # the lanes, and where each one runs today
+python .github/scripts/lanes.py asan-ubsan   # run one
+```
+
+A lane runs inside the CI image as your own user, and keeps its conan cache, its ccache and its
+build folder under `~/.cache/sen-lanes/`, so your own build folder and the devcontainer's volumes
+are left alone. There is no option to run one directly on your machine: it would pick up whichever
+conan profile you have as your default. `--print` shows the commands instead of running them.
+
+`test_lanes.py` checks each definition against the job that runs it today.
+
+The first run builds every dependency from source and takes about twenty minutes; later ones reuse
+what it left. The runners are x86, so an answer can differ where that matters: one undefined
+conversion the sanitizers found yields zero on arm and `INT_MIN` on x86.
+
 ## Editors
 
 `conan install` writes `CMakeUserPresets.json` at the repository root, pointing at the presets

--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -5,7 +5,7 @@
 #                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 # ======================================================================================================================
 #
-# Build environment for Sen CI and the devcontainer.
+# Build environment for Sen CI, the devcontainer and .github/scripts/lanes.py.
 # .github/actions/setup_build_context installs the same toolchain directly
 # on runners; keep the two in sync.
 #

--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -9,15 +9,15 @@
 # .github/actions/setup_build_context installs the same toolchain directly
 # on runners; keep the two in sync.
 #
-# cmake, ninja and node are not installed: Conan tool_requires provide them.
-# Steps that call cmake directly must source the generated conanbuild.sh
-# first.
+# cmake and ninja are installed at the versions conanfile.py tool-requires. A Conan
+# tool_requires reaches the sen package only, so a package built from source in here
+# finds neither. Sen's own build still uses Conan's copies: a step calling cmake or
+# ninja directly must source the generated conanbuild.sh first.
 #
 # Two stages. `base` is what CI validates and what the pipeline is described
-# against. `dev` adds what an editor needs to recognise a toolchain, and is
-# what the devcontainer builds; keeping those tools out of `base` keeps one
-# pinned cmake for the builds themselves. Build `base` explicitly: a plain
-# `docker build` takes the last stage.
+# against. `dev` adds what an editor needs to recognise a toolchain, and is what
+# the devcontainer builds. Build `base` explicitly: a plain `docker build` takes
+# the last stage.
 
 # Pinned by digest: the tag moves whenever Canonical republishes it, which made
 # two developers building a fortnight apart hold different toolchains. Update it
@@ -29,8 +29,10 @@ ARG LLVM_VERSION=20
 ARG CONAN_VERSION=2.28.1
 ARG JUNITPARSER_VERSION=5.0.1
 ARG PYTEST_VERSION=9.1.1
-# For the dev stage only: the editors need a cmake that reads Conan's presets.
+# Both must equal the versions conanfile.py tool-requires, and nothing checks that
+# they do. The header says why the image carries them at all.
 ARG CMAKE_VERSION=3.28.1
+ARG NINJA_VERSION=1.13.2
 
 LABEL org.opencontainers.image.source="https://github.com/airbus/sen" \
       org.opencontainers.image.description="Sen CI build environment" \
@@ -95,11 +97,14 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     && rm -rf /var/lib/apt/lists/*
 
 
-# cmake/util/test.cmake invokes junitparser from the run_tests targets;
-# pytest runs the python test suites.
+# cmake/util/test.cmake invokes junitparser from the run_tests targets; pytest runs
+# the python test suites. cmake comes from pip because Ubuntu 22.04 ships 3.22, which
+# cannot read the CMakeUserPresets.json Conan writes at version 4.
 RUN pip3 install --no-cache-dir \
+        cmake==${CMAKE_VERSION} \
         conan==${CONAN_VERSION} \
         junitparser==${JUNITPARSER_VERSION} \
+        ninja==${NINJA_VERSION} \
         pytest==${PYTEST_VERSION}
 
 # Work as a normal user: on a Linux host the editor remaps this user's ids to
@@ -123,12 +128,10 @@ USER sen
 WORKDIR /workspace
 
 
-# CLion, VS Code and Visual Studio detect a toolchain by looking for cmake, a
-# build tool and a debugger inside the environment, so an editor cannot drive
-# the container without them. cmake comes from pip rather than apt because
-# Ubuntu 22.04 ships 3.22, which cannot read the CMakeUserPresets.json that
-# Conan writes (it declares version 4). graphviz is here for the
-# cmake_target_graph target, which otherwise warns that 'dot' is missing.
+# CLion, VS Code and Visual Studio detect a toolchain by looking for cmake, a build
+# tool and a debugger inside the environment; base carries the first two, so this
+# stage adds the debugger. graphviz is here for the cmake_target_graph target, which
+# otherwise warns that 'dot' is missing.
 FROM base AS dev
 
 # Names again, for the same reason as in the base stage: this user exists in
@@ -138,8 +141,6 @@ USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gdb \
         graphviz \
-        ninja-build \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip3 install --no-cache-dir cmake==${CMAKE_VERSION}
+    && rm -rf /var/lib/apt/lists/*
 # hadolint ignore=DL3066
 USER sen

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -176,6 +176,13 @@ pre-commit hook, and one of them asserts that every declared job is selected
 by some workflow, so a job that reads as coverage but can never run does not
 survive.
 
+`lanes.py` does the same for the lanes that are not matrix legs: the sanitizer lanes,
+clang-tidy and coverage. `test_lanes.py` reads the job each one names
+and compares the commands token for token, so a definition and the workflow that carries
+it cannot drift apart while both exist. A line in a modelled job that is neither a lane
+command nor one of the exceptions named in that file fails the test rather than being
+left out.
+
 **The matrix does not stop at the first failure.** One configuration failing used
 to cancel the others, so a pull request reported one verdict where four were
 wanted, and a fix could not be checked while an unrelated configuration was
@@ -284,8 +291,8 @@ lost a tool therefore fails in the pull request that broke it. `main.yaml` calls
 and `ci-ok` needs it, so a broken image blocks the merge instead of showing up
 as a red mark beside it. Documentation under `tools/ci/` does not trigger it:
 the Dockerfile copies nothing out of the repository. Docker layer caching in the Actions cache keeps
-rebuilds without changes fast. No registry hosts the image: the
-devcontainer and any self-hosted machine build it from this file, and the
+rebuilds without changes fast. No registry hosts the image: the devcontainer,
+`lanes.py` and any self-hosted machine build it from this file, and the
 revision of the file identifies the environment. (The apt packages inside
 the Dockerfile stay unpinned on purpose: the Ubuntu archive removes old
 package versions, so exact pins would break within weeks.)
@@ -305,6 +312,13 @@ The devcontainer builds this same image, keeps the conan and ccache state
 in named volumes, and installs the repository profiles with a default that
 matches the machine architecture.
 
+[`lanes.py`](../../.github/scripts/lanes.py) runs a named lane in that image without an
+editor. It builds `base`, runs the lane's commands inside it as the invoking user, and
+keeps the conan cache, the ccache and the build folder outside the checkout, because a
+build folder configured in a container cannot be built on the host. The devcontainer's
+volumes are deliberately not reused: they belong to the image's own user, and a container
+running as anyone else cannot write to them. `CONTRIBUTING.md` has the commands.
+
 ## Where this is heading
 
 The pieces above describe the pipeline as it is. This section describes the
@@ -312,7 +326,7 @@ shape it is being moved towards, so that changes can be judged against it.
 
 **The environment should have one definition.** Today it has five:
 
-- the Dockerfile's `base` stage, which nothing runs in,
+- the Dockerfile's `base` stage, which `lanes.py` runs in and no CI job does yet,
 - its `dev` stage, which the devcontainer builds,
 - `tools/ci/runtime.Dockerfile`, which the container-based integration tests run in,
 - the `setup_build_context` action, which is what CI actually builds with,
@@ -322,9 +336,16 @@ defect: clang-tidy present in one and missing in the other, coverage tools
 missing from both, conan pinned in one place and floating in another, a
 devcontainer that could not finish a build. The target is a single image,
 built from the file in this repository, published to the GitHub container
-registry when a change lands on main, and used by both the pull-request jobs
-and the devcontainer. Then a tool either exists for everyone or for nobody,
-and a check can no longer pass having analysed nothing.
+registry when a change lands on main, and used by the pull-request jobs, the
+devcontainer and `lanes.py` alike. Then a tool either exists for everyone or for
+nobody, and a check can no longer pass having analysed nothing.
+
+**The lane commands should have one definition too.** They are in the workflow steps and
+in `lanes.py`, with a test holding the second to the first. The direction is for the
+workflow step to call `lanes.py`, a lane at a time, so that what a developer runs and
+what CI runs are one text rather than two a test compares. The same move collapses the
+profile installation, which `setup_build_context`, the devcontainer's `postCreateCommand`
+and `lanes.py` each carry a copy of.
 
 **Publishing to that registry does not work today.** A personal token can push to
 `ghcr.io/airbus`, and the GitHub Actions installation cannot: it is refused `Create`

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -257,27 +257,30 @@ depend on.
 [`Dockerfile`](Dockerfile) defines the build environment: gcc-12, clang-20
 and clang-tidy-20 from a pinned apt.llvm.org repository, ccache, pinned
 versions of conan, junitparser and pytest, and the coverage tools
-(gcovr, lcov and the LLVM equivalents). cmake, ninja and node are not
-installed in the image: Conan provides them as tool_requires. Anything that calls cmake
-directly must source the generated `conanbuild.sh` first.
+(gcovr, lcov and the LLVM equivalents), and cmake and ninja at the versions
+`conanfile.py` tool-requires. Those last two are there for the dependencies. A
+Conan `tool_requires` applies to the sen package alone, so a package built from
+source in the image finds neither, and the profiles select the Ninja generator
+everywhere, so even building ninja needs one. Sen's own build is unaffected:
+anything that calls cmake directly must still source the generated
+`conanbuild.sh` first, which is what puts Conan's copies on PATH.
 `setup_build_context` installs the same toolchain directly on hosted
 runners; keep the two in sync.
 
 The Dockerfile has two stages. `base` is the image described above, the one
-the pipeline is measured against. `dev` adds cmake, ninja, gdb and graphviz,
-because an editor detects a toolchain by looking for the first three and the
-dependency-graph target needs the fourth, and the devcontainer builds that
-stage. Its cmake comes from pip rather than the distribution:
-Conan writes `CMakeUserPresets.json` at version 4, which Ubuntu 22.04's cmake
-3.22 refuses to read. Builds still use the cmake and ninja that Conan pins, so
-the rule above is unchanged; the editor tools exist for the editor.
+the pipeline is measured against. `dev` adds gdb and graphviz, because an
+editor detects a toolchain by looking for cmake, a build tool and a debugger,
+and the dependency-graph target needs `dot`; the devcontainer builds that
+stage. `base` installs cmake from pip rather than from the distribution
+because Conan writes `CMakeUserPresets.json` at version 4, which Ubuntu
+22.04's cmake 3.22 refuses to read.
 
 `ci-image.yaml` builds both stages and then checks what is inside them. For
-`base`: the expected tools are present, cmake and ninja are absent, clang can
-link a sanitizer binary, and the image does not run as root. For `dev`: cmake,
-ninja, gdb and dot are present and cmake is new enough to read the presets. A Dockerfile
-that still builds but lost a tool therefore fails in the pull request that
-broke it. `main.yaml` calls it when a change touches the build environment,
+`base`: the expected tools are present, cmake and ninja report the versions
+`conanfile.py` tool-requires, clang can link a sanitizer binary, and the image
+does not run as root. For `dev`: cmake, ninja, gdb and dot are present and
+cmake is new enough to read the presets. A Dockerfile that still builds but
+lost a tool therefore fails in the pull request that broke it. `main.yaml` calls it when a change touches the build environment,
 and `ci-ok` needs it, so a broken image blocks the merge instead of showing up
 as a red mark beside it. Documentation under `tools/ci/` does not trigger it:
 the Dockerfile copies nothing out of the repository. Docker layer caching in the Actions cache keeps
@@ -336,11 +339,13 @@ runner builds for its own architecture, so the multi-architecture problem does n
 arise.
 
 **One cmake, not two.** Conan provides cmake and ninja as tool requirements,
-so they stay out of the image. The rule that follows is that any step
-invoking cmake must do so inside the environment Conan generates. When a step
-calls the cmake that happens to be installed on the runner instead, it
-disagrees with the one that configured the build, and the whole project
-relinks; that is a real cost that was measured, not a theoretical concern.
+and the rule that follows is that any step invoking cmake must do so inside
+the environment Conan generates. When a step calls the cmake that happens to
+be installed on the runner instead, it disagrees with the one that configured
+the build, and the whole project relinks; that is a real cost that was
+measured, not a theoretical concern. The image carries the same versions for
+the builds a tool requirement cannot reach, which is its own dependencies, so
+the rule holds there too.
 
 **One compiler version across the Linux configurations.** All of them build
 with gcc-12, including the arm configuration, so the profiles no longer
@@ -518,11 +523,6 @@ stack**, and the pull request it blocks is not necessarily the one being merged.
   compile: `apps/cli_run` defines a helper whose only callers sit behind the explorer
   preset, so with the explorer off it is an unused function and `-Werror` stops the
   build.
-- **A dependency cannot be built from source inside the CI image.** cmake is a
-  tool requirement of the sen package only, while the profiles inject ninja for every
-  package and cmake for none, and the image ships no cmake. On a hosted runner the
-  dependency build silently picks up the runner's own cmake, so this only appears when
-  a job runs inside the image with a cold cache.
 - MSVC jobs build but do not run tests (SEN-1725). Uploading coverage to an
   external service is wired but disabled (SEN-1726); the published report and
   the floor cover the same ground without sending anything outside.


### PR DESCRIPTION
Every lane in the workflows is the same shape: a compiler, a build type, conan options and one cmake target. lanes.py holds that as data and runs one inside the CI image as the invoking user, so a lane's answer no longer needs a pull request.

test_lanes.py compares each definition against the job it names, so the two cannot drift while both exist. The workflows call lanes.py in a later change, one lane at a time.

Stacked on the image pull request.