### PR TITLE
fix(examples): fail the call when dividing by zero

### DIFF
--- a/examples/packages/calculators/src/casio_calculator.cpp
+++ b/examples/packages/calculators/src/casio_calculator.cpp
@@ -13,6 +13,9 @@
 #include "sen/core/base/numbers.h"
 #include "sen/core/meta/class_type.h"
 
+// std
+#include <stdexcept>
+
 namespace calculators
 {
 
@@ -47,15 +50,14 @@ protected:
   /// Implementation of divide.
   float32_t divideImpl(float32_t a, float32_t b) override
   {
-    float32_t result = 0.0f;
     if (b == 0.0f)
     {
-      divisionByZero();  // If we divide by zero, emit the event.
+      // The event lets subscribers observe it; the exception is how the caller finds out.
+      divisionByZero();
+      throw std::runtime_error("division by zero");
     }
-    else
-    {
-      result = a / b;
-    }
+
+    const float32_t result = a / b;
 
     // Save the result in our "current" property.
     setNextCurrent(result);

--- a/examples/packages/calculators/src/faulty_calculator.cpp
+++ b/examples/packages/calculators/src/faulty_calculator.cpp
@@ -15,6 +15,7 @@
 
 // std
 #include <cstdint>
+#include <stdexcept>
 
 namespace calculators
 {
@@ -54,15 +55,13 @@ protected:
   {
     callCount_++;
 
-    float32_t result = 0.0f;
     if (b == 0.0f)
     {
       divisionByZero();
+      throw std::runtime_error("division by zero");
     }
-    else
-    {
-      result = (a / b) + (shouldFail() ? 1.0f : 0.0f);
-    }
+
+    const float32_t result = (a / b) + (shouldFail() ? 1.0f : 0.0f);
 
     setNextCurrent(result);
     return result;

--- a/examples/packages/calculators/stl/calculator.stl
+++ b/examples/packages/calculators/stl/calculator.stl
@@ -23,11 +23,11 @@ class Calculator
   // Returns "a / b" and sets the last result to it.
   //
   // @param a left-hand operator.
-  // @param b right-hand operator (if 0, the divisionByZero event gets emitted).
+  // @param b right-hand operator. If 0, the divisionByZero event is emitted and the call fails.
   fn divide(a: f32, b: f32) -> f32;
 
-  // Returns "a / R" where R is was the last result.
-  // If R is 0, the divisionByZero event gets emitted.
+  // Returns "a / R" where R is the last result.
+  // If R is 0, the divisionByZero event is emitted and the call fails.
   //
   // @param a left-hand operator.
   fn divideByCurrent(a: f32) -> f32;


### PR DESCRIPTION
The example calculators emitted `divisionByZero` and then returned `0.0f` as a success, so a caller checking only the return value saw a valid answer where there was none.

The call now fails.
