### PR TITLE
test(kernel): say how a supporting instance ended

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,9 +73,10 @@ jobs:
       - name: Install checkers
         shell: bash
         run: pip install pytest==9.1.1 gitlint==0.19.1 pyyaml==6.0.3
+      # The integration drivers too: plain python, no build needed to test them.
       - name: Run repository script tests
         shell: bash
-        run: python -m pytest .github/scripts/ -v
+        run: python -m pytest .github/scripts/ libs/kernel/test/integration/ -v
       # From the pull request's own base, not from main: a stacked pull request
       # sits on the branch below it, and origin/main would drag in every commit
       # underneath and lint those again.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,11 +113,10 @@ repos:
       name: Repository script tests
       language: python
       additional_dependencies: [pytest==9.1.1, pyyaml==6.0.3]
-      entry: python -m pytest .github/scripts -q
-      # The workflows too: test_lanes.py compares each lane definition against the job
-      # that carries it, so a workflow-only edit is exactly the drift it exists to catch
-      # and used to reach CI before anything said so.
-      files: ^\.github/(scripts|workflows)/
+      entry: python -m pytest .github/scripts libs/kernel/test/integration -q
+      # The workflows, because a lane definition is compared against the job carrying it,
+      # and the integration drivers, which are plain python.
+      files: ^(\.github/(scripts|workflows)/|libs/kernel/test/integration/)
       pass_filenames: false
 
 # Global Configuration

--- a/libs/kernel/test/integration/runner.py
+++ b/libs/kernel/test/integration/runner.py
@@ -13,6 +13,10 @@ import sys
 # How long a supporting instance is given to stop before it is killed outright.
 SHUTDOWN_GRACE_SECONDS = 5
 
+# An instance that ended before it was asked to makes the tester's own failure a
+# consequence rather than a cause. The verdict stays the tester's either way.
+INSTANCE = "runner.py: supporting instance"
+
 
 def run_sen_command(args):
     """
@@ -31,14 +35,29 @@ def run_sen_command(args):
 
 
 def stop(instances):
-    """Stops the given instances, killing any that ignore the request."""
+    """Stops the given instances and says how each of them ended.
+
+    An instance is meant to be running here and to stop because this asks it. terminate()
+    on one that has already gone is a no-op, so the three ways that can be untrue are only
+    separable by asking first.
+    """
+    ended_early = {instance.pid for instance in instances if instance.poll() is not None}
     for instance in instances:
         instance.terminate()
+    ignored_the_request = set()
     for instance in instances:
         try:
             instance.wait(timeout=SHUTDOWN_GRACE_SECONDS)
         except subprocess.TimeoutExpired:
+            ignored_the_request.add(instance.pid)
             instance.kill()
+            instance.wait()
+
+    for instance in instances:
+        if instance.pid in ended_early:
+            print(f"{INSTANCE}: {instance.pid} ended on its own with status {instance.returncode}", flush=True)
+        elif instance.pid in ignored_the_request:
+            print(f"{INSTANCE}: {instance.pid} ignored the request to stop and was killed", flush=True)
 
 
 def main():

--- a/libs/kernel/test/integration/test_runner.py
+++ b/libs/kernel/test/integration/test_runner.py
@@ -1,0 +1,70 @@
+# === test_runner.py ===================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Keeps the runner able to say how a supporting instance ended.
+
+terminate() on an instance that has already gone is a no-op, so the states are only
+separable by asking first.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import runner  # noqa: E402
+
+
+class Instance:
+    """A stand-in for one supporting process, with the states Popen can be in."""
+
+    def __init__(self, pid, alive_at_stop, returncode, ignores_terminate=False):
+        """Records the state this stand-in should be in when stop() reaches it."""
+        self.pid = pid
+        self._alive = alive_at_stop
+        self.returncode = returncode
+        self._ignores = ignores_terminate
+        self.killed = False
+
+    def poll(self):
+        """None while running, the status once it has ended."""
+        return None if self._alive else self.returncode
+
+    def terminate(self):
+        """Ends it, unless this stand-in is one that ignores the request."""
+        self._alive = self._ignores
+
+    def wait(self, timeout=None):
+        """Raises like Popen does when the grace period runs out."""
+        if self._alive and timeout is not None:
+            raise subprocess.TimeoutExpired("sen", timeout)
+        return self.returncode
+
+    def kill(self):
+        """Records that the runner had to resort to this."""
+        self.killed = True
+        self._alive = False
+
+
+def test_an_instance_that_ended_before_being_asked_is_named_with_its_status(capsys):
+    """An instance that went first makes the tester's own exit a consequence."""
+    runner.stop([Instance(11, alive_at_stop=False, returncode=66)])
+    assert "11 ended on its own with status 66" in capsys.readouterr().out
+
+
+def test_an_instance_that_ignored_the_request_is_named_as_that(capsys):
+    """A different fault: it was alive and would not go."""
+    stubborn = Instance(12, alive_at_stop=True, returncode=-9, ignores_terminate=True)
+    runner.stop([stubborn])
+    assert stubborn.killed
+    assert "12 ignored the request to stop and was killed" in capsys.readouterr().out
+
+
+def test_an_instance_we_stopped_says_nothing(capsys):
+    """The common case, which must not become noise."""
+    runner.stop([Instance(13, alive_at_stop=True, returncode=-15)])
+    assert not capsys.readouterr().out


### PR DESCRIPTION
The runner starts two supporting instances, reaps them and reads nothing back, so
a participant that died on its own, one that hung, and one that was alive and
never published are indistinguishable from outside.

It now asks each one before terminating and names which of the three happened.
The exit status is still the tester's, so nothing that passes starts failing.

This week's nightly thread lane failed with the tester's own process exiting
non-zero while its condition still returned false, and no way to tell whether a
participant had gone first. That is the case this describes.

The test sits beside the runner, and the script test paths now reach that
directory.