### PR TITLE
docs(kernel): say what advanceTime actually does

### DIFF
--- a/libs/kernel/stl/sen/kernel/kernel_objects.stl
+++ b/libs/kernel/stl/sen/kernel/kernel_objects.stl
@@ -151,8 +151,9 @@ class VirtualMasterClock: extends VirtualClock
 {
   var delta : Duration [writable];
 
-  // calls advanceTimeDrainInputsAndUpdate(delta) and then flushOutputs()
-  // on all VirtualKernelClocks n times, where n is duration / delta
+  // calls advanceTimeDrainInputsAndUpdate(delta) then flushOutputs() on all
+  // VirtualKernelClocks, until the virtual time advanced reaches duration, rounding
+  // up to a whole delta. Returns the wall time the call took
   fn advanceTime(duration: Duration) -> Duration [bestEffort];
 
   // single step forward, based on delta


### PR DESCRIPTION
The interface comment on `advanceTime` said it steps `duration / delta` times. That is integer division and rounds down; the loop runs `while (elapsedVirtualTime < duration)`, which rounds up. With a 30 ms delta and a 100 ms duration the comment predicts three steps advancing 90 ms, and the code takes four and advances 120 ms.

The implementation is the one that matches the documented behaviour, so the comment is what changes.

It also returns the wall time the call took — `high_resolution_clock::now() - beforeExecution` — rather than the virtual time it advanced. Nothing said so: not this comment, not the how-to guide, not the execution model page. Given the signature a reader would reasonably assume the opposite.

Comment only, no code. The wrong line has been there since the initial commit.
