### PR TITLE
docs: give the readme badges working links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ and rich communication.</h4>
 
 <div align="center">
 
-<a href="">![License](https://img.shields.io/badge/License-Apache%202.0-blue)</a>
-<a href="">![C++](https://img.shields.io/badge/C%2B%2B-17-blue?logo=c%2B%2B)</a>
-<a href="">[![Documentation](https://github.com/airbus/sen/actions/workflows/build_docs.yaml/badge.svg)](https://github.com/airbus/sen/actions/workflows/build_docs.yaml)</a>
+[![Documentation](https://github.com/airbus/sen/actions/workflows/build_docs.yaml/badge.svg?branch=main)](https://github.com/airbus/sen/actions/workflows/build_docs.yaml?query=branch%3Amain)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue)](LICENSE.txt)
+[![C++](https://img.shields.io/badge/C%2B%2B-17-blue?logo=c%2B%2B)](https://en.cppreference.com/w/cpp/17)
 
 </div>
 


### PR DESCRIPTION
All three README badges were wrapped in `<a href="">`. So the License and C++ badges linked nowhere, and the Documentation badge nested a real link inside the empty one.

They now link where they should: the licence file, the C++17 reference, and the documentation workflow's runs.

The documentation badge also names the branch, so it reports `main` rather than whichever branch ran most recently.

**No CI badge here, deliberately.** `main.yaml` renders as failing today: GitHub shows the last *completed* run, and that one was cancelled when two merges landed three minutes apart. Over the last thirty runs on main there were 24 successes, 3 failures and 2 cancellations, so a CI badge would show red for cancellations as well as failures. Worth adding once merges are spaced enough for runs to finish.
