### PR TITLE
ci: let the summary fail a run, for the lane that gates

### DIFF
--- a/.github/scripts/summarise_sanitizer_reports.py
+++ b/.github/scripts/summarise_sanitizer_reports.py
@@ -18,8 +18,11 @@ A race is a pair, so the family is the first sen:: frame on each side: one ancho
 plus whatever the other side happened to be collapses distinct families together.
 Undefined behaviour has no frames to pair, so its location is its identity.
 
-This reports rather than judges: the exit status says whether the summary was
-written, not whether findings were found.
+This reports rather than judges by default, because the nightly lanes exist to collect
+an inventory and one abort would hide what follows it. --fail-on-findings makes it judge,
+for the lane that gates: a finding reaches the report files even when it happened in a
+process ctest never waited on, or in a test whose verdict was inverted, so the files are
+the one place every finding can be seen at once.
 """
 
 import argparse
@@ -34,8 +37,14 @@ from pathlib import Path
 FINDING = re.compile(r"(?:WARNING|ERROR): (\w+Sanitizer): (.+)")
 
 # "libs/core/include/sen/core/base/checked_conversions.h:92:34: runtime error: nan is ..."
-# UndefinedBehaviorSanitizer says neither WARNING nor its own name on this line.
-UBSAN = re.compile(r"^(?P<where>\S+?):(?P<line>\d+):(?P<col>\d+): runtime error: (?P<kind>.+?)\s*$", re.M)
+# UndefinedBehaviorSanitizer says neither WARNING nor its own name on this line. The path is
+# matched loosely because a build directory may contain a space, and \S+? cannot cross one.
+UBSAN = re.compile(r"^(?P<where>.+?):(?P<line>\d+):(?P<col>\d+): runtime error: (?P<kind>.+?)\s*$", re.M)
+
+# A runtime that could not do its job writes this into the log where a finding would go, and
+# with log_path set it writes nothing to stderr -- so every test goes red and the summary
+# beside them used to say there were no findings.
+MALFUNCTION = re.compile(r"(\w+Sanitizer): (failed to (?:read|parse) suppressions[^\n]*|CHECK failed:[^\n]*)")
 
 # "on vptr" is part of the kind; "on address" is not, nor is a pid or an aside.
 KIND_TAIL = re.compile(r"\s+on address\b|\s+on 0x|\s+\(")
@@ -137,22 +146,48 @@ def findings(text: str) -> list[dict]:
     return entries + undefined_behaviour(text)
 
 
-def summarise(entries: list[dict], reports: int | None = None) -> str:
+def malfunctions(text: str) -> list[str]:
+    """Sanitizer failures that are not findings and must not read as their absence."""
+    return sorted({f"{match.group(1)}: {match.group(2).strip()}" for match in MALFUNCTION.finditer(text)})
+
+
+def nothing_found(reports: int | None) -> str:
+    """What to say when a run produced no findings, without saying more than is known.
+
+    Saying "no findings" over nothing read is how a lane that saw nothing and a lane that
+    looked at nothing came to print the same sentence. Whether the lane can detect at all
+    is check_sanitizer_lane.py's question, not this one.
+    """
+    if reports == 0:
+        return "No sanitizer reports were produced in this run.\n"
+    if reports is not None:
+        return f"No sanitizer findings in {reports} report file(s).\n"
+    return "No sanitizer findings in this run.\n"
+
+
+def malfunction_lines(broken: list[str], any_findings: bool) -> list[str]:
+    """The opening of a summary whose run the sanitizer could not properly make."""
+    opening = (
+        "The sanitizer could not do its job in this run, so what follows is not a complete account."
+        if any_findings
+        else "The sanitizer could not do its job in this run, so its silence says nothing."
+    )
+    return [opening, *(f"- `{problem}`" for problem in broken), *([""] if any_findings else [])]
+
+
+def summarise(entries: list[dict], reports: int | None = None, broken: list[str] | None = None) -> str:
     """Renders the grouped findings as markdown.
 
     Grouped by family -- tool, kind and the pair of sen:: frames -- because that
     is the unit a later run can be matched against. Line numbers move; symbols
     survive a refactor.
     """
+    opening = malfunction_lines(broken, bool(entries)) if broken else []
+    if broken and not entries:
+        return "\n".join(opening) + "\n"
+
     if not entries:
-        # Saying "no findings" over nothing read is how a lane that saw nothing and a
-        # lane that looked at nothing came to print the same sentence. Whether the lane
-        # can detect at all is check_sanitizer_lane.py's question, not this one.
-        if reports == 0:
-            return "No sanitizer reports were produced in this run.\n"
-        if reports is not None:
-            return f"No sanitizer findings in {reports} report file(s).\n"
-        return "No sanitizer findings in this run.\n"
+        return nothing_found(reports)
 
     def family(entry: dict) -> tuple:
         return (entry["tool"], entry["kind"], tuple(entry["sites"]))
@@ -166,6 +201,7 @@ def summarise(entries: list[dict], reports: int | None = None) -> str:
         return f"{number} {one if number == 1 else many}"
 
     lines = [
+        *opening,
         f"{count_of(len(entries), 'sanitizer finding', 'sanitizer findings')}, "
         f"{count_of(len(by_family), 'distinct family', 'distinct families')}.",
         "",
@@ -195,19 +231,39 @@ def main() -> int:
         description="Groups a run's sanitizer findings by the site that produced them.",
     )
     parser.add_argument("paths", nargs="+", help="Report files or directories holding them.")
+    parser.add_argument(
+        "--fail-on-findings",
+        action="store_true",
+        help="Exit non-zero when the run produced findings, for a lane that gates rather than collects.",
+    )
     args = parser.parse_args()
 
     text = []
+    unreadable = []
     for raw in args.paths:
         path = Path(raw)
         if path.is_dir():
-            for child in sorted(path.rglob("*")):
-                if child.is_file():
-                    text.append(child.read_text(encoding="utf-8", errors="replace"))
-        elif path.is_file():
-            text.append(path.read_text(encoding="utf-8", errors="replace"))
+            # os.walk reports what it could not open; rglob swallows it, and a directory
+            # nobody can read then reads as a directory with nothing in it.
+            # Consumed, not just created: os.walk is lazy and reports nothing until it runs.
+            list(os.walk(path, onerror=lambda error: unreadable.append(f"{error.filename}: {error.strerror}")))
+            children = sorted(path.rglob("*"))
+        else:
+            children = [path] if path.is_file() else []
+        for child in children:
+            if not child.is_file():
+                continue
+            try:
+                text.append(child.read_text(encoding="utf-8", errors="replace"))
+            except OSError as error:
+                # A container running as root leaves its reports unreadable by the job's
+                # user. Unread is not the same as absent, and used to render as absent.
+                unreadable.append(f"{child}: {error.strerror}")
 
-    report = summarise(findings("\n".join(text)), reports=len(text))
+    joined = "\n".join(text)
+    entries = findings(joined)
+    broken = malfunctions(joined) + [f"could not be read -- {problem}" for problem in unreadable]
+    report = summarise(entries, reports=len(text), broken=broken)
     print(report, end="")
 
     summary = os.environ.get("GITHUB_STEP_SUMMARY")
@@ -215,7 +271,9 @@ def main() -> int:
         with open(summary, "a", encoding="utf-8") as handle:
             handle.write(report)
 
-    return 0
+    # Silence is not judged here: a lane that produced nothing may have looked at nothing,
+    # and check_sanitizer_lane.py is what settles that before the suite runs.
+    return 1 if (args.fail_on_findings and (entries or broken)) else 0
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_summarise_sanitizer_reports.py
+++ b/.github/scripts/test_summarise_sanitizer_reports.py
@@ -6,7 +6,9 @@
 # ======================================================================================================================
 """Pins the grouping that turns a run's sanitizer output into a short report."""
 
