### PR TITLE
feat(kernel): allow limiting the cpu idle latency

### DIFF
--- a/libs/kernel/src/executor.cpp
+++ b/libs/kernel/src/executor.cpp
@@ -36,7 +36,9 @@
 
 // os
 #ifdef __linux__
+#  include <fcntl.h>     // for open()
 #  include <sys/mman.h>  // for mlockall()
+#  include <unistd.h>    // for write() and close()
 #endif
 
 namespace sen::kernel::impl
@@ -78,7 +80,7 @@ Executor::Executor(std::vector<std::unique_ptr<Runner>>& runners)
 {
 }
 
-void Executor::startUp(bool tryToLockPages)
+void Executor::startUp(bool tryToLockPages, bool tryToLimitCpuIdleLatency)
 {
   // early exit
   if (runners_.empty())
@@ -104,8 +106,31 @@ void Executor::startUp(bool tryToLockPages)
         logger->warn("could not call mlockall (use setcap cap_ipc_lock,cap_sys_nice=+eip <path_to_cli_run>)");
       }
     }
+
+    // An idle processor drops into states it is slow to climb out of, and that climb is what makes
+    // a sleeping component wake late. Holding this file open at zero asks for none of them. It
+    // applies to the whole machine, for as long as the descriptor is held.
+    if (tryToLimitCpuIdleLatency && cpuIdleLatencyFd_ == -1)
+    {
+      cpuIdleLatencyFd_ =
+        ::open("/dev/cpu_dma_latency", O_WRONLY | O_CLOEXEC);  // NOLINT(cppcoreguidelines-pro-type-vararg)
+      const int32_t noLatency = 0;
+      if (cpuIdleLatencyFd_ == -1 || ::write(cpuIdleLatencyFd_, &noLatency, sizeof(noLatency)) != sizeof(noLatency))
+      {
+        if (cpuIdleLatencyFd_ != -1)
+        {
+          std::ignore = ::close(cpuIdleLatencyFd_);
+          cpuIdleLatencyFd_ = -1;
+        }
+
+        logger->warn(
+          "could not limit the cpu idle latency (/dev/cpu_dma_latency needs write access; "
+          "components may wake late on an otherwise idle machine)");
+      }
+    }
 #else
     std::ignore = tryToLockPages;
+    std::ignore = tryToLimitCpuIdleLatency;
 #endif
 
     startupFinished_ = true;
@@ -170,6 +195,15 @@ uint32_t Executor::computeMaxGroup(uint32_t previous) const noexcept
 void Executor::shutDown()
 {
   auto logger = KernelImpl::getKernelLogger();
+
+#ifdef __linux__
+  // the idle-latency constraint lasts exactly as long as the descriptor is held
+  if (cpuIdleLatencyFd_ != -1)
+  {
+    std::ignore = ::close(cpuIdleLatencyFd_);
+    cpuIdleLatencyFd_ = -1;
+  }
+#endif
 
   while (true)
   {

--- a/libs/kernel/src/executor.h
+++ b/libs/kernel/src/executor.h
@@ -37,7 +37,7 @@ public:
 
   /// Goes through each group, starting all runners.
   /// Throws std::exception on failure.
-  void startUp(bool tryToLockPages);
+  void startUp(bool tryToLockPages, bool tryToLimitCpuIdleLatency);
 
   /// Goes through each group, shutting down all runners.
   /// Throws std::exception on failure.
@@ -78,6 +78,7 @@ private:
   std::mutex startedConditionMutex_;
   std::atomic_bool startupFinished_;
   bool memoryLocked_ = false;
+  int cpuIdleLatencyFd_ = -1;
 };
 
 }  // namespace sen::kernel::impl

--- a/libs/kernel/src/kernel_impl.cpp
+++ b/libs/kernel/src/kernel_impl.cpp
@@ -88,7 +88,7 @@ int KernelImpl::run(KernelBlockMode blockMode)
       configured_ = true;
     }
 
-    executor_.startUp(config_.getParams().lockMemoryPages);
+    executor_.startUp(config_.getParams().lockMemoryPages, config_.getParams().limitCpuIdleLatency);
 
     // Can only be started after components are preloaded to ensure a trace component can install the tracer factory.
     sessionManager_.startMessageProcessing();

--- a/libs/kernel/stl/sen/kernel/basic_types.stl
+++ b/libs/kernel/stl/sen/kernel/basic_types.stl
@@ -196,7 +196,10 @@ struct KernelParams
   crashReportDisabled : bool,                   // if true, no reports are generated
   lockMemoryPages     : bool,                   // keep process pages memory-resident
   sleepPolicy         : SleepPolicy,            // configurable sleep policy of the kernel component
-  compatibilityMode   : CompatibilityMode       // what to do with a remote type that does not match
+  compatibilityMode   : CompatibilityMode,      // what to do with a remote type that does not match
+  // This struct is reachable over the wire through Kernel.getConfig() and is embedded in SenData,
+  // and the encoding is positional, so adding a field here shifts what follows it either way.
+  limitCpuIdleLatency : bool                    // keep the CPUs out of the deep idle states they are slow to leave
 }
 // --8<-- [end:kernel_params]
 


### PR DESCRIPTION
Adds `limitCpuIdleLatency` beside `lockMemoryPages` in `KernelParams`, opt-in and off by default.

A core that drops into a deep idle state is slow to leave it, which lands in the same window the precision sleeper exists to protect. This asks the operating system to bound that latency for the process.

It is a new `KernelParams` field. The encoding is positional and `SenData` embeds the struct, so the layout shifts either way; kept as its own commit so the kernel protocol version question stays with this change alone rather than riding along with the sleeper fix.
