### PR TITLE
fix(kernel): stop a clock jump hanging the schedule

### DIFF
--- a/libs/kernel/src/runner.cpp
+++ b/libs/kernel/src/runner.cpp
@@ -7,6 +7,8 @@
 
 #include "runner.h"
 
+#include "schedule_cycles.h"
+
 // implementation
 #include "kernel_impl.h"
 #include "operating_system.h"
@@ -682,11 +684,13 @@ void Runner::realTimeExecLoop(std::function<void()>&& workFunction, bool logOver
 
     bool missedFrameEnd = false;
 
-    // check if we need to skip cycles
-    while (workEnd > time64)
+    // check if we need to skip cycles. A clock that jumps forward puts the next cycle an arbitrary
+    // distance away, so walk to it in one step: period by period is unbounded and stopFlag_ is not
+    // read along the way. Only ever forward, as the bus discards updates stamped before the last.
+    if (workEnd > time64)
     {
       missedFrameEnd = true;
-      time64 += period;
+      time64 += period * cyclesToCover(workEnd - time64, period);
     }
 
     if (missedFrameEnd)
@@ -699,16 +703,27 @@ void Runner::realTimeExecLoop(std::function<void()>&& workFunction, bool logOver
       }
     }
 
-    // calibrate the clock from time to time
+    // calibrate the clock from time to time. This instant is read from the same clock it
+    // schedules, so a backward jump leaves it out of reach and stalls drift correction until wall
+    // time catches up.
+    const auto calibrateInterval = wallClock.getCalibrateIntervalNs();
+    if (nextCalibrationTime > workEnd + calibrateInterval)
+    {
+      nextCalibrationTime = workEnd + calibrateInterval;
+    }
+
     if (workEnd >= nextCalibrationTime)
     {
       wallClock.calibrate();
-      nextCalibrationTime = workEnd + wallClock.getCalibrateIntervalNs();
+      nextCalibrationTime = workEnd + calibrateInterval;
     }
 
   doSleep:
-    // sleep until nextCycleStart
-    sleeper.sleep(static_cast<std::chrono::nanoseconds>(time64 - wallClock.highResNow()));
+    // sleep until nextCycleStart, never asking for longer than a cycle. A backward jump makes this
+    // difference arbitrarily large, and the sleeper issues it as one call that does not read
+    // stopFlag_. This bounds the request, not the sleep: where highResNow is the system clock, a
+    // jump landing inside a sleep still holds it for the size of the jump.
+    sleeper.sleep(static_cast<std::chrono::nanoseconds>(std::min(time64 - wallClock.highResNow(), period)));
     const auto wakeUpTime = wallClock.highResNow();
 
     tracer_->plot(oversleepPlotName_, (wakeUpTime - time64).count());
