### PR TITLE
docs: mark the source sections the documentation pulls in

### DIFF
--- a/components/logmaster/src/component.cpp
+++ b/components/logmaster/src/component.cpp
@@ -40,6 +40,7 @@ constexpr auto defaultPeriod = std::chrono::milliseconds(500);
 // LogMasterComponent
 //--------------------------------------------------------------------------------------------------------------
 
+// --8<-- [start:component]
 struct LogMasterComponent final: ::sen::kernel::Component
 {
   [[nodiscard]] ::sen::kernel::FuncResult run(::sen::kernel::RunApi& api) override
@@ -65,6 +66,7 @@ struct LogMasterComponent final: ::sen::kernel::Component
 
   [[nodiscard]] bool isRealTimeOnly() const noexcept override { return true; }
 };
+// --8<-- [end:component]
 
 }  // namespace sen::components::logmaster
 

--- a/components/shell/stl/shell.stl
+++ b/components/shell/stl/shell.stl
@@ -1,5 +1,6 @@
 package sen.components.shell;
 
+// --8<-- [start:config]
 // How lists should be printed
 enum ListStyle: u8
 {
@@ -44,6 +45,7 @@ struct Configuration
   query         : QueryList,    // list of queries to create automatically
   logBus        : string        // where to find the logmaster, if any (default: local.log)
 }
+// --8<-- [end:config]
 
 // Provides a text-based interface to interact with the a sen kernel
 class Shell
@@ -51,6 +53,7 @@ class Shell
   // service configuration
   var config: Configuration [static];
 
+  // --8<-- [start:commands]
   // clears the screen
   fn clear() [const];
 
@@ -80,4 +83,5 @@ class Shell
 
   // lists the current sources
   fn src();
+  // --8<-- [end:commands]
 }

--- a/components/tracy/src/component.cpp
+++ b/components/tracy/src/component.cpp
@@ -98,6 +98,7 @@ private:
 // TracyComponent
 //--------------------------------------------------------------------------------------------------------------
 
+// --8<-- [start:component]
 struct TracyComponent final: ::sen::kernel::Component
 {
   [[nodiscard]] ::sen::kernel::FuncResult preload(::sen::kernel::PreloadApi&& api) override
@@ -118,3 +119,4 @@ struct TracyComponent final: ::sen::kernel::Component
 };
 
 SEN_COMPONENT(TracyComponent)
+// --8<-- [end:component]

--- a/libs/kernel/include/sen/kernel/component.h
+++ b/libs/kernel/include/sen/kernel/component.h
@@ -39,6 +39,7 @@ public:  // special members
   virtual ~Component() = default;
 
 public:
+  // --8<-- [start:hooks]
   /// Preload the component and initialize all self-contained resources.
   /// This function is just called once.
   virtual FuncResult preload(PreloadApi&& /* api */) { return Ok(); }
@@ -69,6 +70,7 @@ public:
 
   /// Return true here if your component is not designed to work with virtualized time.
   [[nodiscard]] virtual bool isRealTimeOnly() const noexcept { return false; }
+  // --8<-- [end:hooks]
 
 protected:  // helpers
   /// Convenience function to return an operation delay request.

--- a/libs/kernel/stl/sen/kernel/basic_types.stl
+++ b/libs/kernel/stl/sen/kernel/basic_types.stl
@@ -39,6 +39,7 @@ enum GitStatus: u8
 }
 
 // Build-related information
+// --8<-- [start:build_info]
 struct BuildInfo
 {
   maintainer : string,    // principal maintainer of the software
@@ -51,6 +52,7 @@ struct BuildInfo
   gitHash    : string,    // git hash
   gitStatus  : GitStatus  // git status
 }
+// --8<-- [end:build_info]
 
 // Basic information of a kernel component
 struct ComponentInfo
@@ -60,6 +62,7 @@ struct ComponentInfo
   buildInfo   : BuildInfo
 }
 
+// --8<-- [start:queue_config]
 // Component queue eviction policy
 enum QueueEvictionPolicy: u32
 {
@@ -72,7 +75,9 @@ struct QueueConfig
   evictionPolicy : QueueEvictionPolicy,  // what to do when the queue is full
   maxSize        : u64                   // 0 means unbounded
 }
+// --8<-- [end:queue_config]
 
+// --8<-- [start:sleep_policy]
 // Use the native system sleep
 struct SystemSleep;
 
@@ -89,6 +94,7 @@ variant SleepPolicy
   PrecisionSleep,
   SystemSleep
 }
