### PR TITLE
fix(gen): declare imports in the generated config schema

### DIFF
--- a/apps/cli_gen/src/json/templates/config_schema.j2
+++ b/apps/cli_gen/src/json/templates/config_schema.j2
@@ -52,12 +52,20 @@
         "description": "A component you wish Sen to build",
         "type": "object",
         "allOf": [ { "$ref": "#/$defs/sen.kernel.ComponentConfig" } ],
-        "required": [ "name" ],
+        "required": [ "name", "imports" ],
         "properties": {
           "name": {
             "description": "Name of the component",
             "type": "string",
             "minLength": 1
+          },
+          "imports": {
+            "description": "The packages this component imports",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
           },
           "freqHz": {
             "description": "Cycle frequency in Hertz",


### PR DESCRIPTION
`imports` is required in a `build:` entry — `bootloader.cpp:562` throws `missing imports` without it — but the generated JSON Schema never declared the key. It appears nowhere in `config_schema.j2`, and `ComponentConfig`, which the item references through `allOf`, has no such field either.

So a config could validate against the shipped schema and still be rejected at load. An author working from the schema got no completion for the key and no validation error when they omitted it; the requirement surfaced only at runtime.

Same class as #163, one field over: that reconciled `freqHz` and `bus` and missed this one.

**Nothing that validates today stops validating.** All 80 configs in the tree with a `build:` block already declare `imports`, `config_yaml.j2` emits it for scaffolded packages, and the schema sets no `additionalProperties: false`.

Verified by generating the schema and validating against it: a `build` entry with `imports` is accepted, one without is rejected with `'imports' is a required property`.

**The kernel side is deliberately untouched.** Relaxing it so a pipeline without `imports` imports nothing was tried and reverted before merge on 2026-08-28: the relaxation's justification was that it made a test pass, and that test was passing on the wrong error either way.
