### PR TITLE
fix(test): give every test its sanitizer options

### DIFF
--- a/cmake/util/sanitizer_default_options.cpp
+++ b/cmake/util/sanitizer_default_options.cpp
@@ -1,0 +1,27 @@
+// === sanitizer_default_options.cpp ===================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// The sanitizer runtimes call these at startup and take what they return as their defaults.
+// They exist because CMake's GoogleTestAddTests.cmake expands test properties unquoted, which
+// flattens a list-valued ENVIRONMENT and drops everything after its first entry. Compiled into
+// each binary, never offered from a library: the linker drops an unreferenced one silently.
+
+#if defined(SEN_ASAN_DEFAULT_OPTIONS)
+extern "C" const char* __asan_default_options() { return SEN_ASAN_DEFAULT_OPTIONS; }
+#endif
+
+#if defined(SEN_LSAN_DEFAULT_OPTIONS)
+extern "C" const char* __lsan_default_options() { return SEN_LSAN_DEFAULT_OPTIONS; }
+#endif
+
+#if defined(SEN_UBSAN_DEFAULT_OPTIONS)
+extern "C" const char* __ubsan_default_options() { return SEN_UBSAN_DEFAULT_OPTIONS; }
+#endif
+
+#if defined(SEN_TSAN_DEFAULT_OPTIONS)
+extern "C" const char* __tsan_default_options() { return SEN_TSAN_DEFAULT_OPTIONS; }
+#endif

--- a/cmake/util/test.cmake
+++ b/cmake/util/test.cmake
@@ -74,6 +74,43 @@ if(SEN_SANITIZER_LOG_DIR)
   set(SEN_SANITIZER_LOG_OPTION ":log_path=${SEN_SANITIZER_LOG_DIR}/report")
 endif()
 
+# Compiled into each test binary rather than passed as a test property; see
+# sanitizer_default_options.cpp for why, and why it cannot come from a library.
+add_library(sen_sanitizer_options INTERFACE)
+target_sources(sen_sanitizer_options INTERFACE ${CMAKE_CURRENT_LIST_DIR}/sanitizer_default_options.cpp)
+
+if(ASAN_SUPPRESSION_FILE)
+  target_compile_definitions(
+    sen_sanitizer_options
+    INTERFACE
+      SEN_ASAN_DEFAULT_OPTIONS="suppressions=${ASAN_SUPPRESSION_FILE}:fast_unwind_on_malloc=0:malloc_context_size=100${SEN_SANITIZER_LOG_OPTION}"
+  )
+endif()
+
+if(LSAN_SUPPRESSION_FILE)
+  target_compile_definitions(
+    sen_sanitizer_options
+    INTERFACE
+      SEN_LSAN_DEFAULT_OPTIONS="suppressions=${LSAN_SUPPRESSION_FILE}:report_objects=1${SEN_SANITIZER_LOG_OPTION}"
+  )
+endif()
+
+# Without print_stacktrace a finding is one line, often naming only a dependency.
+if(UBSAN_SUPPRESSION_FILE)
+  target_compile_definitions(
+    sen_sanitizer_options
+    INTERFACE
+      SEN_UBSAN_DEFAULT_OPTIONS="suppressions=${UBSAN_SUPPRESSION_FILE}:print_stacktrace=1${SEN_SANITIZER_LOG_OPTION}"
+  )
+endif()
+
+if(TSAN_SUPPRESSION_FILE)
+  target_compile_definitions(
+    sen_sanitizer_options
+    INTERFACE SEN_TSAN_DEFAULT_OPTIONS="suppressions=${TSAN_SUPPRESSION_FILE}${SEN_SANITIZER_LOG_OPTION}"
+  )
+endif()
+
 enable_testing()
 
 find_package(GTest QUIET)
@@ -159,6 +196,8 @@ function(add_sen_unit_test_suite test_name)
   if(TARGET sen_coverage_flags)
     target_link_libraries(${test_name} PRIVATE sen_coverage_flags)
   endif()
+
+  target_link_libraries(${test_name} PRIVATE sen_sanitizer_options)
 
   set(labels "unit")
   if(${_arg_FLAKY})
@@ -277,7 +316,9 @@ function(add_sen_integration_test test_name)
   endif()
 
   if(UBSAN_SUPPRESSION_FILE)
-    append_test_env_modification(${test_name} "UBSAN_OPTIONS=set:suppressions=${_ubsan_suppressions}")
+    append_test_env_modification(
+      ${test_name} "UBSAN_OPTIONS=set:suppressions=${_ubsan_suppressions}:print_stacktrace=1"
+    )
   endif()
 
   if(TSAN_SUPPRESSION_FILE)
@@ -401,7 +442,9 @@ function(add_sanitizer_options test_name)
   endif()
 
   if(UBSAN_SUPPRESSION_FILE)
-    append_test_env_modification(${test_name} "UBSAN_OPTIONS=set:suppressions=${UBSAN_SUPPRESSION_FILE}")
+    append_test_env_modification(
+      ${test_name} "UBSAN_OPTIONS=set:suppressions=${UBSAN_SUPPRESSION_FILE}:print_stacktrace=1"
+    )
   endif()
 
   if(TSAN_SUPPRESSION_FILE)


### PR DESCRIPTION
Of 1589 tests, 45 carried `ASAN_OPTIONS` and the rest none. A finding in the other 1544 aborted the
test but wrote no report: without a log path the runtime writes to stderr, and the summary reads
files.

The cause is CMake's `GoogleTestAddTests.cmake`, which expands the test properties unquoted. That
flattens a list-valued `ENVIRONMENT` and keeps only its first entry, so a discovered test never
receives a second variable. Escaping cannot survive it and CMake 4.1 does the same. The options are
compiled into the binaries instead, where the runtimes ask for them at startup. Each binary compiles
its own: offered from a library the linker drops them as unreferenced, and every binary then runs
with no options at all.

Undefined-behaviour findings also asked for no stack trace, so each named a line, often in a
dependency, with nothing about how our code reached it. They now carry frames.

An environment variable still overrides all of it, so the tests that set their own paths are
unchanged.

Checked locally in both directions: clang with the address sanitizer, where the symbols are present
and the suite is 1590 of 1590; and gcc without, where the file compiles to an empty object,
contributes no symbols, and the suite is 1597 of 1597.
