### PR TITLE
fix(kernel)!: make the configured thread priority take effect

### DIFF
--- a/libs/kernel/src/posix/posix_api.cpp
+++ b/libs/kernel/src/posix/posix_api.cpp
@@ -72,6 +72,16 @@ int NativePosixAPI::pthread_attr_setschedparam(pthread_attr_t* attr, const sched
   return ::pthread_attr_setschedparam(attr, param);
 }
 
+int NativePosixAPI::pthread_attr_setinheritsched(pthread_attr_t* attr, int inherit) noexcept
+{
+  return ::pthread_attr_setinheritsched(attr, inherit);
+}
+
+int NativePosixAPI::pthread_attr_setschedpolicy(pthread_attr_t* attr, int policy) noexcept
+{
+  return ::pthread_attr_setschedpolicy(attr, policy);
+}
+
 int NativePosixAPI::pthread_join(pthread_t thread, void** returnVal) noexcept
 {
   return ::pthread_join(thread, returnVal);

--- a/libs/kernel/src/posix/posix_api.h
+++ b/libs/kernel/src/posix/posix_api.h
@@ -63,6 +63,8 @@ public:
                                                       std::size_t) noexcept = 0;                  // NOLINT NOSONAR
   [[nodiscard]] virtual int pthread_attr_setschedparam(pthread_attr_t*,                           // NOLINT NOSONAR
                                                        const sched_param*) noexcept = 0;          // NOLINT NOSONAR
+  [[nodiscard]] virtual int pthread_attr_setinheritsched(pthread_attr_t*, int) noexcept = 0;      // NOLINT NOSONAR
+  [[nodiscard]] virtual int pthread_attr_setschedpolicy(pthread_attr_t*, int) noexcept = 0;       // NOLINT NOSONAR
   [[nodiscard]] virtual int pthread_join(pthread_t, void**) noexcept = 0;                         // NOLINT NOSONAR
   [[nodiscard]] virtual int pthread_cancel(pthread_t thread) noexcept = 0;                        // NOLINT NOSONAR
   [[nodiscard]] virtual int pthread_setcanceltype(int type, int* old_type) noexcept = 0;          // NOLINT NOSONAR
@@ -91,6 +93,8 @@ public:
   [[nodiscard]] int sched_get_priority_min(int) noexcept override;                                       // NOLINT
   [[nodiscard]] int pthread_attr_setstacksize(pthread_attr_t*, std::size_t) noexcept override;           // NOLINT
   [[nodiscard]] int pthread_attr_setschedparam(pthread_attr_t*, const sched_param*) noexcept override;   // NOLINT
+  [[nodiscard]] int pthread_attr_setinheritsched(pthread_attr_t*, int) noexcept override;                // NOLINT
+  [[nodiscard]] int pthread_attr_setschedpolicy(pthread_attr_t*, int) noexcept override;                 // NOLINT
   [[nodiscard]] int pthread_join(pthread_t, void**) noexcept override;                                   // NOLINT
   [[nodiscard]] int pthread_cancel(pthread_t thread) noexcept override;                                  // NOLINT
   [[nodiscard]] int pthread_setcanceltype(int type, int* old_type) noexcept override;                    // NOLINT

--- a/libs/kernel/src/posix/posix_os.cpp
+++ b/libs/kernel/src/posix/posix_os.cpp
@@ -116,8 +116,15 @@ Result<Thread, ThreadCreateErr> PosixOS::createThread(const ThreadConfig& config
   }
 
   threads_.emplace_back(std::move(result).getValue());
-  std::ignore = threads_.back().run();
-  return Ok(Thread {&threads_.back()});
+  if (auto runResult = threads_.back().run(); runResult.isError())
+  {
+    // run() only reports an error when no thread was created, so nothing is running that could
+    // still be reading this object.
+    threads_.pop_back();
+    return Err(runResult.getError());
+  }
+
+  return Ok(Thread {&threads_.back(), threads_.back().priorityApplied(), threads_.back().affinityApplied()});
 }
 
 bool PosixOS::joinThread(Thread thread) noexcept

--- a/libs/kernel/src/posix/thread_impl.cpp
+++ b/libs/kernel/src/posix/thread_impl.cpp
@@ -20,6 +20,7 @@
 #include <sched.h>
 
 // std
+#include <cerrno>
 #include <cstddef>
 #include <memory>
 #include <tuple>
@@ -74,9 +75,22 @@ Result<void, ThreadCreateErr> ThreadImpl::run() noexcept
   // - EPERM  No permission to set the scheduling policy and parameters
   //          specified in attr.
 
