### PR TITLE
fix(test): stop assuming the build generator is Ninja

### DIFF
--- a/.github/scripts/check_sanitizer_lane.py
+++ b/.github/scripts/check_sanitizer_lane.py
@@ -281,30 +281,49 @@ def build_compiler(build_dir: Path, fallback: str) -> str:
     return fallback
 
 
-def linked_here(build_dir: Path) -> list[str]:
+def linked_here(build_dir: Path) -> list[str] | None:
     """What this build links, read from the generator's own edges.
 
     File names cannot answer this: Sen versions its libraries, so the real files are
     `libcore.so.0.0.0` and `sen-0.0.0` with a symlink beside them. A vendored dependency is
     not linked here at all, so the edges exclude it without a list to maintain.
+
+    None when no generator wrote its edges here, which is not the same as a build that
+    linked nothing and must not be reported as one.
     """
     ninja = build_dir / "build.ninja"
-    if not ninja.exists():
-        return []
-    edge = re.compile(r"^build ([^:\n]+): (?:CXX|C)_(?:SHARED_LIBRARY|EXECUTABLE|MODULE_LIBRARY)_LINKER__\S+", re.M)
-    outputs: set[str] = set()
-    for match in edge.finditer(ninja.read_text(encoding="utf-8", errors="replace")):
-        outputs.update(part.replace("$ ", " ") for part in match.group(1).split())
-    return sorted(outputs)
+    if ninja.exists():
+        edge = re.compile(r"^build ([^:\n]+): (?:CXX|C)_(?:SHARED_LIBRARY|EXECUTABLE|MODULE_LIBRARY)_LINKER__\S+", re.M)
+        outputs: set[str] = set()
+        for match in edge.finditer(ninja.read_text(encoding="utf-8", errors="replace")):
+            outputs.update(part.replace("$ ", " ") for part in match.group(1).split())
+        return sorted(outputs)
+
+    # A Makefile build records each link the same way, one file per target. Its -o is
+    # relative to the directory the command runs in, which is the target's own.
+    links = sorted(build_dir.glob("**/CMakeFiles/*.dir/link.txt"))
+    if links:
+        outputs = set()
+        for link in links:
+            written = re.search(r"(?:^|\s)-o\s+(\S+)", link.read_text(encoding="utf-8", errors="replace"))
+            if written:
+                linked = (link.parent.parent.parent / written.group(1)).resolve()
+                outputs.add(str(linked.relative_to(build_dir.resolve())))
+        return sorted(outputs)
+
+    return None
 
 
-def binaries(build_dir: Path) -> list[Path]:
+def binaries(build_dir: Path) -> list[Path] | None:
     """Everything the lane linked that the runtime should be in, and that exists.
 
     A configuration that leaves a target out -- benchmarks here -- names it and does not
     produce it, which is not this check's business.
     """
-    return [build_dir / output for output in linked_here(build_dir) if (build_dir / output).is_file()]
+    outputs = linked_here(build_dir)
+    if outputs is None:
+        return None
+    return [build_dir / output for output in outputs if (build_dir / output).is_file()]
 
 
 def options_of(test: dict) -> tuple[dict[str, str], list[str], str | None]:
