### PR TITLE
fix(coverage): survive a truncated raw profile

### DIFF
--- a/cmake/util/generate_coverage_report.py
+++ b/cmake/util/generate_coverage_report.py
@@ -20,6 +20,8 @@ def merge_coverage_profiles(llvm_profdata, profile_data_dir):
     print(" ├ Merging raw profiles...")
 
     raw_profiles = glob.glob(os.path.join(profile_data_dir, "*.profraw"))
+    if not raw_profiles:
+        raise SystemExit(f"No raw profiles in {profile_data_dir}: the tests produced no coverage data.")
 
     input_files = os.path.join(profile_data_dir, "profile_input_files")
     profdata_path = os.path.join(profile_data_dir, "merged_coverage.profdata")
@@ -27,18 +29,41 @@ def merge_coverage_profiles(llvm_profdata, profile_data_dir):
     with open(input_files, "w", encoding="utf-8") as manifest:
         manifest.write("\n".join(raw_profiles))
 
+    # A process killed while writing its profile leaves a truncated file. Without this, one of
+    # those makes the merge refuse every good profile beside it.
     cmd = [llvm_profdata, "merge"]
     cmd += ["-sparse"]
+    cmd += ["--failure-mode=warn"]
     cmd += ["-f", input_files]
     cmd += ["-o", profdata_path]
 
-    subprocess.check_call(cmd)
+    merge = subprocess.run(cmd, check=True, capture_output=True, text=True, encoding="utf-8")
+    unreadable = [line for line in merge.stderr.splitlines() if line.startswith("warning: ")]
+    for warning in unreadable:
+        print(f" │ {warning}")
+    if unreadable:
+        print(f" │ Skipped {len(unreadable)} of {len(raw_profiles)} raw profiles.")
+
+    if functions_covered(llvm_profdata, profdata_path) == 0:
+        raise SystemExit(f"No raw profile in {profile_data_dir} could be read: the report would be empty.")
 
     for raw_profile in raw_profiles:
         os.remove(raw_profile)
     os.remove(input_files)
 
     return profdata_path
+
+
+def functions_covered(llvm_profdata, profdata_path) -> int:
+    """How many functions the merged profile holds, so an empty report cannot pass for a real one."""
+    summary = subprocess.run(
+        [llvm_profdata, "show", profdata_path], check=True, capture_output=True, text=True, encoding="utf-8"
+    )
+    for line in summary.stdout.splitlines():
+        label, _, count = line.partition(":")
+        if label.strip() == "Total functions":
+            return int(count.strip())
+    raise SystemExit(f"`llvm-profdata show {profdata_path}` reported no function count.")
 
 
 def transform_to_binary_args(binaries) -> list[str]:


### PR DESCRIPTION
The clang coverage job hands every raw profile a run produced to `llvm-profdata merge`. If one of
them cannot be read, the merge refuses the whole batch, so a run where all 1625 tests passed loses
its coverage report and the job goes red. That is what failed #190 and the clang leg of #186; both
logs name a corrupt profile and then `error: no profile can be merged`.

A profile becomes unreadable when the process writing it is killed part way through. The write
happens only as a process exits, sen installs no SIGTERM handler, and the integration test runner
stops every supporting instance when a test ends. So an instance normally contributes no profile at
all, and one signalled during its write leaves a truncated file. Racing SIGTERM into that window
against an instrumented binary reproduces it: a 380,928 byte file where a whole one is 445,680,
reported as `invalid instrumentation profile data (file header is corrupt)`.

The merge now skips a profile it cannot read and prints it, with a count of how many went that way,
so the loss is visible rather than silent. It still fails when none can be read, so an empty report
cannot pass for a real one.

Checked against a real instrumented profile and the truncated file from that race: a normal run
merges as before, valid plus truncated merges and keeps the counts, truncated only fails, an empty
directory fails. `--failure-mode` is present in the llvm-20.1.8 the CI image pins.

Handling SIGTERM in sen is the deeper fix and belongs with whoever owns shutdown behaviour. This
change stays correct either way, since a profile can also be truncated by a cancelled job or a test
that times out.
