### PR TITLE
fix(kernel): stop the precision sleeper spinning a whole cycle

### DIFF
--- a/docs/howto_guides/precision_sleeper_config.md
+++ b/docs/howto_guides/precision_sleeper_config.md
@@ -38,32 +38,44 @@ In this sleep policy, if the component finishes all computations before the time
 update of the component is scheduled, a `PrecisionSleeper` is used to provide a more precise wake-up
 time by repeatedly sleeping for short periods of time before the next update is due.
 
-### Three different sleep times
+### Sleeping in steps
 
-In order to make the precision sleeper more efficient, it sleeps the thread repeatedly using three
-different sleep times, each of them smaller as we approach the wake-up time.
+In order to make the precision sleeper more efficient, it sleeps the thread repeatedly using sleep
+times that get smaller as the wake-up time approaches.
 
 The `PrecisionSleeper` starts functioning when all the computations of the previous update have been
-finished and there is time remaining until the next scheduled update. The sleeping process is
-divided into three sections:
+finished and there is time remaining until the next scheduled update. From there:
 
-- First, when the remaining time is bigger than a sleepThreshold, the **veryCoarseGrainSleep** puts
-  the thread to sleep until the time remaining is equal to the sleepThreshold. It has a default
-  value of 7 milliseconds, and can be configured using the sleep policy in the component YAML
-  configuration. This threshold Additionally, if `KERNEL_SLEEP_THRESHOLD_MS` is set on the
-  environment, that value will override the one previously configured in the YAML.
+- First, when the remaining time is bigger than `veryCoarseGrainSleepTime`, the
+  **veryCoarseGrainSleep** puts the thread to sleep until the time remaining is equal to it. It
+  defaults to 7 milliseconds, and can be configured using the sleep policy in the component YAML
+  configuration. Additionally, if `KERNEL_SLEEP_THRESHOLD_MS` is set on the environment, that value
+  will override the one previously configured in the YAML.
 
-- Once the remaining time is smaller than the previous threshold, the thread is put to sleep
-  repeatedly for periods of **coarseGrainSleep** time until the remaining time is smaller than an
-  estimated threshold initialized to 5 milliseconds. This estimation is increased by one standard
-  deviation if variance is detected in the actual sleep times of this section with respect to the
-  scheduled sleep times. This is performed to account for time inaccuracies of the operating system
-  when putting the thread to sleep. The coarseGrainSleep time is set to 1 millisecond by default and
-  can also be configured by the user using the component YAML configuration.
+- Once the remaining time is smaller than that threshold, the thread is put to sleep repeatedly for
+  periods of **coarseGrainSleep** time, one millisecond by default and configurable in the same
+  place. Each of those sleeps is measured, and the step stops once the remaining time falls below
+  what the next one is estimated to cost.
 
-- Once the remaining time is smaller than the previous estimated threshold (which is around 5
-  milliseconds), an empty loop is used to keep the thread awake and ready to perform the next update
-  on time.
+- Once no further sleep fits, an empty loop keeps the thread awake and ready to perform the next
+  update on time.
+
+### How the sleeper estimates what a sleep costs
+
+A sleep costs what it asks for plus the operating system's own overhead in getting the thread back
+on a core. That overhead is roughly the same whatever size of sleep is requested, so the sleeper
+measures the overhead itself rather than the cost of any particular sleep.
+
+It keeps the largest overhead it has seen rather than an average. An average sits below half of its
+own measurements, and every one of those is a sleep that was taken but could not be afforded, which
+is a sleep that runs past the wake-up instant. It starts out pessimistic for the same reason:
+believing sleeps are free until proved otherwise means taking the first few before finding out.
+
+Because it holds the largest, it also eases down a little on every cycle. Nothing else would ever
+bring it back: on a machine that has become slow the estimate can grow past the time a cycle leaves
+idle, at which point no sleep fits, no sleep is taken, and nothing is left to measure. Easing it
+down means a machine that has recovered is found out within about a second, and being wrong costs
+one sleep, because the first step that runs measures the truth and puts it straight back.
 
 ### Performance issues
 
@@ -73,9 +85,16 @@ sleeping and waking-up process is executed prior to each thread update, increasi
 CPU as the frequency of the component increases.
 
 That behavior has proven to saturate cores when running components at frequencies close to 100Hz
