### PR TITLE
docs: mark the subscribe section query_test's page pulls in

### DIFF
--- a/test/util/query_test/src/component.cpp
+++ b/test/util/query_test/src/component.cpp
@@ -51,6 +51,7 @@ public:
     obj_ = std::make_shared<query_test::QueryTestClassImpl>("object1", sen::VarMap {});
     obj_->setNextCurrentStatus(query_test::Status::idle);
 
+    // --8<-- [start:subscribe]
     const auto bus = api.getSource("se.env");
     bus->add(obj_);
 
@@ -59,6 +60,7 @@ public:
     const auto enumInterest = sen::Interest::make(
       R"(SELECT query_test.QueryTestClass FROM se.env WHERE currentStatus = "error")", api.getTypes());
     bus->addSubscriber(enumInterest, &enumList_, true);
+    // --8<-- [end:subscribe]
 
     return api.execLoop(sen::Duration::fromHertz(100.0),
                         [this, &api]


### PR DESCRIPTION
`docs/howto_guides/objects.md:346` transcludes eight lines of this test. The comment pair naming that section was only ever added on the documentation branch, so on main the page pointed at a section that does not exist — and a check that the target file exists passes, because it does.

Two comment lines. No code changes.

**What is deliberately not here.** The documentation branch also rewrote this test: it renamed two members, replaced a `tick_ == 2` assertion with a match-count condition, raised a timeout from 10 ticks to 200, and changed a failure message. None of that is inside the marked region, so none of it reaches the page — the snippet renders correct, compiling, current code either way.

That rewrite includes what looks like a real fix: asserting a subscription callback has fired by tick 2 is twenty milliseconds at 100Hz, which is a race. It is worth taking on its own merits, reviewed as a test change rather than as documentation riding along.
