### PR TITLE
fix(core): refuse a circular type reference instead of crashing

### DIFF
--- a/apps/cli_gen/test/CMakeLists.txt
+++ b/apps/cli_gen/test/CMakeLists.txt
@@ -344,3 +344,36 @@ add_sen_cli_gen_smoke_test(
   COMMAND ./cli_gen --expect-failure cpp fom --directories=${hla_fom_gen_test_sources}/test24/fom
   WORKING_DIRECTORY ${working_dir}
 )
+
+# Test case 25
+#
+# Two fixed records whose fields name each other.
+#
+# Expected result: failure
+add_sen_cli_gen_smoke_test(
+  hla_fom_gen_smoke_25
+  COMMAND ./cli_gen --expect-failure cpp fom --directories=${hla_fom_gen_test_sources}/test25/fom
+  WORKING_DIRECTORY ${working_dir}
+)
+
+# Test case 26
+#
+# An array whose element type is itself.
+#
+# Expected result: failure
+add_sen_cli_gen_smoke_test(
+  hla_fom_gen_smoke_26
+  COMMAND ./cli_gen --expect-failure cpp fom --directories=${hla_fom_gen_test_sources}/test26/fom
+  WORKING_DIRECTORY ${working_dir}
+)
+
+# Test case 27
+#
+# Two fixed records that include each other.
+#
+# Expected result: failure
+add_sen_cli_gen_smoke_test(
+  hla_fom_gen_smoke_27
+  COMMAND ./cli_gen --expect-failure cpp fom --directories=${hla_fom_gen_test_sources}/test27/fom
+  WORKING_DIRECTORY ${working_dir}
+)

--- a/apps/cli_gen/test/test25/fom/module-A.xml
+++ b/apps/cli_gen/test/test25/fom/module-A.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<objectModel
+        xsi:schemaLocation="http://standards.ieee.org/IEEE1516-2010 http://standards.ieee.org/downloads/1516/1516.2-2010/IEEE1516-DIF-2010.xsd"
+        xmlns="http://standards.ieee.org/IEEE1516-2010" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelIdentification>
+        <name>module-A</name>
+        <type>FOM</type>
+        <version>1.0</version>
+        <securityClassification>unclassified</securityClassification>
+        <purpose/>
+        <applicationDomain/>
+        <description>Two records whose fields refer to each other</description>
+        <useLimitation/>
+        <other/>
+    </modelIdentification>
+    <objects/>
+    <interactions/>
+    <dataTypes>
+        <simpleDataTypes>
+            <simpleData>
+                <name>TestInt</name>
+                <representation>HLAinteger32BE</representation>
+                <units>NA</units>
+                <resolution/>
+                <accuracy/>
+                <semantics/>
+            </simpleData>
+        </simpleDataTypes>
+        <enumeratedDataTypes/>
+        <arrayDataTypes/>
+        <fixedRecordDataTypes>
+            <fixedRecordData>
+                <name>BaseRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>The record whose fields are included by another.</semantics>
+                <field>
+                    <name>Inherited</name>
+                    <dataType>DerivedRecord</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>DerivedRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                                <semantics>Brings in the fields of BaseRecord and adds one of its own.</semantics>
+                <field>
+                    <name>Own</name>
+                    <dataType>BaseRecord</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+        </fixedRecordDataTypes>
+        <variantRecordDataTypes/>
+    </dataTypes>
+    <notes/>
+</objectModel>

--- a/apps/cli_gen/test/test26/fom/module-A.xml
+++ b/apps/cli_gen/test/test26/fom/module-A.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<objectModel
+        xsi:schemaLocation="http://standards.ieee.org/IEEE1516-2010 http://standards.ieee.org/downloads/1516/1516.2-2010/IEEE1516-DIF-2010.xsd"
+        xmlns="http://standards.ieee.org/IEEE1516-2010" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelIdentification>
+        <name>module-A</name>
+        <type>FOM</type>
+        <version>1.0</version>
+        <securityClassification>unclassified</securityClassification>
+        <purpose/>
+        <applicationDomain/>
+        <description>An array whose element type is itself</description>
+        <useLimitation/>
+        <other/>
+    </modelIdentification>
+    <objects/>
+    <interactions/>
+    <dataTypes>
+        <simpleDataTypes>
+            <simpleData>
+                <name>TestInt</name>
+                <representation>HLAinteger32BE</representation>
+                <units>NA</units>
+                <resolution/>
+                <accuracy/>
+                <semantics/>
+            </simpleData>
+        </simpleDataTypes>
+        <enumeratedDataTypes/>
+        <arrayDataTypes>
+            <arrayData>
+                <name>SelfArray</name>
+                <dataType>SelfArray</dataType>
+                <cardinality>Dynamic</cardinality>
+                <encoding>HLAvariableArray</encoding>
+                <semantics/>
+            </arrayData>
+        </arrayDataTypes>
+        <fixedRecordDataTypes>
+            <fixedRecordData>
+                <name>BaseRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>The record whose fields are included by another.</semantics>
+                <field>
+                    <name>Inherited</name>
+                    <dataType>TestInt</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>DerivedRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                                <semantics>Brings in the fields of BaseRecord and adds one of its own.</semantics>
+                <field>
+                    <name>Own</name>
+                    <dataType>TestInt</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+        </fixedRecordDataTypes>
+        <variantRecordDataTypes/>
+    </dataTypes>
+    <notes/>
+</objectModel>