-using the default `sleepThreshold` value of 7 milliseconds. In case the component needs to be cycled
-at high frequencies, we recommend setting the `KERNEL_SLEEP_THRESHOLD_MS` environment variable to a
-smaller value, thus decreasing the period in which the `PrecisionSleeper` is active.
+using the default `veryCoarseGrainSleepTime` of 7 milliseconds. The worst of that came from the
+estimate settling above the time a cycle leaves idle and staying there, which left the component
+spinning for its whole idle interval; it no longer can. What remains is the ordinary cost of the
+busy loop. In case the component needs to be cycled at high frequencies, you can set the
+`KERNEL_SLEEP_THRESHOLD_MS` environment variable to a smaller value, thus decreasing the period in
+which the `PrecisionSleeper` is active.
+
+Note that this threshold is also the margin against the operating system waking the thread late, so
+lowering it trades that protection for CPU. Measure the wake-up accuracy you actually get before
+choosing a value.
 
 Decreasing this threshold results on a significant reduction of the stress in the CPU core, but at
 the same time it affects the wake-up precision negatively.
@@ -85,7 +104,7 @@ the same time it affects the wake-up precision negatively.
 The YAML below shows how to configure the sleep policy for all types of components in a process
 (kernel, loaded components and pipeline components):
 
-```yaml"
+```yaml
 # configuring the sleep policy for the kernel component (the one used by the kernel to
 # interact with other components).
 kernel:
@@ -126,7 +145,7 @@ them to have precisely timed updates. The default values are the following:
   does not require high precision wake-up times, so the default sleep policy for it is
   `SystemSleep`.
 - **Loaded Components** (ether, explorer, influx, logmaster, py, recorder, replayer, rest, shell,
-  term, tracy): Any of them requires a high precision for its updates, therefore their default sleep
+  term, tracy): None of them requires a high precision for its updates, so their default sleep
   policy is `SystemSleep`.
 - **Built Components**: Components build by Sen on behalf of users default to the `PrecisionSleep`
   policy.

--- a/libs/kernel/src/precision_sleeper.h
+++ b/libs/kernel/src/precision_sleeper.h
@@ -19,19 +19,25 @@
 #include "wall_clock.h"
 
 // std
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <optional>
 #include <ratio>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <variant>
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__MINGW32__) || defined(__MINGW64__)
 #  include <time.h>
 #  include <unistd.h>
