### PR TITLE
fix(cli): join the signal thread before the kernel it watches is gone

### DIFF
--- a/apps/cli_run/main.cpp
+++ b/apps/cli_run/main.cpp
@@ -331,9 +331,6 @@ void SignalStopper::watch(sen::kernel::Kernel& kernel) noexcept
 {
   int exitCode = EXIT_FAILURE;
 
-  // Before anything that might start a thread: the mask is what every later thread inherits.
-  SignalStopper stopper;
-
   try
   {
     auto bootloader = makeBootloader(args, app);
@@ -343,6 +340,10 @@ void SignalStopper::watch(sen::kernel::Kernel& kernel) noexcept
       sen::kernel::Kernel::registerTerminationHandler();
     }
     sen::kernel::Kernel kernel(bootloader->getConfig());
+
+    // After the kernel, so it is destroyed before it: the watching thread holds a reference to the
+    // kernel and has to be joined while that reference is still good.
+    SignalStopper stopper;
 
     stopper.watch(kernel);
     if (stopper.signalled())


### PR DESCRIPTION
The signal stopper added in #193 was declared outside the `try` block while the kernel it watches was declared inside it. The kernel is therefore destroyed first, and the watching thread — which holds a reference to it and calls `requestStop` every 50ms — is only joined afterwards, when the stopper is destroyed at the end of the function.

So between the try block closing and `runKernel` returning, a live thread holds a reference to a destroyed `Kernel`.

It only bites once a signal has arrived: until then the thread is parked in `sigwait` rather than in that loop. Every supporting instance the integration runner stops gets a SIGTERM, so that is where it happens.

Declaring the stopper after the kernel, in the same scope, joins the thread while the reference is still good — objects in a scope are destroyed in reverse order of declaration.

Found by the address sanitizer in a local full-suite run, reported as `stack-use-after-scope` with frames in `askUntilItTakes`, the watching thread's lambda, and `runKernel`.