-from summarise_sanitizer_reports import findings, summarise
+import sys
+
+from summarise_sanitizer_reports import findings, main, summarise
 
 RACE = """\
 WARNING: ThreadSanitizer: data race (pid=118)
@@ -202,3 +204,123 @@ def test_nothing_read_is_reported_differently_from_nothing_found():
 def test_the_old_wording_survives_when_the_count_is_unknown():
     """A caller that passes no count keeps the sentence it had."""
     assert summarise([]) == "No sanitizer findings in this run.\n"
+
+
+def test_it_can_be_told_to_judge_and_says_nothing_over_an_empty_run(tmp_path, monkeypatch):
+    """The report files are the one place every finding can be seen at once.
+
+    A finding written by a process ctest never waited on, or by a test whose verdict was
+    inverted, reaches the files and reaches nothing else. So the lane that gates reads
+    them; the nightly, which collects an inventory, must keep its exit status of zero.
+    """
+    reports = tmp_path / "sanitizer-reports"
+    reports.mkdir()
+    (reports / "report.1").write_text(SUPPRESSIONS, encoding="utf-8")
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    monkeypatch.setattr(sys, "argv", ["summarise", str(reports)])
+    assert main() == 0, "a lane that collects must not gate"
+    monkeypatch.setattr(sys, "argv", ["summarise", "--fail-on-findings", str(reports)])
+    assert main() == 0, "a suppression tally is not a finding, so it must not fail a gate"
+
+    (reports / "report.2").write_text(RACE, encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["summarise", "--fail-on-findings", str(reports)])
+    assert main() == 1, "a real finding must fail the lane that gates"
+    monkeypatch.setattr(sys, "argv", ["summarise", str(reports)])
+    assert main() == 0, "and must still not fail the lane that collects"
+
+
+def test_judging_says_nothing_about_silence(tmp_path, monkeypatch):
+    """Whether a silent lane looked at anything is check_sanitizer_lane.py's question.
+
+    Answering it here as well would turn every clean run red on a missing directory.
+    """
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(sys, "argv", ["summarise", "--fail-on-findings", str(tmp_path / "never-created")])
+    assert main() == 0
+
+
+def test_a_runtime_that_could_not_do_its_job_is_not_read_as_silence(tmp_path, monkeypatch):
+    """With a log path set the runtime writes this into the file and nothing to stderr.
+
+    Every test then goes red while the summary beside them said there were no findings,
+    which is the worst of both: a wall of failures and a report claiming a clean run.
+    """
+    reports = tmp_path / "sanitizer-reports"
+    reports.mkdir()
+    (reports / "report.1").write_text(
+        "AddressSanitizer: failed to read suppressions file '/gone/asan_ignorelist.txt'\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(sys, "argv", ["summarise", "--fail-on-findings", str(reports)])
+    assert main() == 1
+
+    text = summarise([], reports=1, broken=["AddressSanitizer: failed to read suppressions file '/gone'"])
+    assert "silence says nothing" in text
+    assert "No sanitizer findings" not in text
+
+
+def test_a_report_that_cannot_be_read_is_not_the_same_as_one_that_is_not_there(tmp_path, monkeypatch):
+    """A container running as root leaves its reports unreadable by the job's user."""
+    reports = tmp_path / "sanitizer-reports"
+    reports.mkdir()
+    unreadable = reports / "report.1"
+    unreadable.write_text("anything\n", encoding="utf-8")
+    unreadable.chmod(0o000)
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(sys, "argv", ["summarise", "--fail-on-findings", str(reports)])
+    try:
+        assert main() == 1
+    finally:
+        unreadable.chmod(0o644)
+
+
+def test_a_finding_whose_path_contains_a_space_is_still_a_finding():
+    """A build directory may contain one, and the pattern could not cross it."""
+    entries = findings("/work/src dir/ub.cpp:2:55: runtime error: signed integer overflow\n")
+    assert len(entries) == 1
+    assert entries[0]["tool"] == "UndefinedBehaviorSanitizer"
+
+
+def test_both_wordings_of_a_suppression_file_it_cannot_use_are_recognised(tmp_path, monkeypatch):
+    """A missing file says "read"; an unreadable or malformed one says "parse".
+
+    Only the first was matched, so the likelier half of the failure this was written for
+    still printed "No sanitizer findings" while every test in the run went red.
+    """
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    for wording in ("failed to read suppressions file '/gone'", "failed to parse suppressions."):
+        reports = tmp_path / wording.split()[2].strip("'/.")
+        reports.mkdir()
+        (reports / "report.1").write_text(f"AddressSanitizer: {wording}\n", encoding="utf-8")
+        monkeypatch.setattr(sys, "argv", ["summarise", "--fail-on-findings", str(reports)])
+        assert main() == 1, wording
+
+
+def test_a_malfunction_is_still_reported_when_the_run_also_found_things():
+    """The warning has to survive alongside the table, not be replaced by it.
+
+    That is when a reader most needs it: a suppression file that failed to load means the
+    findings listed beside it may be noise that should have been suppressed.
+    """
+    text = summarise(findings(RACE), reports=1, broken=["AddressSanitizer: failed to parse suppressions."])
+    assert "could not do its job" in text
+    assert "sanitizer finding" in text
+
+
+def test_a_directory_that_cannot_be_opened_is_not_read_as_an_empty_one(tmp_path, monkeypatch):
+    """The container writes its reports as root; the job's user cannot open the directory.
+
+    rglob walks past it without a word, so a heap-use-after-free read as "no reports".
+    """
+    reports = tmp_path / "sanitizer-reports"
+    inner = reports / "container-0"
+    inner.mkdir(parents=True)
+    (inner / "report.1").write_text("WARNING: AddressSanitizer: heap-use-after-free\n", encoding="utf-8")
+    inner.chmod(0o000)
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(sys, "argv", ["summarise", "--fail-on-findings", str(reports)])
+    try:
+        assert main() == 1
+    finally:
+        inner.chmod(0o755)


### PR DESCRIPTION
A finding reaches the report files even when it came from a process ctest never
waited on, or from a test whose verdict was inverted. Those files are the one
place every finding is visible at once, and nothing could act on them.

`--fail-on-findings` makes the summary judge instead of report. **No workflow
passes it, so nothing changes today** — the nightly lanes must keep collecting an
inventory, where one abort would hide what follows it. Turning the gate on later
becomes one line rather than a change.

It also stops reading three things as silence: a suppression file it could not
read or parse, which the runtime writes where a finding would go and nowhere
else; a report directory it cannot open, which is what a container running as
root produces; and a finding whose source path contains a space.