### PR TITLE
fix(examples): take the timer's elapsed time from the clock

### DIFF
--- a/examples/packages/timer/src/timer.cpp
+++ b/examples/packages/timer/src/timer.cpp
@@ -15,6 +15,7 @@
 
 // std
 #include <iostream>
+#include <optional>
 
 namespace timer
 {
@@ -33,9 +34,21 @@ public:
 public:
   void update(sen::kernel::RunApi& runApi) override
   {
+    // --8<-- [start:elapsed]
+    // Elapsed time comes from the clock, not from the configured period: a skipped cycle covers two
+    // periods, and a component that is stepped rather than cycled has no period at all.
+    // The first cycle has nothing to difference against, so it contributes nothing rather than the
+    // whole interval since the kernel started.
+    const auto now = runApi.getTime();
+    const auto elapsedTime = now - lastUpdate_.value_or(now);
+
+    // Advanced on every cycle, including while the timer is off, so switching it on does not
+    // subtract the whole interval it spent paused.
+    lastUpdate_ = now;
+    // --8<-- [end:elapsed]
+
     if (const auto countdown = getCountdown(); getState() == RunningState::on && countdown > 0)
     {
-      const auto elapsedTime = runApi.getTargetCycleTime().value();
       const auto newTimerValue = elapsedTime > countdown ? 0 : countdown - elapsedTime;
       setNextCountdown(newTimerValue);
 
@@ -53,6 +66,10 @@ protected:
   {
     onProgramChanged({this, [this]() { setNextCountdown(getProgram()); }}).keep();
   }
+
+private:
+  /// Empty until the first update, which has nothing to difference against yet.
+  std::optional<sen::TimeStamp> lastUpdate_;
 
   bool programAcceptsSet(sen::Duration /*val*/) const override
   {


### PR DESCRIPTION
The timer advanced its countdown by `runApi.getTargetCycleTime()`, the configured period, rather than by differencing the clock. A skipped cycle covers two periods and only one was subtracted, so the countdown ran slow and `timeout()` fired late. A component that is stepped rather than cycled has no configured period at all.

`execution_model.md` tells readers to do the opposite — take `dt` from the clock so the same code is correct when a cycle is skipped and when the component is stepped. This is the one component in the repository whose whole purpose is counting down time.

It now differences `getTime()` against the previous update. The first cycle has nothing to difference against, so it contributes nothing rather than the whole interval since the kernel started. The timestamp advances on every cycle including while the timer is off, so switching it on does not subtract the interval it spent paused.

That also removes an unguarded `.value()` on an optional. `cycleTime_` is only set inside `execLoop`, so a component that is not cycling has it empty and the call throws.

Verified by driving the example to completion and comparing against the unchanged version: both time out correctly on a 2 second program, so the normal path is unaffected. The skipped-cycle and stepping cases are what the change is for and are not exercised by that run.

The `[start:elapsed]` / `[end:elapsed]` markers are for a documentation page that will transclude this calculation.