--- a/apps/cli_gen/test/test27/fom/module-A.xml
+++ b/apps/cli_gen/test/test27/fom/module-A.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<objectModel
+        xsi:schemaLocation="http://standards.ieee.org/IEEE1516-2010 http://standards.ieee.org/downloads/1516/1516.2-2010/IEEE1516-DIF-2010.xsd"
+        xmlns="http://standards.ieee.org/IEEE1516-2010" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelIdentification>
+        <name>module-A</name>
+        <type>FOM</type>
+        <version>1.0</version>
+        <securityClassification>unclassified</securityClassification>
+        <purpose/>
+        <applicationDomain/>
+        <description>Two records that include each other</description>
+        <useLimitation/>
+        <other/>
+    </modelIdentification>
+    <objects/>
+    <interactions/>
+    <dataTypes>
+        <simpleDataTypes>
+            <simpleData>
+                <name>TestInt</name>
+                <representation>HLAinteger32BE</representation>
+                <units>NA</units>
+                <resolution/>
+                <accuracy/>
+                <semantics/>
+            </simpleData>
+        </simpleDataTypes>
+        <enumeratedDataTypes/>
+        <arrayDataTypes/>
+        <fixedRecordDataTypes>
+            <fixedRecordData>
+                <name>BaseRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                <include>DerivedRecord</include>
+                <semantics>The record whose fields are included by another.</semantics>
+                <field>
+                    <name>Inherited</name>
+                    <dataType>TestInt</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>DerivedRecord</name>
+                <encoding>HLAfixedRecord</encoding>
+                <include>BaseRecord</include>
+                <semantics>Brings in the fields of BaseRecord and adds one of its own.</semantics>
+                <field>
+                    <name>Own</name>
+                    <dataType>TestInt</dataType>
+                    <semantics/>
+                </field>
+            </fixedRecordData>
+        </fixedRecordDataTypes>
+        <variantRecordDataTypes/>
+    </dataTypes>
+    <notes/>
+</objectModel>

--- a/libs/core/src/lang/fom_document_set.cpp
+++ b/libs/core/src/lang/fom_document_set.cpp
@@ -9,6 +9,7 @@
 
 // sen
 #include "sen/core/base/assert.h"
+#include "sen/core/base/scope_guard.h"
 #include "sen/core/io/util.h"
 #include "sen/core/lang/stl_resolver.h"
 #include "sen/core/lang/string_utils.h"
@@ -898,6 +899,22 @@ std::pair<ConstTypeHandle<>, ParsedDoc*> FomDocumentSet::getOrCreateTypeFromFomN
     return std::move(lookup).value();
   }
 
+  // A type that names itself, directly or through a chain of other types, would otherwise be
+  // resolved over and over until the stack runs out. The document is part of the key because
+  // resolving the same name in a dependency is how the search below descends.
+  const auto beingResolved = std::make_pair(fomName, static_cast<const ParsedDoc*>(result));
+  if (std::find(typesBeingResolved_.begin(), typesBeingResolved_.end(), beingResolved) != typesBeingResolved_.end())
+  {
+    std::string err;
+    err.append("circular reference while resolving type '");
+    err.append(fomName);
+    err.append("'");
+    throwRuntimeError(err);
+  }
+
+  typesBeingResolved_.push_back(beingResolved);
+  const auto resolved = makeScopeGuard([this]() { typesBeingResolved_.pop_back(); });
+
   // not parsed yet, has to be somewhere in this document
   using Func = std::function<ConstTypeHandle<>(const pugi::xpath_node&)>;
   using Check = std::pair<std::string, Func>;
@@ -1091,15 +1108,6 @@ ConstTypeHandle<> FomDocumentSet::recordType(const pugi::xpath_node& node, Parse
       err.append("record '");
       err.append(name);
       err.append("' includes more than one record, which sen cannot represent: a struct has a single parent");
-      throwRuntimeError(err);
-    }
-
-    if (includedName == name)
-    {
-      std::string err;
-      err.append("record '");
-      err.append(name);
-      err.append("' includes itself");
       throwRuntimeError(err);
     }
 

--- a/libs/core/src/lang/fom_document_set.h
+++ b/libs/core/src/lang/fom_document_set.h
@@ -184,6 +184,7 @@ private:
   std::unique_ptr<lang::TypeSet> rootTypeSet_;
   std::optional<TypeHandle<ClassType>> rootClass_;
   TypeSettings settings_;
+  std::vector<std::pair<std::string, const ParsedDoc*>> typesBeingResolved_;  ///< guards circular references
 };
 
 }  // namespace sen::lang


### PR DESCRIPTION
A FOM type naming itself, directly or through a chain of other types, resolved over and over until the stack ran out. Records, arrays and inclusions all reached it.

Resolution now tracks what it is in the middle of resolving and refuses a cycle with a diagnostic. The document is part of the key, because resolving the same name in a dependency is how the search descends.

This subsumes and removes the narrower self-inclusion check added by #187, which has merged.