@@ -716,11 +731,11 @@ void Runner::realTimeExecLoop(std::function<void()>&& workFunction, bool logOver
     // check if we missed one or more cycles while sleeping
     bool skippedFrames = false;
 
-    // jump over the cycles we missed
-    while (wakeUpTime - time64 > period)
+    // jump over the cycles we missed, in one step for the same reason as above
+    if (wakeUpTime - time64 > period)
     {
       skippedFrames = true;
-      time64 += period;
+      time64 += period * cyclesToCover(wakeUpTime - time64 - period, period);
     }
 
     if (skippedFrames)

--- a/libs/kernel/src/schedule_cycles.h
+++ b/libs/kernel/src/schedule_cycles.h
@@ -1,0 +1,35 @@
+// === schedule_cycles.h ===============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#ifndef SEN_LIBS_KERNEL_SRC_SCHEDULE_CYCLES_H
+#define SEN_LIBS_KERNEL_SRC_SCHEDULE_CYCLES_H
+
+// std
+#include <chrono>
+#include <cstdint>
+
+namespace sen::kernel
+{
+
+/// How many cycles of "period" it takes to cover "amount", rounding up, and none when there is
+/// nothing to cover. Computed rather than walked one cycle at a time: a clock that jumps forward
+/// leaves an arbitrary amount to cover, and the walk is unbounded and never reads the stop flag.
+[[nodiscard]] inline int64_t cyclesToCover(std::chrono::nanoseconds amount, std::chrono::nanoseconds period) noexcept
+{
+  if (amount.count() <= 0 || period.count() <= 0)
+  {
+    return 0;
+  }
+
+  // Divide before adding: the sum would overflow for a clock that jumps by decades, and an
+  // overflowed count is negative, which would walk the schedule backwards.
+  return amount.count() / period.count() + (amount.count() % period.count() != 0);
+}
+
+}  // namespace sen::kernel
+
+#endif  // SEN_LIBS_KERNEL_SRC_SCHEDULE_CYCLES_H

--- a/libs/kernel/test/unit/CMakeLists.txt
+++ b/libs/kernel/test/unit/CMakeLists.txt
@@ -11,6 +11,7 @@ add_sen_unit_test_suite(
   env_substitution_test.cpp
   pipeline_frequency_test.cpp
   precision_sleeper_test.cpp
+  runner_schedule_test.cpp
   type_specs_utils_test.cpp
   test_kernel/test_kernel_test.cpp
   LINK_DEPS

--- a/libs/kernel/test/unit/runner_schedule_test.cpp
+++ b/libs/kernel/test/unit/runner_schedule_test.cpp
@@ -1,0 +1,134 @@
+// === runner_schedule_test.cpp ========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// kernel
+#include "schedule_cycles.h"
+
+// gtest
+#include <gtest/gtest.h>
+
+// std
+#include <chrono>
+#include <cstdint>
+
+namespace
+{
+
+using sen::kernel::cyclesToCover;
+using NanoSecs = std::chrono::nanoseconds;
+
+constexpr auto ms(int64_t value) { return std::chrono::duration_cast<NanoSecs>(std::chrono::milliseconds(value)); }
+
+/// What the schedule used to do: one period per iteration, until the instant is reached.
+[[nodiscard]] int64_t cyclesByWalking(NanoSecs amount, NanoSecs period)
+{
+  int64_t cycles = 0;
+  for (auto covered = NanoSecs {0}; covered < amount; covered += period)
+  {
+    ++cycles;
+  }
+
+  return cycles;
+}
+
+/// The other walk this replaces, which ran while the schedule was more than a whole cycle behind.
+/// Its caller subtracts one period first, and that subtraction is what needs checking: one period
+/// out would run a frame that should have been skipped.
+[[nodiscard]] int64_t cyclesByWalkingAfterOversleep(NanoSecs behind, NanoSecs period)
+{
+  int64_t cycles = 0;
+  for (auto remaining = behind; remaining > period; remaining -= period)
+  {
+    ++cycles;
+  }
+
+  return cycles;
+}
+
+/// @test
+/// The computed count matches the loop it replaces, so this is a refactor rather than a change of
+/// behaviour.
+TEST(RunnerSchedule, CountsTheSameCyclesTheOldWalkDid)
+{
+  for (const auto period: {ms(1), ms(10), ms(100)})
+  {
+    for (int64_t multiple = 0; multiple < 40; ++multiple)
+    {
+      for (const auto offset: {NanoSecs {-1}, NanoSecs {0}, NanoSecs {1}})
+      {
+        const auto amount = period * multiple + offset;
+        EXPECT_EQ(cyclesToCover(amount, period), cyclesByWalking(amount, period))
+          << "period " << period.count() << ", amount " << amount.count();
+      }
+    }
+  }
+}
+
+/// @test
+/// The same, for the caller that has overslept. It asks about the time beyond one whole cycle, so
+/// the count has to match a walk that stops one cycle short of the one above.
+TEST(RunnerSchedule, CountsTheSameCyclesTheOversleepWalkDid)
+{
+  for (const auto period: {ms(1), ms(10), ms(100)})
+  {
+    for (int64_t multiple = 0; multiple < 40; ++multiple)
+    {
+      for (const auto offset: {NanoSecs {-1}, NanoSecs {0}, NanoSecs {1}})
+      {
+        const auto behind = period * multiple + offset;
+        EXPECT_EQ(cyclesToCover(behind - period, period), cyclesByWalkingAfterOversleep(behind, period))
+          << "period " << period.count() << ", behind " << behind.count();
+      }
+    }
+  }
+}
+
+/// @test
+/// Nothing to cover means no cycles, so an on-time frame does not move the schedule.
+TEST(RunnerSchedule, AdvancesNothingWhenTheScheduleIsNotBehind)
+{
+  EXPECT_EQ(cyclesToCover(NanoSecs {0}, ms(10)), 0);
+  EXPECT_EQ(cyclesToCover(NanoSecs {-1}, ms(10)), 0);
+  EXPECT_EQ(cyclesToCover(ms(-500), ms(10)), 0);
+}
+
+/// @test
+/// A period of zero cannot be divided by, and a schedule cannot advance in steps of nothing.
+TEST(RunnerSchedule, RefusesAPeriodOfZero)
+{
+  EXPECT_EQ(cyclesToCover(ms(10), NanoSecs {0}), 0);
+  EXPECT_EQ(cyclesToCover(ms(10), ms(-1)), 0);
+}
+
+/// @test
+/// The schedule lands past the instant it was catching up to, which is the property the caller
+/// relies on: one cycle short would leave the frame still behind.
+TEST(RunnerSchedule, LandsPastTheInstantItChases)
+{
+  const auto period = ms(10);
+  for (const auto behind: {NanoSecs {1}, ms(1), ms(10), ms(11), ms(999), ms(60000)})
+  {
+    const auto advanced = period * cyclesToCover(behind, period);
+    EXPECT_GE(advanced.count(), behind.count()) << "behind by " << behind.count();
+    EXPECT_LT((advanced - period).count(), behind.count()) << "overshot by more than a cycle";
+  }
+}
+
+/// @test
+/// A clock that jumps forward by years is arithmetic here, not iteration. The walk it replaces
+/// would have run for billions of iterations without reading the stop flag.
+TEST(RunnerSchedule, HandlesAJumpOfYearsWithoutIterating)
+{
+  const auto period = ms(10);  // 100 Hz
+  const auto decades = std::chrono::duration_cast<NanoSecs>(std::chrono::hours(24 * 365 * 20));
+
+  const auto cycles = cyclesToCover(decades, period);
+  EXPECT_EQ(cycles, decades.count() / period.count());
+  EXPECT_GT(cycles, 63000000000);
+}
+
+}  // namespace


### PR DESCRIPTION
A clock that jumps forward left the schedule walking to the new time one period at a time. The walk is as long as the jump — a jump of a day at 100 Hz is over eight million iterations — and it does not read the stop flag, so the kernel could not be stopped while it ran. The count is computed now and the schedule moves in one step.

A jump backward made the sleep until the next cycle arbitrarily long, and the sleeper issues it as a single call that does not read the stop flag either. What we ask for is now bounded to one cycle. That bounds the request rather than the sleep: where the high resolution clock is the system clock rather than the counter, a jump landing inside a sleep still holds it for the size of the jump.

The calibration instant is read from the same clock it schedules, so a backward jump put it beyond reach and stalled the drift correction until wall time caught up. It is pulled back when that happens.

**Not fixed here.** After a backward step the schedule stays ahead by the size of the step. Converging it means either weakening the responsiveness bound or running the component below its rate, and no convergence policy was invented.

Both replacements of a walk by a computed count were checked against the loops they replace over ten thousand cases — negative amounts, exact multiples, and one nanosecond either side — with no mismatch.