-  if (api_->pthread_create(&thread_, &attributes_, threadFunction, this) != 0U)
+  if (const auto created = api_->pthread_create(&thread_, &attributes_, threadFunction, this); created != 0)
   {
-    return Err(ThreadCreateErr::internalOsError);
+    // Only EPERM means the scheduling attributes were refused, and only then is running without
+    // them better than not running at all. Anything else fails the way it always did.
+    if (created != EPERM)
+    {
+      return Err(ThreadCreateErr::internalOsError);
+    }
+
+    if (api_->pthread_attr_setinheritsched(&attributes_, PTHREAD_INHERIT_SCHED) != 0U ||
+        api_->pthread_create(&thread_, &attributes_, threadFunction, this) != 0U)
+    {
+      return Err(ThreadCreateErr::internalOsError);
+    }
+
+    priorityApplied_ = false;
   }
 
   // attributes are not needed anymore
@@ -84,8 +98,14 @@ Result<void, ThreadCreateErr> ThreadImpl::run() noexcept
 
   std::ignore = api_->pthread_setname_np(thread_, config_.name.c_str());
 
-  // now that the thread is created, we have to set the affinity (if needed).
-  return configureAffinity();
+  // The thread exists from here on, so a failure past this point must not be reported as a failure
+  // to create it: the caller would destroy this object while the thread is still reading it.
+  if (configureAffinity().isError())
+  {
+    affinityApplied_ = false;
+  }
+
+  return Ok();
 }
 
 bool ThreadImpl::join() const noexcept
@@ -112,26 +132,31 @@ bool ThreadImpl::kill() const noexcept
 
 Result<void, ThreadCreateErr> ThreadImpl::configurePriority() noexcept
 {
-  if (config_.priority == Priority::nominalMin)
+  // Only the upper half of the enum asks for a real-time policy. "lowest" is for background work,
+  // so promoting it above every other thread would invert what it means, and lowering it needs a
+  // nice value that is not wired here.
+  if (config_.priority == Priority::lowest || config_.priority == Priority::nominalMin)
   {
     return Ok();
   }
 
-  // Fetch the scheduling policy by calling 'pthread_attr_getschedpolicy'.
-  // This might return EINVAL if the value specified by attr does
-  // not refer to an initialized thread attribute object. This cannot
-  // happen, as this is already initialized in the configure()
-  // function, which calls this one.
-  int policy = 0;
-  if (api_->pthread_attr_getschedpolicy(&attributes_, &policy) != 0U)
+  // A priority only means something under a real-time policy: SCHED_OTHER reports the same value
+  // for its lowest and highest, so there is no range to place a thread in. POSIX also ignores the
+  // attributes unless asked to honour them, which is what made this function do nothing.
+  if (api_->pthread_attr_setinheritsched(&attributes_, PTHREAD_EXPLICIT_SCHED) != 0U)
   {
     return Err(ThreadCreateErr::internalOsError);
   }
 
+  if (api_->pthread_attr_setschedpolicy(&attributes_, SCHED_FIFO) != 0U)
+  {
+    return Err(ThreadCreateErr::internalOsError);
+  }
+
+  const int policy = SCHED_FIFO;
+
   const auto osMinimumPrio = api_->sched_get_priority_min(policy);
   const auto osMaximumPrio = api_->sched_get_priority_max(policy);
-  const auto osNominalMin = 70;
-  const auto osNominalMax = osMaximumPrio - 1;
 
   // 'sched_get_priority_max', and 'sched_get_priority_min' return -1 in case of error. The
   // error is EINVAL and means that the argument policy does not identify a defined scheduling
@@ -149,17 +174,13 @@ Result<void, ThreadCreateErr> ThreadImpl::configurePriority() noexcept
 
   sched_param sched {};  // NOLINT(misc-include-cleaner): sched.h is included; the check cannot map the type
 
-  if (config_.priority == Priority::lowest)
-  {
-    sched.sched_priority = osMinimumPrio;
-  }
-  else if (config_.priority == Priority::highest)
+  if (config_.priority == Priority::highest)
   {
     sched.sched_priority = osMaximumPrio;
   }
   else
   {
-    sched.sched_priority = (osNominalMax - osNominalMin) / 2;
+    sched.sched_priority = osMinimumPrio + (osMaximumPrio - osMinimumPrio) / 2;
   }
 
   if (api_->pthread_attr_setschedparam(&attributes_, &sched) != 0U)

--- a/libs/kernel/src/posix/thread_impl.h
+++ b/libs/kernel/src/posix/thread_impl.h
@@ -47,6 +47,15 @@ public:
   /// Calls pthread_create and sets the affinity (if any).
   [[nodiscard]] Result<void, ThreadCreateErr> run() noexcept;
   [[nodiscard]] bool join() const noexcept;
+
+  /// False when the configured priority could not be applied and the thread runs without it.
+  [[nodiscard]] bool priorityApplied() const noexcept { return priorityApplied_; }
+
+  /// False when the configured cpu affinity could not be applied and the thread runs unpinned.
+  [[nodiscard]] bool affinityApplied() const noexcept { return affinityApplied_; }
+
+  /// The underlying handle, so a test can ask the operating system what the thread actually got.
+  [[nodiscard]] pthread_t nativeThread() const noexcept { return thread_; }
   [[nodiscard]] bool kill() const noexcept;
   [[nodiscard]] bool detach() const noexcept;
 
@@ -70,6 +79,8 @@ private:
 private:
   ThreadConfig config_;
   pthread_attr_t attributes_ {};
+  bool priorityApplied_ = true;
+  bool affinityApplied_ = true;
   pthread_t thread_ {};
   std::shared_ptr<PosixAPI> api_;
 };

