### PR TITLE
fix(examples): point the schema glob at the schemas that exist

### DIFF
--- a/examples/packages/CMakeLists.txt
+++ b/examples/packages/CMakeLists.txt
@@ -41,7 +41,7 @@ if(NOT
 )
 
   # add the sen schemas
-  file(GLOB sen_schemas ${SEN_PATH}/schemas/*.json)
+  file(GLOB sen_schemas ${PROJECT_SOURCE_DIR}/schemas/*.json)
   list(APPEND schema_files ${sen_schemas})
 
   # assemble the final schema


### PR DESCRIPTION
`examples/packages/CMakeLists.txt` globbed `${SEN_PATH}/schemas/*.json`. Nothing sets `SEN_PATH` — it is a CMake variable, not the environment one, and after #208 it is the last mention of that name in the tree. So it expanded to `/schemas/*.json`, matched nothing, and `file(GLOB)` succeeded quietly. The configure stayed green and the combined schema was assembled without Sen's own definitions.

Every example yaml carries `# $schema: ../base/schema.json`, and `docs/users_guide/configuration.md` documents that mechanism to users, so the promise was editor validation the build half-delivered.

Measured by regenerating the schema with and without the change: `$defs` goes from **1052 to 1153**, gaining 101 definitions from `fom`, `sen` and `stress_testing_utils`.

The schemas are generated into `${PROJECT_SOURCE_DIR}/schemas` at build time by `sen_package_utils.cmake:153` and gitignored, which is why that is the right path and why the directory is not in the repository.

Two things still hide problems here and are left alone: `file(GLOB)` reports nothing when it matches nothing, and the whole block sits inside a guard that skips it entirely on Makefile generators.
