### PR TITLE
ci: let dependabot title its pull requests

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -15,7 +15,9 @@ regex-style-search=True
 types=build,chore,ci,docs,feat,fix,perf,refactor,revert,test
 
 # Dependency bumps are written by Dependabot and cite compare URLs that run well past
-# the line limit and cannot be wrapped. The limit still applies to everything else,
+# the line limit and cannot be wrapped. The title has the same problem: it names the
+# manifest's directory, so a package under components/jsonrpc/clients/typescript is over
+# the limit before the version numbers. The limits still apply to everything else,
 # including the rest of a dependency commit's body.
 #
 # This list REPLACES the one in [general] for matching titles, it does not add to it,
@@ -23,4 +25,4 @@ types=build,chore,ci,docs,feat,fix,perf,refactor,revert,test
 # fails: it pipes a bare title into gitlint, which then has no body at all.
 [ignore-by-title]
 regex=^chore\(deps\)
-ignore=body-max-line-length,body-is-missing
+ignore=body-max-line-length,body-is-missing,title-max-length


### PR DESCRIPTION
Every npm dependency bump fails the pull request title check:

    1: T1 Title exceeds max length (89>72):
       "chore(deps): bump postcss from 8.5.15 to 8.5.28 in /components/jsonrpc/clients/typescript"

Dependabot names the manifest directory in the title, so a package under
`components/jsonrpc/clients/typescript` is past the limit before the version numbers. It
started when the TypeScript client added a manifest four directories deep. Nine Dependabot
pull requests are open, five failing on this, and they cannot merge while it stands.

`.gitlint` already exempts `chore(deps)` from the body limit, for the same reason: what
Dependabot writes cannot be wrapped. The title was not covered. This adds it.

Checked in both directions:

| title | before | after |
|---|---|---|
| the failing 89-character `chore(deps)` one | fails T1 | passes |
| `feat(kernel):` at 87 characters | fails T1 | still fails T1 |
| `chore(deps)` without the colon | fails CT1 | still fails CT1 |

So only the length limit is lifted, and only for titles Dependabot writes. A human writing
`ci(deps)` is still checked, which the existing comment says is deliberate.

Not addressed here: why the count is 61 in the first place. A newly added dependency tree
arriving with that many advisories suggests the versions were already behind when they
landed, rather than drifting since. Worth understanding separately.