--- a/libs/kernel/src/runner.cpp
+++ b/libs/kernel/src/runner.cpp
@@ -314,6 +314,24 @@ FuncResult Runner::run()
   threadConfig.name = std::string(component_.info.name) + "-component";
 
   auto threadCreationResult = os_.createThread(threadConfig);
+  if (threadCreationResult.isOk() && !threadCreationResult.getValue().priorityApplied)
+  {
+    // Running without the configured priority beats refusing to start, but the component is not
+    // scheduled the way it was configured.
+    SPDLOG_LOGGER_WARN(KernelImpl::getKernelLogger(),
+                       "component '{}' runs without its configured priority: the operating system "
+                       "refused it",
+                       component_.info.name);
+  }
+
+  if (threadCreationResult.isOk() && !threadCreationResult.getValue().affinityApplied)
+  {
+    // Same reasoning: a mask the machine cannot honour used to be ignored in silence.
+    SPDLOG_LOGGER_WARN(KernelImpl::getKernelLogger(),
+                       "component '{}' runs unpinned: the configured cpu affinity could not be applied",
+                       component_.info.name);
+  }
+
   if (threadCreationResult.isError())
   {
     std::string msg;

--- a/libs/kernel/src/thread.h
+++ b/libs/kernel/src/thread.h
@@ -37,6 +37,8 @@ struct ThreadConfig
 struct Thread
 {
   void* nativeHandle = nullptr;  ///< A nullptr handle indicates an invalid thread.
+  bool priorityApplied = true;   ///< False when the configured priority could not be granted.
+  bool affinityApplied = true;   ///< False when the configured cpu affinity could not be applied.
 };
 
 }  // namespace sen::kernel

--- a/libs/kernel/src/win32/thread_impl.cpp
+++ b/libs/kernel/src/win32/thread_impl.cpp
@@ -131,7 +131,9 @@ Result<void, ThreadCreateErr> ThreadImpl::configurePriority() noexcept
 
   if (api_->SetThreadPriority(thread_, nPriority) == FALSE)
   {
-    return Err(ThreadCreateErr::internalOsError);
+    // Running without the requested priority beats refusing to run, the same as on posix. The
+    // caller reports it.
+    priorityApplied_ = false;
   }
 
   return Ok();
@@ -145,10 +147,13 @@ Result<void, ThreadCreateErr> ThreadImpl::configureAffinity() noexcept
     return Ok();
   }
 
-  DWORD affinity = DWORD(config_.affinity);
-  if (api_->SetThreadAffinityMask(thread_, affinity) != 0U)
+  // SetThreadAffinityMask returns the thread's PREVIOUS mask, and zero only on failure. Testing
+  // for non-zero reported every success as a failure.
+  const DWORD affinity = DWORD(config_.affinity);
+  if (api_->SetThreadAffinityMask(thread_, affinity) == 0U)
   {
-    return Err(ThreadCreateErr::invalidAffinity);
+    // the thread is already running, so report this rather than failing its creation
+    affinityApplied_ = false;
   }
 
   return Ok();

--- a/libs/kernel/src/win32/thread_impl.h
+++ b/libs/kernel/src/win32/thread_impl.h
@@ -36,6 +36,12 @@ public:
 public:
   [[nodiscard]] Result<void, ThreadCreateErr> run() noexcept;
   [[nodiscard]] bool join() noexcept;
