### PR TITLE
fix(ether): let a failed connection to the discovery hub be retried

### DIFF
--- a/components/ether/src/tcp_beam_tracker.cpp
+++ b/components/ether/src/tcp_beam_tracker.cpp
@@ -146,6 +146,12 @@ void TcpBeamTracker::connect()
                         err.message(),
                         err.value());
 
+      // A socket whose connect failed cannot be connected again: the next attempt returns
+      // ECONNABORTED on linux and EINVAL on macos, whatever the peer is doing by then. Closing it
+      // here is what makes the retry below a retry -- connect() opens a fresh one.
+      asio::error_code closeError;
+      us->socket_.close(closeError);  // NOLINT(bugprone-unused-return-value)
+
       us->timer_.cancel();
       us->timer_.expires_after(reconnectTimeout);
       us->timer_.async_wait(


### PR DESCRIPTION
A socket whose connect has failed cannot be connected again, but the retry reused it: `connect()` opens a socket only when one is not already open, and the failed-connect path left it open. The next attempt then fails with `ECONNABORTED` regardless of what the hub is doing, and only the attempt after that succeeds — so a component that lost the startup race waited two retry cycles to join instead of one.

Measured by starting the client a second before the hub, with and without the change:

```
without                                with
  +0.000  connect refused                +0.000  connect refused
  +1.007  hub starts listening           +0.999  hub starts listening
  +2.005  retry -> ECONNABORTED
  +4.006  connected                      +2.001  connected
```

The fix closes the socket before scheduling the retry, so `connect()` opens a fresh one. The same file already does this when an established connection is lost; only the never-established path did not.

**Scope.** This removes a wasted retry cycle, not a hang: the component did eventually join. It is worth having because the reconnect interval is two seconds and the integration tests run under a twenty-second cap, so an avoidable two-second delay at startup has somewhere to go wrong. It is not established that this is the cause of the intermittent integration failures — it is one delay that contributes.

**No test.** This component has no unit test infrastructure, and adding it means a new test target, a test directory, and a harness that can drive an `asio` retry against a real `RunApi`. That belongs in its own change rather than inside a five-line fix. The evidence here is the measurement above.
