### PR TITLE
fix(cmake): make the build tree relocatable

### DIFF
--- a/cmake/util/sen_internal_utils.cmake
+++ b/cmake/util/sen_internal_utils.cmake
@@ -19,8 +19,19 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_INSTALL_LIBDIR lib)
 set(CMAKE_LINK_WHAT_YOU_USE OFF "Enable this to get feedback about the linkage")
 
+# Components are opened by bare name, so the loader resolves them through the run path of libkernel.
+# Keep that run path relative to the library itself, in the build tree as well as the installed one,
+# or loading depends on the working directory. The entries pointing at conan's package folders stay
+# absolute in the build tree; an installed tree has those libraries beside the binaries instead.
 if(UNIX AND NOT APPLE)
   set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN/")
+  set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+elseif(APPLE)
+  # The same intent, spelled the way the mach-o loader expects. Nothing builds this today: there is
+  # no macOS profile under .conan/profiles, and the install guide says macOS is unsupported. It is
+  # here so the two loaders do not drift apart while that remains true.
+  set(CMAKE_INSTALL_RPATH "@loader_path/../lib;@loader_path")
+  set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
 endif()
 
 include(GNUInstallDirs)

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -230,9 +230,17 @@ directory is `<sen_path>` in the snippets below.
     ```shell
     export SEN_PREFIX=<sen_path>
 
-    # Sen binaries on PATH. Sen installs binaries, shared libraries, and archives all under <prefix>/bin
-    # (CMAKE_INSTALL_BINDIR), so the same directory goes on LD_LIBRARY_PATH.
+    # Sen binaries on PATH. Sen finds its own shared libraries through its run path, so this is all
+    # that running sen needs.
     export PATH="$SEN_PREFIX/bin:$PATH"
+    ```
+
+    An application you build against Sen has to find those libraries itself. Give it a run path of
+    its own, or tell the loader where to look:
+
+    ```shell
+    # Sen installs binaries, shared libraries and archives all under <prefix>/bin
+    # (CMAKE_INSTALL_BINDIR), so that is the directory to name.
     export LD_LIBRARY_PATH="$SEN_PREFIX/bin:$LD_LIBRARY_PATH"
     ```
 


### PR DESCRIPTION
The build run path held the absolute path of the build directory, so a binary found its libraries only where that path existed. It worked in the tests because the run path ends in an empty entry, which sends the loader to the working directory.

`CMAKE_INSTALL_RPATH` was already set; this adds the build-tree half. The Apple branch builds nowhere today and is there so the two loaders do not drift apart. The install guide no longer asks readers to set a library path to run `sen`.

Verified by installing into a scratch prefix and running `sen` with `LD_LIBRARY_PATH` unset: exit 0, run path `[$ORIGIN]`. CI cannot check this — every run-smoke test is handed `LD_LIBRARY_PATH` pointing at its own working directory (`cmake/util/test.cmake:336`), so those binaries resolve through the variable either way. Green checks do not cover this change.