+
+  /// False when the configured priority could not be applied and the thread runs without it.
+  [[nodiscard]] bool priorityApplied() const noexcept { return priorityApplied_; }
+
+  /// False when the configured cpu affinity could not be applied and the thread runs unpinned.
+  [[nodiscard]] bool affinityApplied() const noexcept { return affinityApplied_; }
   [[nodiscard]] bool kill() noexcept;
   [[nodiscard]] bool detach() noexcept;
 
@@ -52,6 +58,8 @@ private:
 
 private:
   ThreadConfig config_;
+  bool priorityApplied_ = true;
+  bool affinityApplied_ = true;
   HANDLE thread_ {};
   std::shared_ptr<Win32API> api_;
 };

--- a/libs/kernel/src/win32/win32_os.cpp
+++ b/libs/kernel/src/win32/win32_os.cpp
@@ -83,7 +83,7 @@ Result<Thread, ThreadCreateErr> Win32OS::createThread(const ThreadConfig& config
     return Err(runResult.getError());
   }
 
-  return Ok(Thread {threads_.back().get()});
+  return Ok(Thread {threads_.back().get(), threads_.back()->priorityApplied(), threads_.back()->affinityApplied()});
 }
 
 bool Win32OS::joinThread(Thread thread) noexcept

--- a/libs/kernel/test/unit/CMakeLists.txt
+++ b/libs/kernel/test/unit/CMakeLists.txt
@@ -18,6 +18,10 @@ add_sen_unit_test_suite(
   sen::kernel
 )
 
