### PR TITLE
ci: check that commands printed in prose are ones a reader can run

### DIFF
--- a/.github/scripts/check_command_consistency.py
+++ b/.github/scripts/check_command_consistency.py
@@ -1,0 +1,150 @@
+# === check_command_consistency.py =====================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Fails when a command printed in prose is one that will not work for a reader.
+
+The documentation, the README, CONTRIBUTING and the example guides all print
+commands people copy. Nothing runs them, so they rot in a way tests do not catch:
+CI builds Sen its own way and never executes the line a newcomer pastes.
+
+That gap produced F-229. Every `conan install` in the corpus said `--profile`, which
+sets only the host profile and leaves Conan looking for a build profile named
+`default`. CI creates a `default` before building, so the pipeline was green while the
+documented command was wrong for every reader who did not have one. The sweep that
+fixed it reached `docs/`, `README.md` and `examples/README.md`, and missed
+`CONTRIBUTING.md`, which stayed wrong until somebody read it.
+
+Each rule below is an invariant a command in prose has to satisfy. They are deliberately
+narrow: a rule fires on an actual invocation, never on prose *about* a flag, so pages
+can still explain why `--profile` is the wrong one to use.
+
+    python3 .github/scripts/check_command_consistency.py           # whole repository
+    python3 .github/scripts/check_command_consistency.py FILE ...  # named files
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Directories whose markdown is not ours to lint, or is generated.
+SKIPPED = ("node_modules", "build", ".git", "dist", "doxygen_gen", "docs/snippets", "licenses")
+
+
+@dataclass(frozen=True)
+class Rule:
+    """One invariant, and what to say when a line breaks it."""
+
+    name: str
+    trigger: re.Pattern[str]
+    accept: re.Pattern[str] | None
+    message: str
+
+
+RULES = (
+    Rule(
+        name="conan-profile-all",
+        # An actual invocation: `conan` then a verb that takes a profile.
+        trigger=re.compile(r"\bconan\s+(?:install|build|create|lock|graph|profile\s+show)\b[^\n`]*--profile"),
+        # `--profile:all`, `--profile:host`, `--profile:build` are all explicit. `-pr:a` too.
+        accept=re.compile(r"--profile:(?:all|host|build)\b"),
+        message=(
+            "uses bare `--profile`, which sets only the host profile. A reader without a "
+            "`default` build profile gets an error, and a reader with one silently builds "
+            "for their own machine. Use `--profile:all` (or `-pr:a`). See F-229."
+        ),
+    ),
+    Rule(
+        name="installer-version",
+        trigger=re.compile(r"install\.sh[^\n`]*\ssh\s+-s\s+--\s+(\d+\.\d+\.\d+)"),
+        accept=None,  # handled by the cross-file check below
+        message="pins an installer version; all of them have to agree.",
+    ),
+)
+
+
+def markdown_files(paths: list[str]) -> list[Path]:
+    """The markdown to lint: the named files, or the whole repository."""
+    if paths:
+        return [Path(p) for p in paths]
+    out = []
+    for path in sorted(REPO_ROOT.rglob("*.md")):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if any(skip in rel for skip in SKIPPED):
+            continue
+        out.append(path)
+    return out
+
+
+def display_path(path: Path) -> str:
+    """A path as it should be reported, whether the caller gave us an absolute one or not.
+
+    Both entry points need this. When it lived in only one of them, the other
+    crashed with `ValueError: not in the subpath of` on any relative argument.
+    """
+    if not path.is_absolute():
+        return path.as_posix()
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        # Outside the repository: report it whole rather than dying on the way to saying so.
+        return path.as_posix()
+
+
+def check_line(rule: Rule, line: str) -> bool:
+    """True when the line triggers the rule and does not satisfy it."""
+    if not rule.trigger.search(line):
+        return False
+    if rule.accept is None:
+        return False
+    return not rule.accept.search(line)
+
+
+def collect_versions(files: list[Path]) -> dict[str, list[str]]:
+    """Installer versions pinned in prose, grouped by version."""
+    rule = RULES[1]
+    found: dict[str, list[str]] = {}
+    for path in files:
+        for number, line in enumerate(path.read_text(errors="ignore").splitlines(), 1):
+            match = rule.trigger.search(line)
+            if match:
+                where = f"{display_path(path)}:{number}"
+                found.setdefault(match.group(1), []).append(where)
+    return found
+
+
+def main() -> int:
+    """Lint every command in prose, and report each line that a rule rejects."""
+    files = markdown_files(sys.argv[1:])
+    problems = []
+
+    for path in files:
+        rel = display_path(path)
+        for number, line in enumerate(path.read_text(errors="ignore").splitlines(), 1):
+            for rule in RULES:
+                if check_line(rule, line):
+                    problems.append(f"{rel}:{number}: {rule.message}")
+
+    versions = collect_versions(files)
+    if len(versions) > 1:
+        listed = ", ".join(f"{version} ({len(sites)}x)" for version, sites in sorted(versions.items()))
+        problems.append(f"installer version disagrees across the corpus: {listed}")
+        for version, sites in sorted(versions.items()):
+            for site in sites:
+                problems.append(f"  {site}: pins {version}")
+
+    for problem in problems:
+        print(problem)
+
+    print(f"\n{len(problems)} problem(s) in {len(files)} file(s).")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_check_command_consistency.py
+++ b/.github/scripts/test_check_command_consistency.py
@@ -1,0 +1,151 @@
+# === test_check_command_consistency.py ================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Pins what counts as a broken command in prose, and what does not.
+
+The "accepted" cases are the ones that matter. A page has to be able to explain
+why `--profile` is the wrong flag without the check firing on the explanation,
+or the pages that teach the rule would be the ones that fail it.
+"""
+
+import sys
+from pathlib import Path
+
+import check_command_consistency as check
+
+PROFILE_RULE = check.RULES[0]
+
+
+def rejects(line):
+    """True when the profile rule reports this line."""
+    return check.check_line(PROFILE_RULE, line)
+
+
+# --------------------------------------------------------------------------------------------------------------------
+# Rejected: invocations a reader would copy
+# --------------------------------------------------------------------------------------------------------------------
+
+
+def test_rejects_bare_profile_on_install():
+    """The invocation F-229 was about: it is the one a reader copies first."""
+    assert rejects("conan install . --profile=sen_gcc_x86 --build=missing")
+
+
+def test_rejects_bare_profile_on_build():
+    """`conan build` takes the same flag and rots the same way."""
+    assert rejects("conan build . --profile=sen_gcc_x86")
+
+
+def test_rejects_bare_profile_with_a_space():
+    """`--profile x` and `--profile=x` are the same command and must fail alike."""
+    assert rejects("conan install . --profile sen_gcc --build=missing")
+
+
+def test_rejects_bare_profile_on_create():
+    """Package authors copy `create` lines; the flag is wrong there too."""
+    assert rejects("conan create . --profile=sen_msvc")
+
+
+# --------------------------------------------------------------------------------------------------------------------
+# Accepted: correct invocations
+# --------------------------------------------------------------------------------------------------------------------
+
+
+def test_accepts_profile_all():
+    """The correction the rule exists to steer people towards."""
+    assert not rejects("conan install . --profile:all=sen_gcc --build=missing")
+
+
+def test_accepts_explicit_host_and_build():
+    """Naming both profiles is equally correct and must not be flagged."""
+    assert not rejects("conan install . --profile:host=sen_gcc --profile:build=sen_gcc")
+
+
+# --------------------------------------------------------------------------------------------------------------------
+# Accepted: prose about the flag, which is how the rule gets taught
+# --------------------------------------------------------------------------------------------------------------------
+
+
+def test_accepts_prose_explaining_the_flag():
+    """A page must be able to say why the flag is wrong without failing on it."""
+    line = "`--profile:all` sets both the host and the build profile. `--profile` sets only the host one,"
+    assert not rejects(line)
+
+
+def test_accepts_prose_naming_the_flag_without_an_invocation():
+    """Naming a flag mid-sentence is not an invocation."""
+    assert not rejects("and Conan then looks for a build profile named `default` when you pass `--profile`.")
+
+
+def test_accepts_an_unrelated_tool_taking_a_profile():
+    """Other tools have a `--profile` and none of this applies to them."""
+    assert not rejects("aws s3 ls --profile=default")
+
+
+# --------------------------------------------------------------------------------------------------------------------
+# The cross-file version check
+# --------------------------------------------------------------------------------------------------------------------
+
+
+def test_collects_a_pinned_installer_version(tmp_path, monkeypatch):
+    """A version is only comparable across files once it is found in one."""
+    page = tmp_path / "install.md"
+    page.write_text("curl -sSf https://example/install.sh | sh -s -- 0.6.0\n")
+    monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+    assert check.collect_versions([page]) == {"0.6.0": ["install.md:1"]}
+
+
+def test_disagreeing_versions_are_grouped(tmp_path, monkeypatch):
+    """Two files pinning different versions is the defect; both must be reported."""
+    one = tmp_path / "a.md"
+    one.write_text("curl -sSf https://example/install.sh | sh -s -- 0.6.0\n")
+    two = tmp_path / "b.md"
+    two.write_text("curl -sSf https://example/install.sh | sh -s -- 0.5.2\n")
+    monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+    found = check.collect_versions([one, two])
+    assert sorted(found) == ["0.5.2", "0.6.0"]
+
+
+# --------------------------------------------------------------------------------------------------------------------
+# Path handling. The checker is invoked with relative paths as often as absolute ones,
+# and the guard for that originally lived in only one of the two entry points, so the
+# other raised `ValueError: not in the subpath of` on any relative argument.
+# --------------------------------------------------------------------------------------------------------------------
+
+
+def test_display_path_accepts_a_relative_path():
+    """pre-commit passes relative paths, so this is the common case."""
+    assert check.display_path(Path("docs/getting_started/install.md")) == "docs/getting_started/install.md"
+
+
+def test_display_path_trims_the_repository_root_from_an_absolute_path():
+    """The absolute form, which the entry point that walks the tree produces."""
+    assert check.display_path(check.REPO_ROOT / "docs" / "index.md") == "docs/index.md"
+
+
+def test_runs_against_a_relative_filename_without_raising(tmp_path, monkeypatch):
+    """The whole point: this is the invocation that used to crash."""
+    page = tmp_path / "guide.md"
+    page.write_text("curl -sSf https://example/install.sh | sh -s -- 0.6.0\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["check_command_consistency.py", "guide.md"])
+    assert check.main() == 0
+
+
+def test_reports_a_relative_filename_as_given(tmp_path, monkeypatch, capsys):
+    """What a reader sees in the failure: the path they recognise, not an absolute one."""
+    page = tmp_path / "guide.md"
+    page.write_text("conan install . --profile=sen_gcc --build=missing\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["check_command_consistency.py", "guide.md"])
+    assert check.main() == 1
+    assert "guide.md:1" in capsys.readouterr().out
+
+
+def test_a_path_outside_the_repository_is_reported_not_crashed_on():
+    """It reports paths. One it cannot make relative must still be reportable."""
+    assert check.display_path(Path("/tmp/elsewhere/README.md")) == "/tmp/elsewhere/README.md"
+    assert check.display_path(Path("docs/guide.md")) == "docs/guide.md"


### PR DESCRIPTION
Nothing executes the commands the README, CONTRIBUTING and the guides print, and CI builds Sen its
own way, so a wrong flag survives a green pipeline.

That gap produced F-229: every `conan install` in the corpus said `--profile`, which sets only the
host profile and leaves Conan looking for a build profile named `default`. CI creates a `default`
before building, so the pipeline was green while the documented command was wrong for every reader
who did not have one. The sweep that fixed it missed `CONTRIBUTING.md`; the follow-up missed the
README.

**It is still true.** On a container with no `default` profile:

```
$ conan install . --profile=sen_gcc_x86 --build=missing      # as README.md:190 prints it
ERROR: The default build profile '/tmp/fresh/.conan2/profiles/default' doesn't exist.

$ conan install . --profile:all=sen_gcc_x86 --build=missing
(proceeds)
```

The checker reports 14 such commands across `README.md`, `CONTRIBUTING.md`,
`docs/getting_started/install.md` and `examples/README.md`.

Each rule fires on an actual invocation and never on prose about a flag, so a page can still explain
why `--profile` is the wrong one to use. Sixteen tests cover both directions, including prose that
names the flag and an unrelated tool that has one.

**The pre-commit hook is deliberately not here.** Adding it would fail every commit until the corpus
is corrected, and those corrections are already made on the documentation branch — repeating them
here would collide across the four files it rewrites. The hook lands when that does.