@@ -541,6 +560,8 @@ def instrumentation_problems(build_dir: Path, symbols: list[str]) -> list[str]:
     instrumented, and one instrumented library is enough to hide the whole of the rest.
     """
     found = binaries(build_dir)
+    if found is None:
+        return [f"no build.ninja and no link.txt under {build_dir}: what this build linked cannot be read"]
     if not found:
         return [f"no libraries or executables under {build_dir}, so nothing can be checked for instrumentation"]
 

--- a/.github/scripts/test_check_sanitizer_lane.py
+++ b/.github/scripts/test_check_sanitizer_lane.py
@@ -252,3 +252,28 @@ def test_two_tests_differing_only_in_where_they_write_are_one_option_set():
         "c": {"ASAN_OPTIONS": "suppressions=/other:log_path=/r/c/report"},
     }
     assert len(check.option_sets(tests)) == 2
+
+
+def test_a_makefile_build_is_read_like_a_ninja_one(tmp_path):
+    """The lane is checked locally as well as on the runner, and the two use different generators."""
+    target = tmp_path / "libs" / "core" / "CMakeFiles" / "core.dir"
+    target.mkdir(parents=True)
+    (target / "link.txt").write_text(
+        "/usr/bin/clang++-20 -fsanitize=address -shared -o ../../bin/libcore.so.0.0.0 core.cpp.o\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "bin").mkdir(parents=True)
+    (tmp_path / "bin" / "libcore.so.0.0.0").write_text("", encoding="utf-8")
+
+    assert check.linked_here(tmp_path) == ["bin/libcore.so.0.0.0"]
+    assert [path.name for path in check.binaries(tmp_path)] == ["libcore.so.0.0.0"]
+
+
+def test_a_tree_with_no_generator_edges_is_not_reported_as_linking_nothing(tmp_path):
+    """A check that cannot see must say so. Reported as an empty build it reads as a real finding."""
+    assert check.linked_here(tmp_path) is None
+    assert check.binaries(tmp_path) is None
+
+    problems = check.instrumentation_problems(tmp_path, ["__asan_init"])
+    assert problems, "a tree it cannot read must be a problem, not a pass"
+    assert "cannot be read" in problems[0]

--- a/cmake/util/test.cmake
+++ b/cmake/util/test.cmake
@@ -318,15 +318,16 @@ function(add_sen_run_smoke_test test_name)
     set(_working_dir ${_arg_WORKING_DIRECTORY})
   elseif(DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)
     set(_working_dir ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-  elseif(
-    NOT
-    CMAKE_GENERATOR
-    STREQUAL
-    "Ninja"
-  )
-    set(_working_dir ${PROJECT_BINARY_DIR}/bin/${CMAKE_BUILD_TYPE})
   else()
-    set(_working_dir ${PROJECT_BINARY_DIR}/bin)
+    # Only a multi-config generator writes binaries under a per-configuration directory.
+    # Keyed on the generator's name, every single-config build that is not Ninja was sent
+    # to one that does not exist, and ctest will not start a test there.
+    get_property(_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(_multi_config)
+      set(_working_dir ${PROJECT_BINARY_DIR}/bin/$<CONFIG>)
+    else()
+      set(_working_dir ${PROJECT_BINARY_DIR}/bin)
+    endif()
   endif()
 
   get_filename_component(_abs_config ${_arg_CONFIG_FILE} ABSOLUTE)


### PR DESCRIPTION
Two checks decided what to do from the generator's name rather than from what the generator does,
and both were wrong away from a Ninja build. Neither shows on this repository's runners, which
always generate Ninja; both bite anyone checking a build locally.

**Sixteen smoke tests did not run.** `add_sen_run_smoke_test` picked its working directory by asking
whether the generator is called `Ninja`, treating everything else as multi-config. Under Unix
Makefiles that names `bin/<config>`, which a single-config build never creates, and ctest reports a
test whose working directory is missing as `Not Run` without attempting it. Under a real
multi-config generator it named `bin/` with an empty configuration, since `CMAKE_BUILD_TYPE` is not
set there, so the same tests would not have run on Windows either.

| generator | before | after |
|---|---|---|
| Ninja | `bin` | `bin` |
| Unix Makefiles | `bin/Debug`, which does not exist | `bin` |
| Ninja Multi-Config | `bin/`, configuration empty | `bin/$<CONFIG>` |
| Visual Studio | `bin/`, configuration empty | `bin/$<CONFIG>` |

It now asks `GENERATOR_IS_MULTI_CONFIG`, which is the actual question, and takes the configuration
from a generator expression rather than a variable that is empty exactly where it is needed.

**The sanitizer canary could not read a Makefile build.** It reads what a build linked from
`build.ninja`. Given a build without one it returned nothing and reported `no libraries or
executables under <dir>, so nothing can be checked for instrumentation` -- an empty build stated as
fact, with sixty-two libraries and executables sitting beside it. It now reads a Makefile build's
`link.txt` files too, and separates "no generator wrote its edges here" from "this build linked
nothing". A check that cannot see must say so; reported as an empty build it reads as a real
finding, which is the failure this canary exists to prevent.

**Found and verified by running the whole lane locally**: the canary passes, and the suite is 1589
of 1589 where it was 1573 of 1589.
