### PR TITLE
test(core): exit the abort handler without running the at-exit chain

### DIFF
--- a/libs/core/test/base/assert_test.cpp
+++ b/libs/core/test/base/assert_test.cpp
@@ -53,7 +53,9 @@ void testAssertHandler(const CheckInfo& checkInfo) noexcept
   ASSERT_EQ(checkInfo.getExpression(), expectedCheckInfo.getExpression());
 }
 
-void exitOnAbort(int /*signal*/) { std::exit(0); }
+// _Exit rather than exit: this runs inside a signal handler, and exit is not async-signal-safe --
+// it runs the at-exit chain, so static destructors free memory in the signal context.
+void exitOnAbort(int /*signal*/) { std::_Exit(0); }
 
 [[noreturn]] void triggerDefaultCheckHandler()
 {


### PR DESCRIPTION
The assert death tests install a SIGABRT handler that calls `std::exit(0)`. `exit` is not async-signal-safe: it runs the at-exit chain, so static destructors free memory inside the signal context. The thread sanitizer reports it in all seven `AssertDeathTest` cases, with `operator delete` under a vector destructor under an at-exit callback under the handler.

`std::_Exit` skips the at-exit chain and is signal-safe.

**The product is not at fault here.** `defaultCheckHandler` is allocation-free — an assignment, a `DEBUG`-only stream write, and `raise`. The finding is in the test's own handler.

Found by the concurrency redesign session, where it has been a registered sanitizer family since August. All seven cases pass; the sanitizer lane on `core_test` should go quiet.
