### PR TITLE
docs: mark the timer's elapsed-time state for the page that shows it

### DIFF
--- a/examples/packages/timer/src/timer.cpp
+++ b/examples/packages/timer/src/timer.cpp
@@ -68,8 +68,10 @@ protected:
   }
 
 private:
+  // --8<-- [start:elapsed_state]
   /// Empty until the first update, which has nothing to difference against yet.
   std::optional<sen::TimeStamp> lastUpdate_;
+  // --8<-- [end:elapsed_state]
 
   bool programAcceptsSet(sen::Duration /*val*/) const override
   {


### PR DESCRIPTION
A documentation page transcludes the timer's elapsed-time calculation, which reads `lastUpdate_.value_or(now)`. The member is declared elsewhere in the file, so without a marker around it a reader meets `value_or` on something the snippet never shows, and the page would have to explain in prose what the code could show directly.

Two comment lines. The doc comment on the member is inside the pair deliberately — it says what a reader needs in order to understand the other block.

This belonged in #212. It was committed locally and the branch was never force-pushed before the merge, so it went in with only the first marker pair.