+// --8<-- [end:sleep_policy]
 
 // What to do when a type published by another kernel does not match the local one
 enum CompatibilityMode: u8
@@ -99,6 +105,7 @@ enum CompatibilityMode: u8
 }
 
 // Basic runtime configuration for a component
+// --8<-- [start:component_config]
 struct ComponentConfig
 {
   priority    : Priority,     // thread priority
@@ -109,6 +116,7 @@ struct ComponentConfig
   outQueue    : QueueConfig,  // queuing of outbound information
   sleepPolicy : SleepPolicy   // configurable component sleep policy
 }
+// --8<-- [end:component_config]
 
 // Category of a problem during component execution
 enum ErrorCategory: u8
@@ -163,6 +171,7 @@ enum ComponentState: u8
 sequence<string> StringList;
 
 // Run modes for the kernel
+// --8<-- [start:run_mode]
 enum RunMode: u8
 {
   realTime,           // components execute using system time
@@ -170,8 +179,10 @@ enum RunMode: u8
   virtualTimeRunning, // same as virtualTime, but continuously advancing the time
   startAndStop,       // starts and stops (useful for smoke tests)
 }
+// --8<-- [end:run_mode]
 
 // Parameters to configure kernel execution
+// --8<-- [start:kernel_params]
 struct KernelParams
 {
   runMode             : RunMode,                // how to run the kernel
@@ -187,6 +198,7 @@ struct KernelParams
   sleepPolicy         : SleepPolicy,            // configurable sleep policy of the kernel component
   compatibilityMode   : CompatibilityMode       // what to do with a remote type that does not match
 }
+// --8<-- [end:kernel_params]
 
 // Type of operating system
 enum OsKind : u8

--- a/libs/kernel/stl/sen/kernel/kernel_objects.stl
+++ b/libs/kernel/stl/sen/kernel/kernel_objects.stl
@@ -128,6 +128,7 @@ class KernelApi
   fn getConfig() -> KernelParams [const];
 }
 
+// --8<-- [start:clocks]
 // Allows inspecting and controlling the advance of virtual time and associated component iteration
 class VirtualClock
 {
@@ -160,3 +161,4 @@ class VirtualMasterClock: extends VirtualClock
   // perform 'count' steps forward, based on delta
   fn steps(count: u64) -> Duration [bestEffort];
 }
+// --8<-- [end:clocks]

--- a/libs/kernel/stl/sen/kernel/type_specs.stl
+++ b/libs/kernel/stl/sen/kernel/type_specs.stl
@@ -487,6 +487,7 @@ struct ClassTypeSpecV4
 }
 
 // all custom types
+// --8<-- [start:custom_type_data]
 variant CustomTypeData
 {
   EnumTypeSpec,
@@ -498,6 +499,7 @@ variant CustomTypeData
   OptionalTypeSpec,
   ClassTypeSpec
 }
