### PR TITLE
ci: say what failed in the nightly's tracking issue

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -475,18 +475,48 @@ jobs:
     if: failure() || cancelled()
     permissions:
       issues: write
+      actions: read
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      # The comment carried a bare link, so learning what failed meant opening the run,
+      # picking the job and reading a log. Five nights of findings went unread that way.
+      - name: Collect the sanitizer reports the lanes archived
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: sanitizer-reports-*
+          path: collected-reports
+
       - name: Update the nightly tracking issue
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO: ${{ github.repository }}
         run: |
           title="Nightly lane failure"
-          body="Failed run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          number=$(gh issue list --repo "${{ github.repository }}" --state open \
+          {
+            echo "Failed run: $RUN_URL"
+            echo
+            echo "**Jobs that failed:**"
+            gh run view "${{ github.run_id }}" --repo "$REPO" --json jobs \
+                --jq '.jobs[] | select(.conclusion == "failure") | "- \(.name)"' \
+              || echo "- (could not be read)"
+            for dir in collected-reports/sanitizer-reports-*; do
+              [ -d "$dir" ] || continue
+              echo
+              echo "**${dir##*sanitizer-reports-}:**"
+              echo
+              python3 .github/scripts/summarise_sanitizer_reports.py "$dir" \
+                || echo "(the summary could not be produced)"
+            done
+          } > comment.md
+          number=$(gh issue list --repo "$REPO" --state open \
               --search "in:title \"$title\"" --json number --jq '.[0].number')
           if [ -n "$number" ]; then
-              gh issue comment "$number" --repo "${{ github.repository }}" --body "$body"
+              gh issue comment "$number" --repo "$REPO" --body-file comment.md
           else
-              gh issue create --repo "${{ github.repository }}" --title "$title" --body "$body"
+              gh issue create --repo "$REPO" --title "$title" --body-file comment.md
           fi


### PR DESCRIPTION
The comment carried one line — a link to the run. Learning what had failed meant opening it, picking
the right job out of a dozen and reading a log, so nobody did.

Issue #118 has ten such comments. The nightly has failed five nights running, and over that period
the TSan lane went from "No sanitizer reports were produced in this run" to 41 findings in nine
distinct families, with two tests failing. Nothing said so.

The comment now names the jobs that failed and carries the sanitizer summary for each lane that
archived reports. The summariser already produces that table; it was only ever written to a log and
a step summary that the link pointed near, rather than at.

A nightly that fails with no sanitizer reports — docs, packaging — still comments, with the link and
the job names. The artifact download is `continue-on-error` for that reason.

Checked locally in both directions: with an archived report the comment carries the findings table
per lane; with none it degrades to the link plus the job names, exit 0 either way. The wiring itself
cannot be exercised until a nightly fails.
