### PR TITLE
test(query): re-enable, and stop shutdown failing it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,8 +106,7 @@ if(SEN_BUILD_TESTS)
   add_subdirectory(test/util/stress_testing_utils)
   add_subdirectory(test/util/calls_on_removal)
   add_subdirectory(test/util/publish_types_manually)
-  # TODO(SEN-1725): Fix test that fails on arm
-  # add_subdirectory(test/util/query_test)
+  add_subdirectory(test/util/query_test)
   add_subdirectory(test/support)
 endif()
 

--- a/test/util/query_test/src/component.cpp
+++ b/test/util/query_test/src/component.cpp
@@ -55,12 +55,18 @@ public:
     const auto bus = api.getSource("se.env");
     bus->add(obj_);
 
-    std::ignore = enumList_.onAdded([this](const auto& /*iterators*/) { enumHits_++; });
+    std::ignore = objectsInError_.onAdded([this](const auto& /*iterators*/) { matchCount_++; });
 
-    const auto enumInterest = sen::Interest::make(
+    const auto interest = sen::Interest::make(
       R"(SELECT query_test.QueryTestClass FROM se.env WHERE currentStatus = "error")", api.getTypes());
-    bus->addSubscriber(enumInterest, &enumList_, true);
+    bus->addSubscriber(interest, &objectsInError_, true);
     // --8<-- [end:subscribe]
+
+    // The change has to cross the bus and fire the subscription callback, which one cycle
+    // does not bound on a loaded machine. Wait for the match and bound the wait instead.
+    // The bound stops applying once the stop is requested: the loop keeps ticking while the
+    // kernel shuts down, and a slow shutdown was failing this test rather than the query.
+    constexpr int maxTicks = 200;  // ~2 s at 100 Hz
 
     return api.execLoop(sen::Duration::fromHertz(100.0),
                         [this, &api]
@@ -71,26 +77,28 @@ public:
                           {
                             obj_->setNextCurrentStatus(query_test::Status::error);
                           }
-                          else if (tick_ == 2)
+                          else if (matchCount_ > 0 && !stopRequested_)
                           {
-                            if (enumHits_ != 1)
+                            if (matchCount_ != 1)
                             {
-                              sen::throwRuntimeError("Enum query failed to match property change");
+                              sen::throwRuntimeError("Enum query matched the property change more than once");
                             }
 
+                            stopRequested_ = true;
                             api.requestKernelStop(0);
                           }
-                          else if (tick_ > 10)
+                          else if (tick_ > maxTicks && !stopRequested_)
                           {
-                            sen::throwRuntimeError("Test timeout");
+                            sen::throwRuntimeError("Enum query never matched the property change");
                           }
                         });
   }
 
 private:
   std::shared_ptr<query_test::QueryTestClassImpl> obj_;
-  sen::ObjectList<query_test::QueryTestClassInterface> enumList_;
-  int enumHits_ = 0;
+  sen::ObjectList<query_test::QueryTestClassInterface> objectsInError_;
+  int matchCount_ = 0;
+  bool stopRequested_ = false;
   int tick_ = 0;
 };
 


### PR DESCRIPTION
The test was commented out on 2026-06-30 during a pipeline refactor, noted as failing on arm.

It does fail on arm — 8 times in 20 under gcc — and not for the reason recorded. The change arrives,
the match fires, the stop is requested. The loop then keeps ticking while the kernel shuts down,
passes its own `tick_ > 10` bound and throws `Test timeout`. A test that had passed reported a
timeout because shutdown took longer than eighty milliseconds. That bound no longer applies once the
stop has been requested.

A second race is fixed that had not fired. The old code asserted at tick 2 that the change had
crossed the bus and fired the callback — one cycle, 10 ms at 100 Hz. It now waits for the match,
bounded at 200 ticks. Both messages name what happened rather than blaming the query engine, and a
duplicate match still reports as a duplicate.

Measured on arm, gcc, twenty runs each way: 8 failures before, none after.
