### PR TITLE
fix(kernel): log the cycles a component loses

### DIFF
--- a/libs/kernel/include/sen/kernel/component_api.h
+++ b/libs/kernel/include/sen/kernel/component_api.h
@@ -297,6 +297,8 @@ public:
 
   /// A basic execution loop.
   /// Func is an optional callback that will be invoked on each cycle.
+  /// logOverruns keeps the log lines for a missed deadline: an execution time overrun and
+  /// the two ways a cycle is lost. The Tracy messages are emitted either way.
   [[nodiscard]] FuncResult execLoop(Duration cycleTime,
                                     std::function<void()>&& func = nullptr,
                                     bool logOverruns = true);

--- a/libs/kernel/src/runner.cpp
+++ b/libs/kernel/src/runner.cpp
@@ -674,6 +674,11 @@ void Runner::realTimeExecLoop(std::function<void()>&& workFunction, bool logOver
     if (missedFrameEnd)
     {
       tracer_->message(missedFrameEndMessage_);
+
+      if (SEN_LIKELY(logOverruns))
+      {
+        SPDLOG_LOGGER_WARN(logger, missedFrameEndMessage_);
+      }
     }
 
     // calibrate the clock from time to time
@@ -703,6 +708,11 @@ void Runner::realTimeExecLoop(std::function<void()>&& workFunction, bool logOver
     if (skippedFrames)
     {
       tracer_->message(oversleptMessage_);
+
+      if (SEN_LIKELY(logOverruns))
+      {
+        SPDLOG_LOGGER_WARN(logger, oversleptMessage_);
+      }
 
       // check if we have enough time to run. If not, sleep until the next cycle
       if (wakeUpTime - time64 > halfPeriod)


### PR DESCRIPTION
Of the three per-cycle signals, only the overrun reached the log, and it is measured in CPU time, so a component blocking rather than computing missed frames silently. The missed frame emitted a tracer message and no log line, and the oversleep was a tracer plot with no log at all — a system without Tracy attached had no way to see either.

Both now reach the log behind the existing `logOverruns` flag, alongside the tracer output they already produced.