+if(NOT WIN32)
+  target_sources(kernel_test PRIVATE thread_priority_test.cpp)
+endif()
+
 sen_generate_cpp(
   TARGET kernel_test
   STL_FILES test_kernel/stl/my_class.stl

--- a/libs/kernel/test/unit/thread_priority_test.cpp
+++ b/libs/kernel/test/unit/thread_priority_test.cpp
@@ -1,0 +1,155 @@
+// === thread_priority_test.cpp ========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#ifndef _WIN32
+
+// kernel
+#  include "posix/posix_api.h"
+#  include "posix/posix_os.h"
+#  include "thread.h"
+
+// stl
+#  include "stl/sen/kernel/basic_types.stl.h"
+
+// gtest
+#  include <gtest/gtest.h>
+
+// std
+#  include <atomic>
+#  include <memory>
+#  include <string>
+
+namespace
+{
+
+std::atomic<int> ranCount {0};
+
+/// The scheduling policy the thread saw for itself. Asking from outside races the thread's exit:
+/// one process per test means it has usually gone, and pthread_getschedparam returns ESRCH.
+std::atomic<int> observedPolicy {-1};
+
+void countingThread(void* /*arg*/)
+{
+  observedPolicy.store(::sched_getscheduler(0));
+  ranCount.fetch_add(1);
+}
+
+/// @test
+/// A component that asks for a priority must still start when the process cannot be granted one:
+/// a real-time policy needs a privilege many deployments do not have.
+TEST(ThreadPriority, StartsEvenWhenThePriorityCannotBeGranted)
+{
+  sen::kernel::PosixOS os {std::make_shared<sen::kernel::NativePosixAPI>()};
+
+  sen::kernel::ThreadConfig config {};
+  config.name = "prio-test";
+  config.function = &countingThread;
+  config.arg = &ranCount;
+  config.priority = sen::kernel::Priority::highest;
+
+  const auto before = ranCount.load();
+  auto result = os.createThread(config);
+
+  ASSERT_TRUE(result.isOk()) << "asking for a priority must not stop the thread starting";
+  EXPECT_TRUE(os.joinThread(result.getValue()));
+  EXPECT_EQ(ranCount.load(), before + 1) << "the thread never ran";
+
+  // Whether it was granted depends on this process's privileges. What must hold either way is
+  // that the thread ran and that we can tell which happened.
+  const auto applied = result.getValue().priorityApplied;
+  RecordProperty("priorityApplied", applied ? "true" : "false");
+}
+
+/// @test
+/// A component asking to be scheduled low must not be promoted. "lowest" is for background work,
+/// so a real-time policy would put it above every other thread in the process.
+TEST(ThreadPriority, DoesNotPromoteAThreadThatAskedToBeLow)
+{
+  sen::kernel::PosixOS os {std::make_shared<sen::kernel::NativePosixAPI>()};
+
+  sen::kernel::ThreadConfig config {};
+  config.name = "low-test";
+  config.function = &countingThread;
+  config.arg = &ranCount;
+  config.priority = sen::kernel::Priority::lowest;
+
+  observedPolicy.store(-1);
+  auto result = os.createThread(config);
+  ASSERT_TRUE(result.isOk());
+  EXPECT_TRUE(os.joinThread(result.getValue()));
+
+  // The thread reports its own policy, so this holds whether or not a real-time one could have
+  // been granted. Asking instead whether the request was granted would pass on a privileged
+  // machine, which is exactly where the defect bites.
+  EXPECT_EQ(observedPolicy.load(), SCHED_OTHER) << "a thread that asked to be low was given a real-time policy";
+}
+
+/// @test
+/// An affinity the machine cannot honour leaves the thread running unpinned and says so. Failing
+/// thread creation instead would destroy an object the new thread is still reading.
+///
+/// Linux only: the macOS shim always reports that it applied, so there is nothing to observe.
+#  if defined(__linux__)
+TEST(ThreadPriority, RunsUnpinnedWhenTheAffinityCannotBeApplied)
+{
+  sen::kernel::PosixOS os {std::make_shared<sen::kernel::NativePosixAPI>()};
+
+  sen::kernel::ThreadConfig config {};
+  config.name = "affinity-test";
+  config.function = &countingThread;
+  config.arg = &ranCount;
+  // The mask is 64 bits wide, so on a machine with 64 or more cpus every bit names a real one and
+  // there is no unapplicable mask to ask for.
+  if (std::thread::hardware_concurrency() >= 64U)
+  {
+    GTEST_SKIP() << "every bit of the mask names a real cpu on this machine";
+  }
+
+  config.affinity = 1ULL << 63U;
+
+  const auto before = ranCount.load();
+  auto result = os.createThread(config);
+
+  ASSERT_TRUE(result.isOk()) << "an affinity the machine cannot honour must not fail thread creation";
+  EXPECT_FALSE(result.getValue().affinityApplied) << "it was reported as applied";
+  EXPECT_TRUE(os.joinThread(result.getValue()));
+  EXPECT_EQ(ranCount.load(), before + 1) << "the thread never ran";
+}
+#  endif  // __linux__
+
+/// @test
+/// A thread that genuinely could not be created is reported as an error. The creation path used to
+/// discard that result, handing the caller a handle to a thread that never started.
+TEST(ThreadPriority, ReportsAThreadThatCouldNotBeCreated)
+{
+  sen::kernel::PosixOS os {std::make_shared<sen::kernel::NativePosixAPI>()};
+
+  sen::kernel::ThreadConfig config {};
+  config.name = "doomed";
+  config.function = &countingThread;
+  config.arg = &ranCount;
+  // This has to exceed the address space, not merely be enormous: a 64TB stack is mapped without
+  // complaint under overcommit, and the test then skips instead of exercising the failure. Do not
+  // reduce it -- a smaller value turns this into a permanent skip that still looks green.
+  config.stackSize = 1ULL << 62U;
+
+  const auto before = ranCount.load();
+  auto result = os.createThread(config);
+
+  if (result.isOk())
+  {
+    // the system did map it after all, so there is nothing to assert here
+    EXPECT_TRUE(os.joinThread(result.getValue()));
+    GTEST_SKIP() << "this system allocated a stack larger than its address space";
+  }
+
+  EXPECT_EQ(ranCount.load(), before) << "the thread ran, so this is not the failure path";
+}
+
+}  // namespace
+
+#endif  // _WIN32


### PR DESCRIPTION
A configured `priority:` had never taken effect. POSIX ignores the scheduling attributes unless asked explicitly with `PTHREAD_EXPLICIT_SCHED`, and Sen never asked, so every `priority:` in every configuration has been doing nothing.

Because the default scheduling class has no priority range to place a thread in, a configured priority now requests a real-time policy. `lowest` and `nominalMin` keep the default scheduling and are unaffected.

Also fixed here, found while testing the above:

- A use-after-free on the thread creation path.
- On Windows, `SetThreadAffinityMask` returns the previous mask on success and zero on failure, and the check tested for non-zero. Every Windows component with an affinity configured called `std::terminate()` precisely when the affinity **worked**.

A component whose affinity cannot be applied now starts unpinned and warns, where it was previously ignored in silence. Requesting a priority needs `CAP_SYS_NICE`; without it the component still starts, unprioritised, and logs one warning.

**Marked breaking.** The commit carries a `BREAKING CHANGE:` footer, which is what puts it in the generated release notes — the pull request description does not reach the squashed commit, so it has to be in the message. A priority that was inert now takes effect, and unprivileged systems get one warning per component where there was silence. Review any `priority:` values you are carrying: they were written against a mechanism that did nothing, so they may not say what you would choose today.