+// --8<-- [end:custom_type_data]
 
 variant CustomTypeDataV5
 {

--- a/libs/kernel/test/unit/test_kernel/test_kernel_test.cpp
+++ b/libs/kernel/test/unit/test_kernel/test_kernel_test.cpp
@@ -59,6 +59,7 @@ TEST(TestKernel, emptyConfig) { EXPECT_NO_THROW(auto kernel = sen::kernel::TestK
 /// @requirements(SEN-363)
 TEST(TestKernel, oneComponent)
 {
+  // --8<-- [start:setup]
   // to track the evolution of the test
   int32_t counter = 0;
   int32_t eventCount = 0;
@@ -107,6 +108,7 @@ TEST(TestKernel, oneComponent)
 
   // create the kernel holding only our simple component
   sen::kernel::TestKernel kernel(&component);
+  // --8<-- [end:setup]
 
   // iteration 0, time is 0
   emitEvent = false;
@@ -119,6 +121,7 @@ TEST(TestKernel, oneComponent)
   EXPECT_EQ(std::chrono::seconds(0), lastTime.sinceEpoch().toChrono());
   EXPECT_EQ(std::chrono::seconds(1), kernel.getTime().sinceEpoch().toChrono());
 
+  // --8<-- [start:delay]
   // iteration 1, sim time was 1s, we have executed 2s, we emit the event
   emitEvent = true;
   emitProp = true;
@@ -140,6 +143,7 @@ TEST(TestKernel, oneComponent)
   EXPECT_EQ(1, propCount);
   EXPECT_EQ(std::chrono::seconds(2), lastTime.sinceEpoch().toChrono());
   EXPECT_EQ(std::chrono::seconds(3), kernel.getTime().sinceEpoch().toChrono());
+  // --8<-- [end:delay]
 
   for (std::size_t i = counter; i < 10; ++i)
   {

--- a/libs/util/include/sen/util/dr/algorithms.h
+++ b/libs/util/include/sen/util/dr/algorithms.h
@@ -53,6 +53,9 @@ SEN_NON_RANGED_QUANTITY(TimeSeconds, f64)
 /// Non-dimensional damping coefficient
 SEN_NON_RANGED_QUANTITY(DampingCoefficient, f64)
 
+// The structs below are also tabulated in docs/users_guide/util_library.md, with their
+// units and frames spelled out for readers who do not read C++. Update both together.
+// --8<-- [start:dr_config]
 /// Dead Reckoning configuration.
 struct DrConfig
 {
@@ -81,6 +84,7 @@ struct DrConfig
   /// Damping coefficient for the smoothed orientation solution.
   DampingCoefficient orientationDamping = 20.0;
 };
+// --8<-- [end:dr_config]
 
 /// World Location struct
 struct Location
@@ -138,6 +142,7 @@ struct AngularAcceleration
   AngularAccelerationRadiansPerSecondSquared z;
 };
 
+// --8<-- [start:situation]
 /// Situation structure with the following parameters:
 struct Situation
 {
@@ -167,7 +172,9 @@ struct Situation
   /// Angular acceleration vector with respect to body reference system.
   AngularAcceleration angularAcceleration {};
 };
+// --8<-- [end:situation]
 
+// --8<-- [start:geodetic_situation]
 /// GeodeticSituation structure with the following parameters:
 struct GeodeticSituation
 {
@@ -196,6 +203,7 @@ struct GeodeticSituation
   /// Angular acceleration vector with respect to body-reference system.
   AngularAcceleration angularAcceleration {};
 };
+// --8<-- [end:geodetic_situation]
 
 /// Enumeration of the different Spatial algorithms
 enum class SpatialAlgorithm

--- a/libs/util/include/sen/util/dr/dead_reckoner.h
+++ b/libs/util/include/sen/util/dr/dead_reckoner.h
@@ -26,6 +26,7 @@ namespace sen::util
 /// Enables the user to predict an object’s position and movement at any future time applying dead
 /// reckoning. It adheres to the algorithms specified in IEEE 1278_1:2012, Annex E.
 /// @tparam T rpr::BaseEntityInterface or a subclass of it
+// --8<-- [start:dead_reckoner]
 template <typename T>
 class DeadReckoner: public DeadReckonerTemplateBase<T>
 {
@@ -91,6 +92,7 @@ private:
   sen::TimeStamp lastTimeStamp_;
   SpatialVariant lastSpatial_;
 };
+// --8<-- [end:dead_reckoner]
 
 /// @}
 

--- a/libs/util/include/sen/util/dr/detail/dead_reckoner_base.h
+++ b/libs/util/include/sen/util/dr/detail/dead_reckoner_base.h
@@ -19,6 +19,7 @@ namespace sen::util
 /// \addtogroup dr
 /// @{
 
+// --8<-- [start:dead_reckoner_base]
 /// Extrapolates the Situation of an entity at a certain time. The extrapolation is smoothed by
 /// default unless the user specifies otherwise.
 class DeadReckonerBase
@@ -91,6 +92,7 @@ private:
   Situation cachedSituation_;
   GeodeticSituation cachedGeodeticSituation_;
 };
+// --8<-- [end:dead_reckoner_base]
 
 /// Base class for the DeadReckoner and SettableDeadReckoner classes.
 template <typename T>


### PR DESCRIPTION
Eight documentation pages transclude regions of real source, so a page shows code the compiler checks rather than a copy that drifts. The comment pairs naming those regions were only ever added on the documentation branch, so on main the pages point at sections that do not exist.

The failure mode is worth knowing: a check that the transclusion target exists **passes**, because the file does exist — only the section inside it is missing. mkdocs then fails at build time or renders an empty block, and nothing catches it earlier.

Comments only. Eleven files, forty-two lines, no deletions and no code changes. Twenty sections, each a matched start/end pair.

One hunk adds more than a marker: `algorithms.h` gains two lines recording that the structs below are also tabulated in `docs/users_guide/util_library.md` and that both should be updated together. That is a maintenance contract rather than decoration.

`settable_dead_reckoner.h` already carries its marker — it rode along with #144 — so this completes the set rather than starting it.