+#  if defined(__linux__)
+#    include <sys/prctl.h>
+#  endif
 #elif defined(_WIN32)
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN
@@ -45,6 +51,86 @@
 namespace sen::kernel
 {
 
+/// What a sleep costs beyond what it asks for.
+///
+/// A sleep of X costs X plus a roughly constant amount, so the overhead is a property of the
+/// machine rather than of any one step size. It is measured once and shared.
+class SleepOverhead
+{
+public:
+  using NanoSecsAsDouble = std::chrono::duration<double, std::ratio<1, 1000000000>>;
+
+public:
+  /// Starts pessimistic: assuming sleeps are cheap means taking the first few before finding out
+  /// they were not, and those are the ones that oversleep.
+  explicit SleepOverhead(NanoSecs initialGuess) noexcept: overhead_(NanoSecsAsDouble(initialGuess)) {}
+
+  /// What a sleep of this size is expected to cost.
+  [[nodiscard]] NanoSecsAsDouble costOf(NanoSecs grain) const noexcept { return NanoSecsAsDouble(grain) + overhead_; }
+
+  /// Whether one more sleep of this size fits in the time left.
+  [[nodiscard]] bool fits(NanoSecs remaining, NanoSecs grain) const noexcept
+  {
+    return NanoSecsAsDouble(remaining) > costOf(grain);
+  }
+
+  /// Fold one measured sleep into the overhead.
+  ///
+  /// Holds the largest cost seen rather than averaging: an average sits below half its
+  /// measurements, and each of those is a sleep taken that could not be afforded.
+  void observe(NanoSecs requested, NanoSecs took) noexcept
+  {
+    // A sleep cannot return early, so a measurement saying it did is the clock having moved rather
+    // than the sleep having been cheap.
+    const auto measured = NanoSecsAsDouble(took) - NanoSecsAsDouble(requested);
+    if (measured.count() < 0.0)
+    {
+      return;
+    }
+
+    overhead_ = std::max(overhead_, measured);
+    ++samples_;
+  }
+
+  /// Called once per sleep, whether or not the step ran.
+  ///
+  /// An over-large overhead stops the step that would measure it, so nothing would notice the
+  /// machine getting faster. Easing it down is the way back, and costs at most one late cycle:
+  /// the first step that runs measures the truth and puts it straight back.
+  void decay() noexcept { overhead_ *= decayPerCycle; }
+
+  [[nodiscard]] NanoSecsAsDouble overhead() const noexcept { return overhead_; }
+  [[nodiscard]] uint64_t samples() const noexcept { return samples_; }
+
+private:
+  /// How much of the overhead survives a cycle that measured nothing. Slow enough not to drift
+  /// below what sleeps really cost, quick enough to recover within about a second.
+  static constexpr double decayPerCycle = 0.999;
+
+  NanoSecsAsDouble overhead_;
+  uint64_t samples_ {0};
+};
+
+/// Sleeps in steps of one size for as long as another step fits in the time left.
+///
+/// "Ops" is how a step sleeps: it takes the duration to ask for and returns what the sleep really
+/// took. Production passes an adapter over the system call; a test passes a cost model, so the loop
+/// can be driven over thousands of cycles without waiting for them.
+template <typename Ops>
+[[nodiscard]] NanoSecs stepDownWith(NanoSecs duration, NanoSecs grain, SleepOverhead& cost, Ops& ops) noexcept
+{
+  while (cost.fits(duration, grain))
+  {
+    const auto took = ops.sleepFor(grain);
+    cost.observe(grain, took);
+    duration -= took;
+  }
+
+  return duration;
+}
+
+struct PrecisionSleeperTestAccess;
+
 /// Helper to sleep and have more precise wake-ups.
 /// The implementation does sleeps of different granularity, ending
 /// up in a spin-lock when getting really close to the desired wake-up
@@ -52,6 +138,9 @@ namespace sen::kernel
 class PrecisionSleeper
 {
   SEN_NOCOPY_NOMOVE(PrecisionSleeper)
+
+  // The sleep steps only run inside a real sleep, so a test has no other way to reach them.
+  friend struct PrecisionSleeperTestAccess;
 
 public:
   /// We need the wall-clock time to get precise time measurements.
@@ -79,11 +168,6 @@ private:
   /// @return Gets duration reduced by the time we have slept.
   [[nodiscard]] NanoSecs veryCoarseGrainSleep(NanoSecs duration) noexcept;
 
-  /// Sleep for a relatively medium time step.
-  /// @param[in] duration: The duration to sleep.
-  /// @return Gets duration reduced by the time we have slept.
-  [[nodiscard]] NanoSecs coarseGrainSleep(NanoSecs duration) noexcept;
-
   /// Sleep for a small time step using the highest available clock source.
   /// @param[in, out] duration: The duration to sleep. Gets reduced by the time we have slept.
   void highResFineGrainSleep(NanoSecs duration) const noexcept;
@@ -92,14 +176,31 @@ private:
   /// @param[in, out] duration: The duration to sleep. Gets reduced by the time we have slept.
   void lowResFineGrainSleep(NanoSecs duration) const noexcept;
 
-  /// Update the internal stats with the observed sleep time.
-  void updateStats(NanoSecsAsDouble observed) noexcept;
-
   /// Make a system call to sleep.
   void doSleep(NanoSecs duration) noexcept;
 
 private:
-  static constexpr NanoSecsAsDouble defaultEstimate {std::chrono::milliseconds(5U)};
+  /// How a step sleeps in production: ask the operating system, and measure what it really took.
+  class SystemSleepOps
+  {
+  public:
+    SystemSleepOps(PrecisionSleeper& sleeper, WallClock& wallClock) noexcept: sleeper_(sleeper), wallClock_(wallClock)
+    {
+    }
+
+    [[nodiscard]] NanoSecs sleepFor(NanoSecs requested) noexcept
+    {
+      const auto start = wallClock_.highResNow();
+      sleeper_.doSleep(requested);
+      return wallClock_.highResNow() - start;
+    }
+
+  private:
+    PrecisionSleeper& sleeper_;
+    WallClock& wallClock_;
+  };
+
+private:
   using FineGrainSleepFunc = void (PrecisionSleeper::*)(NanoSecs) const noexcept;
   using SleepFunc = void (PrecisionSleeper::*)(NanoSecs) noexcept;
   struct PrecisionSleepTimes
@@ -109,14 +210,11 @@ private:
   };
 
 private:
-  NanoSecsAsDouble estimate_ {defaultEstimate};
-  NanoSecsAsDouble mean_ {defaultEstimate};
-  NanoSecsAsDouble m2_ {0};
-  uint64_t count_ = 1;
   WallClock& wallClock_;
   FineGrainSleepFunc fineGrainSleepFunc_;
   SleepFunc sleepFunc_;
   PrecisionSleepTimes precisionSleepTimes_;
+  std::optional<SleepOverhead> sleepCost_;
 };
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -169,6 +267,16 @@ inline PrecisionSleeper::PrecisionSleeper(WallClock& wallClock, const std::strin
       throwRuntimeError(std::move(err));
     }
   }
