### PR TITLE
feat(cli): stop cleanly on SIGTERM and SIGINT

### DIFF
--- a/apps/cli_run/main.cpp
+++ b/apps/cli_run/main.cpp
@@ -7,6 +7,7 @@
 
 // sen
 #include "sen/core/base/assert.h"
+#include "sen/core/base/compiler_macros.h"
 #include "sen/core/base/hash32.h"
 #include "sen/kernel/bootloader.h"
 #include "sen/kernel/kernel.h"
@@ -29,7 +30,20 @@
 #include <CLI/CLI.hpp>  // NOLINT (misc-include-cleaner): to correctly link
 #include <CLI/Validators.hpp>
 
+// platform
+#if defined(_WIN32)
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <Windows.h>
+#else
+#  include <pthread.h>
+#endif
+
 // std
+#include <atomic>
+#include <chrono>
+#include <csignal>
 #include <cstdio>
 #include <cstdlib>
 #include <exception>
@@ -37,6 +51,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <tuple>
 
 namespace
@@ -141,6 +156,170 @@ std::unique_ptr<sen::kernel::Bootloader> makeBootloader(const std::shared_ptr<Ru
   return bootloader;
 }
 
+/// Turns a termination request from the operating system into an orderly kernel stop.
+///
+/// Without this the process keeps the default disposition and dies where it stands, losing whatever
+/// it was in the middle of writing. `docker stop`, systemd and ctrl-c all arrive this way.
+class SignalStopper
+{
+public:
+  SEN_NOCOPY_NOMOVE(SignalStopper)
+
+  SignalStopper() noexcept;
+  ~SignalStopper() noexcept;
+
+public:
+  /// Stops the signals killing the process, and must run before anything else in main: until it
+  /// does, the default disposition applies and a request arriving takes the process down. It is
+  /// separate from watching because the kernel does not exist yet at that point.
+  static void blockEarly() noexcept;
+
+  /// Starts watching. The kernel must outlive this object.
+  void watch(sen::kernel::Kernel& kernel) noexcept;
+
+  /// True once a request has arrived, so one that lands during start-up is not lost.
+  [[nodiscard]] bool signalled() const noexcept { return signalled_.load(); }
+
+private:
+  /// Asks the kernel to stop, and keeps asking.
+  ///
+  /// requestStop is dropped while the kernel is still starting up, and start-up is where a
+  /// supervisor's first request often lands. Once one takes, the rest are no-ops.
+  void askUntilItTakes(sen::kernel::Kernel& kernel) noexcept;
+
+private:
+  std::atomic_bool signalled_ {false};
+  std::atomic_bool stopping_ {false};
+
+#if defined(_WIN32)
+  /// Windows runs this on a thread of its own, so it may take a lock. A static member rather than a
+  /// free function because it reaches the two below.
+  static BOOL WINAPI consoleHandler(DWORD event);
+
+  static inline SignalStopper* instance_ {nullptr};
+  static inline sen::kernel::Kernel* kernel_ {nullptr};
+#else
+  sigset_t mask_ {};
+  bool armed_ {false};
+  std::thread waiter_;
+
+  /// Whether blockEarly succeeded. Static because it runs before any instance exists.
+  static inline bool blocked_ {false};
+#endif
+};
+
+void SignalStopper::askUntilItTakes(sen::kernel::Kernel& kernel) noexcept
+{
+  signalled_.store(true);
+  while (!stopping_.load())
+  {
+    kernel.requestStop(0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+}
+
+#if defined(_WIN32)
+
+/// Nothing to block: windows delivers to a handler on its own thread rather than killing outright.
+void SignalStopper::blockEarly() noexcept {}
+
+SignalStopper::SignalStopper() noexcept { instance_ = this; }
+
+SignalStopper::~SignalStopper() noexcept
+{
+  stopping_.store(true);
+  std::ignore = SetConsoleCtrlHandler(consoleHandler, FALSE);
+  instance_ = nullptr;
+  kernel_ = nullptr;
+}
+
+void SignalStopper::watch(sen::kernel::Kernel& kernel) noexcept
+{
+  kernel_ = &kernel;
+  std::ignore = SetConsoleCtrlHandler(consoleHandler, TRUE);
+}
+
+/// Returning TRUE says the event is handled; the process then has a few seconds before windows ends
+/// it regardless.
+BOOL WINAPI SignalStopper::consoleHandler(DWORD event)
+{
+  if (event != CTRL_C_EVENT && event != CTRL_BREAK_EVENT && event != CTRL_CLOSE_EVENT && event != CTRL_SHUTDOWN_EVENT)
+  {
+    return FALSE;
+  }
+
+  if (instance_ != nullptr && kernel_ != nullptr)
+  {
+    instance_->askUntilItTakes(*kernel_);
+  }
+
+  return TRUE;
+}
+
+#else
+
+namespace
+{
+/// The signals this process turns into a stop.
+void fillTerminationMask(sigset_t& mask) noexcept
+{
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGTERM);
+  sigaddset(&mask, SIGINT);
+}
+}  // namespace
+
+/// Blocking here rather than in the constructor closes the window between the process starting and
+/// the kernel being built. Threads inherit the mask, so every thread made later is covered too.
+void SignalStopper::blockEarly() noexcept
+{
+  sigset_t mask;
+  fillTerminationMask(mask);
+  blocked_ = pthread_sigmask(SIG_BLOCK, &mask, nullptr) == 0;
+}
+
+SignalStopper::SignalStopper() noexcept
+{
+  fillTerminationMask(mask_);
+  armed_ = blocked_;
+}
+
+SignalStopper::~SignalStopper() noexcept
+{
+  stopping_.store(true);
+  if (waiter_.joinable())
+  {
+    // The thread is parked in sigwait, so send it the signal it is waiting for.
+    std::ignore = pthread_kill(waiter_.native_handle(), SIGTERM);
+    waiter_.join();
+  }
+}
+
+/// A handler may not touch a mutex and requestStop takes one, so a thread waits for the signal
+/// instead and calls it as ordinary code.
+void SignalStopper::watch(sen::kernel::Kernel& kernel) noexcept
+{
+  if (!armed_)
+  {
+    return;
+  }
+
+  waiter_ = std::thread(
+    [this, &kernel]()
+    {
+      // Which of the two it was makes no difference: both mean stop.
+      int sig = 0;
+      if (sigwait(&mask_, &sig) != 0 || stopping_.load())
+      {
+        return;
+      }
+
+      askUntilItTakes(kernel);
+    });
+}
+
+#endif
+
 // Exit codes:
 //   0       success
 //   1       std::runtime_error escaped from the kernel
@@ -151,6 +330,10 @@ std::unique_ptr<sen::kernel::Bootloader> makeBootloader(const std::shared_ptr<Ru
 [[nodiscard]] int runKernel(const std::shared_ptr<RunArgs>& args, CLI::App& app)
 {
   int exitCode = EXIT_FAILURE;
+
+  // Before anything that might start a thread: the mask is what every later thread inherits.
+  SignalStopper stopper;
+
   try
   {
     auto bootloader = makeBootloader(args, app);
@@ -160,6 +343,15 @@ std::unique_ptr<sen::kernel::Bootloader> makeBootloader(const std::shared_ptr<Ru
       sen::kernel::Kernel::registerTerminationHandler();
     }
     sen::kernel::Kernel kernel(bootloader->getConfig());
+
+    stopper.watch(kernel);
+    if (stopper.signalled())
+    {
+      // Asked to stop while we were still loading, so there is nothing to run. Only a shortcut:
+      // a request that arrives after this point is caught by the loop instead.
+      return 0;
+    }
+
     exitCode = kernel.run();
   }
   catch (const std::runtime_error& err)
@@ -243,6 +435,9 @@ int runApp(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
+  // First, before any thread exists and before anything can take time.
+  SignalStopper::blockEarly();
+
   try
   {
     return runApp(argc, argv);

--- a/libs/kernel/test/CMakeLists.txt
+++ b/libs/kernel/test/CMakeLists.txt
@@ -16,6 +16,7 @@ if(NOT MSVC)
   add_subdirectory(integration/runtime_compatibility)
   add_subdirectory(integration/crash_report)
   add_subdirectory(integration/type_clash)
+  add_subdirectory(integration/termination)
   #
   # integration tests that use containers (only available in Linux)
   if(LINUX)

--- a/libs/kernel/test/integration/termination/CMakeLists.txt
+++ b/libs/kernel/test/integration/termination/CMakeLists.txt
@@ -1,0 +1,20 @@
+# === CMakeLists.txt ===================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+add_sen_integration_test(
+  kernel_termination_test
+  COMMAND
+  ${Python3_EXECUTABLE}
+  ${CMAKE_CURRENT_SOURCE_DIR}/terminate_test.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/bare_kernel.yaml
+  WORKING_DIRECTORY $<TARGET_FILE_DIR:sen::cli_run>
+  REQ_DEPS cli_run
+)
+
+set_tests_properties(kernel_termination_test PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1")

--- a/libs/kernel/test/integration/termination/bare_kernel.yaml
+++ b/libs/kernel/test/integration/termination/bare_kernel.yaml
@@ -1,0 +1,3 @@
+# A kernel with nothing loaded and nothing built. It runs until it is asked to stop, which is all
+# this test needs: no component, no discovery, no second process.
+load: []

--- a/libs/kernel/test/integration/termination/terminate_test.py
+++ b/libs/kernel/test/integration/termination/terminate_test.py
@@ -1,0 +1,75 @@
+# === terminate_test.py ================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Checks that a termination request stops the kernel instead of killing it."""
+
+import signal
+import subprocess
+import sys
+import time
+
+# How long the kernel is given to stop. Generous: what is being tested is that it stops at all, and
+# a tight bound here would turn a slow machine into a failure.
+STOP_TIMEOUT_SECONDS = 15
+
+
+def run_until_signalled(config, sig, delay):
+    """Start a kernel, signal it after delay seconds, and return (exit code, seconds taken)."""
+    kernel = subprocess.Popen(["./sen", "run", config], start_new_session=True)  # noqa: S603
+    time.sleep(delay)
+
+    start = time.monotonic()
+    kernel.send_signal(sig)
+    try:
+        return kernel.wait(timeout=STOP_TIMEOUT_SECONDS), time.monotonic() - start
+    except subprocess.TimeoutExpired:
+        kernel.kill()
+        kernel.wait()
+        return None, time.monotonic() - start
+
+
+def check(config, name, sig, delay):
+    """Report whether one case stopped cleanly."""
+    code, took = run_until_signalled(config, sig, delay)
+
+    if code is None:
+        print(f"FAIL {name}: still running {took:.1f}s after the request, had to be killed")
+        return False
+
+    # A negative code is python for "killed by a signal", which is the whole defect: the process
+    # died where it stood instead of stopping.
+    if code < 0:
+        print(f"FAIL {name}: killed by signal {-code} rather than stopping")
+        return False
+
+    if code != 0:
+        print(f"FAIL {name}: stopped with exit code {code}, expected 0")
+        return False
+
+    print(f"ok   {name}: stopped cleanly in {took:.2f}s")
+    return True
+
+
+def main():
+    """Run every case and fail if any of them did."""
+    if len(sys.argv) != 2:
+        sys.exit("Usage: python terminate_test.py <config_yaml>")
+
+    config = sys.argv[1]
+
+    # Not covered: a request arriving while the kernel is still being built. This kernel loads
+    # nothing, so it is built in under a millisecond and there is no window to aim at. Covering it
+    # needs a kernel slow enough to start.
+    results = [
+        check(config, "SIGTERM while running", signal.SIGTERM, 1.0),
+        check(config, "SIGINT while running", signal.SIGINT, 1.0),
+    ]
+
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`sen run` handled neither signal, so both killed the process where it stood — no component unload, nothing flushed. That is how `docker stop`, systemd, ctrl-c and the integration runner all ask a process to finish.

A signal handler may not take a mutex and `requestStop` does, so on posix the signals are blocked at the top of `main` and one thread waits for them, calling `requestStop` as ordinary code. Windows delivers to a handler on its own thread and calls it directly.

Measured on a kernel that does not exit by itself: SIGTERM took it down instantly with status -15, and now ends it in 0.58s with status 0.

**Exit code is 0.** A stop the operator asked for is a success, which is how systemd and Kubernetes read it. The alternative is `128+signum`, at the cost of every supervisor treating a normal stop as a failure.

**Test:** `kernel_termination_test`, a single process with no components loaded. It fails on main for both signals.

**Not covered:** a request arriving while the kernel is still being built, which is what the retry in `askUntilItTakes` is for. A kernel that loads nothing is built in under a millisecond, so there is no window to aim at; covering it needs a kernel slow enough to start.
