### PR TITLE
fix(cli_package): generated projects looked for a variable nothing sets

### DIFF
--- a/apps/cli_package/templates/package/cmakelists_txt.j2
+++ b/apps/cli_package/templates/package/cmakelists_txt.j2
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 project({{ package_name }}_project VERSION 0.0.1 LANGUAGES CXX C)
 
-if(DEFINED ENV{SEN_PATH})
-   list(APPEND CMAKE_PREFIX_PATH "$ENV{SEN_PATH}/cmake")
+if(DEFINED ENV{SEN_PREFIX})
+   list(APPEND CMAKE_PREFIX_PATH "$ENV{SEN_PREFIX}/cmake")
 endif()
 
 find_package(sen REQUIRED)

--- a/docs/getting_started/first_package.md
+++ b/docs/getting_started/first_package.md
@@ -34,8 +34,8 @@ Let's inspect the contents of the newly-created folder:
 ```{ .cmake .annotate }
 project(my_package_project VERSION 0.0.1 LANGUAGES CXX C)
 
-if(DEFINED ENV{SEN_PATH}) # (1)!
-   list(APPEND CMAKE_PREFIX_PATH "$ENV{SEN_PATH}/cmake") # (2)!
+if(DEFINED ENV{SEN_PREFIX}) # (1)!
+   list(APPEND CMAKE_PREFIX_PATH "$ENV{SEN_PREFIX}/cmake") # (2)!
 endif()
 
 find_package(sen REQUIRED)
@@ -54,7 +54,7 @@ add_sen_package( # (3)!
 )
 ```
 
-1. The `SEN_PATH` environment variable gets defined by our setup script.
+1. The `SEN_PREFIX` environment variable is exported by the installer's activate script.
 2. This enables CMake to find the Sen package below.
 3. This function becomes automatically accessible once Sen is found.
 4. Not mandatory, but helpful if redistributing the package.


### PR DESCRIPTION
The CMakeLists every generated project gets guards on `ENV{SEN_PATH}`. Nothing sets that variable — the installer's activate script exports `SEN_PREFIX`, and `SEN_PATH` appears nowhere in the repository except as something read. So the guard is never true, `CMAKE_PREFIX_PATH` never gets Sen's cmake directory, and `find_package(sen)` fails in a project straight out of `sen package init`.

`first_package.md` walks through the same block, so the page moves with the template.

Verified end to end rather than by reading: installed Sen to a prefix, ran `sen package init`, and configured the generated project with only `SEN_PREFIX` set — which is the state the installer leaves a user in. It configures.