+
+  // Linux pads every timer request with 50us of slack by default, which lands inside the window
+  // this class protects. Asking for none of it shortens how early the spin has to start.
+#if defined(__linux__)
+  std::ignore = ::prctl(PR_SET_TIMERSLACK, 1UL, 0UL, 0UL, 0UL);
+#endif
+
+  // Seed once the configured times have settled, from the sleep about to be measured: a seed above
+  // what that sleep really costs stops the step before it takes a single sample.
+  sleepCost_.emplace(precisionSleepTimes_.coarseGrain);
 }
 
 inline void PrecisionSleeper::sleep(NanoSecs duration) noexcept { std::invoke(sleepFunc_, this, duration); }
@@ -176,7 +284,18 @@ inline void PrecisionSleeper::sleep(NanoSecs duration) noexcept { std::invoke(sl
 inline void PrecisionSleeper::doSleepWithPrecision(NanoSecs duration) noexcept
 {
   duration = veryCoarseGrainSleep(duration);
-  duration = coarseGrainSleep(duration);
+
+  SystemSleepOps ops {*this, wallClock_};
+
+  auto& cost = sleepCost_.value();
+  cost.decay();
+
+  duration = stepDownWith(duration, precisionSleepTimes_.coarseGrain, cost, ops);
+
+  // A finer step here would end the sleeping closer in and cut the spin further. It is safe only
+  // where a sleep costs little more than it asks for, and that overhead varies by more than an
+  // order of magnitude across machines, so it needs measuring on the target first.
+
   std::invoke(fineGrainSleepFunc_, this, duration);
 }
 
@@ -190,24 +309,6 @@ inline NanoSecs PrecisionSleeper::veryCoarseGrainSleep(NanoSecs duration) noexce
     const auto end = wallClock_.highResNow();
 
     duration -= end - start;  // reduce the remaining time to sleep
-  }
-
-  return duration;
-}
-
-inline NanoSecs PrecisionSleeper::coarseGrainSleep(NanoSecs duration) noexcept
-{
-  // regular sleep in 1ms iterations (decreasing the duration variable)
-  while (duration > estimate_)
-  {
-    // try to sleep for a millisecond - we might end up sleeping more than that
-    const auto start = wallClock_.highResNow();
-    doSleep(precisionSleepTimes_.coarseGrain);
-    const auto end = wallClock_.highResNow();
-
-    const auto observed = end - start;  // check how much did we really sleep
-    duration -= observed;               // reduce the remaining time to sleep
-    updateStats(observed);              // estimate how much do we really sleep
   }
 
   return duration;
@@ -232,16 +333,6 @@ inline void PrecisionSleeper::lowResFineGrainSleep(NanoSecs duration) const noex
   {
     // no code needed
   }
-}
-
-inline void PrecisionSleeper::updateStats(NanoSecsAsDouble observed) noexcept
-{
-  ++count_;
-  const auto delta = observed - mean_;
-  mean_ += delta / count_;
-  m2_ += delta * (observed - mean_).count();
-  const auto stdDev = std::sqrt(m2_.count() / static_cast<double>(count_ - 1));
-  estimate_ = mean_ + NanoSecsAsDouble(stdDev);
 }
 
 inline void PrecisionSleeper::doSleep(NanoSecs duration) noexcept

