### PR TITLE
fix(core): read the fixedRecordData include element

### DIFF
--- a/apps/cli_gen/test/CMakeLists.txt
+++ b/apps/cli_gen/test/CMakeLists.txt
@@ -289,3 +289,58 @@ add_sen_integration_test(
 
 # link them so the checker only runs if the generator succeeds
 set_tests_properties(hla_fom_gen_integration_test_20 PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1")
+
+# Test case 21
+#
+# ModuleA-21 defines a fixed record that includes the fields of another one.
+#
+# Check that after compilation the including record carries both its own field and the included one
+add_sen_package(
+  TARGET included_record_fom
+  HLA_FOM_DIRS test21/fom
+  GEN_HDR_FILES included_record_fom_headers
+  PUBLIC_SYMBOLS
+)
+
+add_executable(included_record_tester test21/main.cpp)
+sen_configure_target(included_record_tester)
+target_link_libraries(included_record_tester PRIVATE sen::core included_record_fom)
+
+add_sen_smoke_test(
+  test_included_record_generation
+  COMMAND included_record_tester
+  WORKING_DIRECTORY ${working_dir} REQ_DEPS included_record_tester
+)
+
+# Test case 22
+#
+# A fixed record including two other records, which a sen struct cannot represent.
+#
+# Expected result: failure
+add_sen_cli_gen_smoke_test(
+  hla_fom_gen_smoke_22
+  COMMAND ./cli_gen --expect-failure cpp fom --directories=${hla_fom_gen_test_sources}/test22/fom
+  WORKING_DIRECTORY ${working_dir}
+)
+
+# Test case 23
+#
+# A fixed record including a type that is not a record.
+#
+# Expected result: failure
+add_sen_cli_gen_smoke_test(
+  hla_fom_gen_smoke_23
+  COMMAND ./cli_gen --expect-failure cpp fom --directories=${hla_fom_gen_test_sources}/test23/fom
+  WORKING_DIRECTORY ${working_dir}
+)
+
+# Test case 24
+#
+# A fixed record including itself.
+#
+# Expected result: failure
+add_sen_cli_gen_smoke_test(
+  hla_fom_gen_smoke_24
+  COMMAND ./cli_gen --expect-failure cpp fom --directories=${hla_fom_gen_test_sources}/test24/fom
+  WORKING_DIRECTORY ${working_dir}
+)

--- a/apps/cli_gen/test/test21/fom/module-A.xml
+++ b/apps/cli_gen/test/test21/fom/module-A.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<objectModel
+        xsi:schemaLocation="http://standards.ieee.org/IEEE1516-2010 http://standards.ieee.org/downloads/1516/1516.2-2010/IEEE1516-DIF-2010.xsd"
+        xmlns="http://standards.ieee.org/IEEE1516-2010" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelIdentification>
+        <name>module-A</name>
+        <type>FOM</type>
+        <version>1.0</version>
+        <securityClassification>unclassified</securityClassification>
+        <purpose/>
+        <applicationDomain/>
+        <description>A fixed record including the fields of another one</description>
+        <useLimitation/>
+        <other/>
+    </modelIdentification>
+    <objects/>
+    <interactions/>
+    <dataTypes>
+        <simpleDataTypes>
+            <simpleData>
+                <name>TestInt</name>
+                <representation>HLAinteger32BE</representation>
+                <units>NA</units>
+                <resolution/>
+                <accuracy/>
+                <semantics/>
+            </simpleData>
+        </simpleDataTypes>
+        <enumeratedDataTypes/>
+        <arrayDataTypes/>
+        <fixedRecordDataTypes>
+            <fixedRecordData>
+                <name>BaseRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>The record whose fields are included by another.</semantics>
+                <field>
+                    <name>Inherited</name>
+                    <dataType>TestInt</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>DerivedRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                <include>BaseRecord</include>
+                <semantics>Brings in the fields of BaseRecord and adds one of its own.</semantics>
+                <field>
+                    <name>Own</name>
+                    <dataType>TestInt</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+        </fixedRecordDataTypes>
+        <variantRecordDataTypes/>
+    </dataTypes>
+    <notes/>
+</objectModel>

--- a/apps/cli_gen/test/test21/main.cpp
+++ b/apps/cli_gen/test/test21/main.cpp
@@ -1,0 +1,19 @@
+// === main.cpp ========================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// included record fom
+#include "fom/module-a.xml.h"
+
+int main()
+{
+  constexpr fom::DerivedRecord record {{45}, 67};
+
+  static_assert(record.inherited == 45);
+  static_assert(record.own == 67);
+
+  return 0;
+}

--- a/apps/cli_gen/test/test22/fom/module-A.xml
+++ b/apps/cli_gen/test/test22/fom/module-A.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<objectModel
+        xsi:schemaLocation="http://standards.ieee.org/IEEE1516-2010 http://standards.ieee.org/downloads/1516/1516.2-2010/IEEE1516-DIF-2010.xsd"
+        xmlns="http://standards.ieee.org/IEEE1516-2010" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelIdentification>
+        <name>module-A</name>
+        <type>FOM</type>
+        <version>1.0</version>
+        <securityClassification>unclassified</securityClassification>
+        <purpose/>
+        <applicationDomain/>
+        <description>A fixed record including two others</description>
+        <useLimitation/>
+        <other/>
+    </modelIdentification>
+    <objects/>
+    <interactions/>
+    <dataTypes>
+        <simpleDataTypes>
+            <simpleData>
+                <name>TestInt</name>
+                <representation>HLAinteger32BE</representation>
+                <units>NA</units>
+                <resolution/>
+                <accuracy/>
+                <semantics/>
+            </simpleData>
+        </simpleDataTypes>
+        <enumeratedDataTypes/>
+        <arrayDataTypes/>
+        <fixedRecordDataTypes>
+            <fixedRecordData>
+                <name>BaseRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>The record whose fields are included by another.</semantics>
+                <field>
+                    <name>Inherited</name>
+                    <dataType>TestInt</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>OtherBaseRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>A second record whose fields could be included.</semantics>
+                <field>
+                    <name>AlsoInherited</name>
+                    <dataType>TestInt</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>DerivedRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                <include>BaseRecord</include>
+                <include>OtherBaseRecord</include>
+                <semantics>Brings in the fields of BaseRecord and adds one of its own.</semantics>
+                <field>
+                    <name>Own</name>
+                    <dataType>TestInt</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+        </fixedRecordDataTypes>
+        <variantRecordDataTypes/>
+    </dataTypes>
+    <notes/>
+</objectModel>

--- a/apps/cli_gen/test/test23/fom/module-A.xml
+++ b/apps/cli_gen/test/test23/fom/module-A.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<objectModel
+        xsi:schemaLocation="http://standards.ieee.org/IEEE1516-2010 http://standards.ieee.org/downloads/1516/1516.2-2010/IEEE1516-DIF-2010.xsd"
+        xmlns="http://standards.ieee.org/IEEE1516-2010" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelIdentification>
+        <name>module-A</name>
+        <type>FOM</type>
+        <version>1.0</version>
+        <securityClassification>unclassified</securityClassification>
+        <purpose/>
+        <applicationDomain/>
+        <description>A fixed record including a type that is not a record</description>
+        <useLimitation/>
+        <other/>
+    </modelIdentification>
+    <objects/>
+    <interactions/>
+    <dataTypes>
+        <simpleDataTypes>
+            <simpleData>
+                <name>TestInt</name>
+                <representation>HLAinteger32BE</representation>
+                <units>NA</units>
+                <resolution/>
+                <accuracy/>
+                <semantics/>
+            </simpleData>
+        </simpleDataTypes>
+        <enumeratedDataTypes/>
+        <arrayDataTypes/>
+        <fixedRecordDataTypes>
+            <fixedRecordData>
+                <name>BaseRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>The record whose fields are included by another.</semantics>
+                <field>
+                    <name>Inherited</name>
+                    <dataType>TestInt</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>DerivedRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                <include>TestInt</include>
+                <semantics>Brings in the fields of BaseRecord and adds one of its own.</semantics>
+                <field>
+                    <name>Own</name>
+                    <dataType>TestInt</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+        </fixedRecordDataTypes>
+        <variantRecordDataTypes/>
+    </dataTypes>
+    <notes/>
+</objectModel>

--- a/apps/cli_gen/test/test24/fom/module-A.xml
+++ b/apps/cli_gen/test/test24/fom/module-A.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<objectModel
+        xsi:schemaLocation="http://standards.ieee.org/IEEE1516-2010 http://standards.ieee.org/downloads/1516/1516.2-2010/IEEE1516-DIF-2010.xsd"
+        xmlns="http://standards.ieee.org/IEEE1516-2010" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelIdentification>
+        <name>module-A</name>
+        <type>FOM</type>
+        <version>1.0</version>
+        <securityClassification>unclassified</securityClassification>
+        <purpose/>
+        <applicationDomain/>
+        <description>A fixed record including itself</description>
+        <useLimitation/>
+        <other/>
+    </modelIdentification>
+    <objects/>
+    <interactions/>
+    <dataTypes>
+        <simpleDataTypes>
+            <simpleData>
+                <name>TestInt</name>
+                <representation>HLAinteger32BE</representation>
+                <units>NA</units>
+                <resolution/>
+                <accuracy/>
+                <semantics/>
+            </simpleData>
+        </simpleDataTypes>
+        <enumeratedDataTypes/>
+        <arrayDataTypes/>
+        <fixedRecordDataTypes>
+            <fixedRecordData>
+                <name>BaseRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>The record whose fields are included by another.</semantics>
+                <field>
+                    <name>Inherited</name>
+                    <dataType>TestInt</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>DerivedRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                <include>DerivedRecord</include>
+                <semantics>Brings in the fields of BaseRecord and adds one of its own.</semantics>
+                <field>
+                    <name>Own</name>
+                    <dataType>TestInt</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+        </fixedRecordDataTypes>
+        <variantRecordDataTypes/>
+    </dataTypes>
+    <notes/>
+</objectModel>

--- a/libs/core/src/lang/fom_document_set.cpp
+++ b/libs/core/src/lang/fom_document_set.cpp
@@ -1078,6 +1078,44 @@ ConstTypeHandle<> FomDocumentSet::recordType(const pugi::xpath_node& node, Parse
   auto specQualifiedName = fomTypeNameToSenTypeNameQual(doc->doc, specName);
   auto specDescription = formatSemantics(node.node().child_value("semantics"));
 
+  // <include> brings in the fields of another record. A sen struct expresses that as its parent,
+  // and takes exactly one, so a record including more than one cannot be represented.
+  MaybeConstTypeHandle<StructType> parent;
+  for (const auto& includeNode: node.node().children("include"))
+  {
+    const std::string includedName = includeNode.child_value();
+
+    if (parent)
+    {
+      std::string err;
+      err.append("record '");
+      err.append(name);
+      err.append("' includes more than one record, which sen cannot represent: a struct has a single parent");
+      throwRuntimeError(err);
+    }
+
+    if (includedName == name)
+    {
+      std::string err;
+      err.append("record '");
+      err.append(name);
+      err.append("' includes itself");
+      throwRuntimeError(err);
+    }
+
+    parent = dynamicTypeHandleCast<const StructType>(getOrCreateTypeFromFomName(includedName, doc).first);
+    if (!parent)
+    {
+      std::string err;
+      err.append("record '");
+      err.append(name);
+      err.append("' includes '");
+      err.append(includedName);
+      err.append("', which is not a record");
+      throwRuntimeError(err);
+    }
+  }
+
   std::vector<StructField> fields;
   for (const auto& fieldNode: node.node().children("field"))
   {
@@ -1088,7 +1126,7 @@ ConstTypeHandle<> FomDocumentSet::recordType(const pugi::xpath_node& node, Parse
     fields.push_back(std::move(field));
   }
 
-  StructSpec spec(specName, specQualifiedName, specDescription, fields, std::nullopt);
+  StructSpec spec(specName, specQualifiedName, specDescription, fields, parent);
 
   return StructType::make(spec);
 }


### PR DESCRIPTION
`<include>` inside `fixedRecordData` brings in another record's fields. It was not read at all, so the generated struct silently lacked them — no diagnostic, no failure, just a type missing what the FOM said it had.

It is read now and becomes the struct's parent. A Sen struct takes exactly one parent, so a record including more than one is refused with a diagnostic rather than represented wrongly.