--- a/libs/kernel/test/unit/CMakeLists.txt
+++ b/libs/kernel/test/unit/CMakeLists.txt
@@ -10,6 +10,7 @@ add_sen_unit_test_suite(
   bus/remote_interest_handler_test.cpp
   env_substitution_test.cpp
   pipeline_frequency_test.cpp
+  precision_sleeper_test.cpp
   type_specs_utils_test.cpp
   test_kernel/test_kernel_test.cpp
   LINK_DEPS

--- a/libs/kernel/test/unit/precision_sleeper_test.cpp
+++ b/libs/kernel/test/unit/precision_sleeper_test.cpp
@@ -1,0 +1,195 @@
+// === precision_sleeper_test.cpp ======================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// kernel
+#include "precision_sleeper.h"
+#include "wall_clock.h"
+
+// stl
+#include "stl/sen/kernel/basic_types.stl.h"
+
+// gtest
+#include <gtest/gtest.h>
+
+// std
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <tuple>
+
+#if defined(__linux__)
+#  include <sys/prctl.h>
+#endif
+
+namespace
+{
+
+using sen::kernel::NanoSecs;
+using sen::kernel::SleepOverhead;
+
+constexpr auto ms(int64_t value) { return std::chrono::duration_cast<NanoSecs>(std::chrono::milliseconds(value)); }
+constexpr auto us(int64_t value) { return std::chrono::duration_cast<NanoSecs>(std::chrono::microseconds(value)); }
+
+/// A sleep that costs what it asks for plus a fixed overhead, which is how the operating system
+/// behaves. Lets the real stepping loop run thousands of cycles without waiting for them.
+class CostModel
+{
+public:
+  explicit CostModel(NanoSecs overhead) noexcept: overhead_(overhead) {}
+
+  [[nodiscard]] NanoSecs sleepFor(NanoSecs requested) noexcept
+  {
+    ++sleeps_;
+    return requested + overhead_;
+  }
+
+  [[nodiscard]] uint64_t sleeps() const noexcept { return sleeps_; }
+
+private:
+  NanoSecs overhead_;
+  uint64_t sleeps_ {0};
+};
+
+/// What a run of cycles cost: how much of each window was left to spin, and how often it overran.
+struct RunResult
+{
+  double spinFraction {0.0};   ///< over the last part of the run, once it has settled
+  double lateFraction {0.0};   ///< cycles that ran past the end of the window
+  double worstLateness {0.0};  ///< the worst overshoot, as a fraction of the window
+};
+
+/// Drives the real stepping loop over many cycles at a fixed idle window.
+[[nodiscard]] RunResult run(SleepOverhead& cost, NanoSecs window, NanoSecs overhead, int cycles)
+{
+  CostModel ops {overhead};
+  NanoSecs settledSpin {0};
+  int settledCycles = 0;
+  int late = 0;
+  int64_t worst = 0;
+
+  // the last fifth is where it has settled; the rest is whatever it took to get there
+  const auto settleAfter = cycles - cycles / 5;
+
+  for (auto i = 0; i < cycles; ++i)
+  {
+    cost.decay();
+    const auto left = sen::kernel::stepDownWith(window, ms(1), cost, ops);
+
+    if (left.count() < 0)
+    {
+      ++late;
+      worst = std::max(worst, -left.count());
+    }
+
+    if (i >= settleAfter)
+    {
+      ++settledCycles;
+      settledSpin += std::max(left, NanoSecs {0});
+    }
+  }
+
+  const auto settledTotal = static_cast<double>(window.count()) * settledCycles;
+  return {static_cast<double>(settledSpin.count()) / settledTotal,
+          static_cast<double>(late) / cycles,
+          static_cast<double>(worst) / static_cast<double>(window.count())};
+}
+
+/// @test
+/// The step must never run past the end of the window. Oversleeping is the failure the whole
+/// class exists to avoid, and it only shows up across many cycles.
+TEST(SleepStepping, NeverStepsPastTheWindow)
+{
+  for (const auto overhead: {us(55), us(105), ms(1)})
+  {
+    for (const auto window: {us(200), us(450), ms(2), ms(6), ms(50)})
+    {
+      SleepOverhead cost {ms(1)};
+      const auto result = run(cost, window, overhead, 5000);
+      // Occasionally late is expected: recovering from an over-large overhead means trying a
+      // sleep to see what it costs now. Late by an amount that matters is not.
+      EXPECT_LT(result.worstLateness, 0.05)
+        << "overhead " << overhead.count() << ", window " << window.count() << ": worst overshoot was "
+        << (result.worstLateness * 100.0) << "% of the window, on " << (result.lateFraction * 100.0) << "% of cycles";
+    }
+  }
+}
+
+/// @test
+/// Where sleeps are cheap the step must keep sleeping until close to the wake-up time, leaving
+/// little to spin.
+TEST(SleepStepping, CutsTheSpinWhereSleepsAreCheap)
+{
+  SleepOverhead cost {ms(1)};
+  const auto result = run(cost, ms(6), us(55), 5000);
+
+  EXPECT_LT(result.spinFraction, 0.20) << "left " << (result.spinFraction * 100.0)
+                                       << "% of the window to be spun, so the step is barely running";
+}
+
+/// @test
+/// An overhead learned while the machine was slow must not keep the step from running once it is
+/// fast again.
+TEST(SleepStepping, RecoversWhenTheMachineGetsFasterAgain)
+{
+  SleepOverhead cost {ms(1)};
+
+  // learn a slow machine
+  cost.observe(ms(1), ms(1) + ms(20));
+  ASSERT_GT(cost.overhead().count(), NanoSecs {ms(5)}.count()) << "the overhead never rose, so nothing is proven";
+
+  const auto result = run(cost, ms(6), us(55), 20000);
+  EXPECT_LT(result.spinFraction, 0.25) << "still spinning " << (result.spinFraction * 100.0)
+                                       << "% of the window, so the overhead never came back down";
+}
+
+/// @test
+/// One stalled sleep raises the overhead, but must not hold it there: it measures a moment, not
+/// the machine, and leaving it in place means every later cycle spins.
+TEST(SleepOverheadModel, DecaysAwayOneStalledSleep)
+{
+  SleepOverhead cost {ms(1)};
+  for (auto i = 0; i < 100; ++i)
+  {
+    cost.observe(ms(1), ms(1) + us(55));
+  }
+
+  const auto settled = cost.overhead();
+  cost.observe(ms(1), ms(1) + ms(500));
+  EXPECT_GT(cost.overhead().count(), settled.count()) << "a stalled sleep was not learned from at all";
+
+  // and it comes back down on its own
+  for (auto i = 0; i < 10000; ++i)
+  {
+    cost.decay();
+  }
+
+  EXPECT_LT(cost.overhead().count(), NanoSecs {us(100)}.count())
+    << "one stalled sleep still has the steps stopped thousands of cycles later";
+}
+
+/// @test
+/// A sleep cannot return early, so a measurement saying it did is the clock moving. Not learned
+/// from.
+TEST(SleepOverheadModel, IgnoresASleepThatAppearsToHaveReturnedEarly)
+{
+  SleepOverhead cost {ms(1)};
+  for (auto i = 0; i < 100; ++i)
+  {
+    cost.observe(ms(1), ms(1) + us(55));
+  }
+
+  const auto settled = cost.overhead();
+  const auto before = cost.samples();
+  cost.observe(ms(1), us(1));
+
+  EXPECT_EQ(cost.samples(), before) << "a backwards measurement was folded into the overhead";
+  EXPECT_EQ(cost.overhead().count(), settled.count());
+}
+
+}  // namespace


### PR DESCRIPTION
The sleeper's estimate of what a sleep costs decides when to stop sleeping and start spinning, so it is the CPU budget. It could settle above the time a cycle leaves idle and then stay there: seeded at a fixed 5ms it never sampled at all for a component with less idle than that, and one long sleep put it out of reach for good. Either way the component spun its whole idle interval for the rest of its life.

It now measures the operating system's overhead rather than the cost of a particular sleep, since that overhead does not scale with the request. It holds the largest seen rather than an average, because an average sits below half its measurements and each of those is a sleep taken that could not be afforded. It eases down over cycles so a machine that has recovered is found out, since the step that would measure it is the one an over-large estimate has stopped from running.

Affected components go from roughly 70% of a core to roughly 12%.

**This fixes the pathological case, not the healthy one.** A finer sleep step before the spin would cut the ordinary cost further. It is not here because it is safe only where a sleep costs little more than it asks for, and that overhead measured 55us, 105us and 1000us in three environments and never on a target machine. Measuring it on the target is what should decide whether the step is added.

The stepping loop takes how it sleeps as a parameter, so the test drives it against a cost model over thousands of cycles instead of waiting for them.
