### PR TITLE
ci: cover dev dependency bumps in the title exemption

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -24,5 +24,5 @@ types=build,chore,ci,docs,feat,fix,perf,refactor,revert,test
 # so body-is-missing has to be repeated here. Without it the pull request title check
 # fails: it pipes a bare title into gitlint, which then has no body at all.
 [ignore-by-title]
-regex=^chore\(deps\)
+regex=^chore\(deps(-dev)?\)
 ignore=body-max-line-length,body-is-missing,title-max-length


### PR DESCRIPTION
Dependabot titles dev dependency updates `chore(deps-dev)`, which the exemption regex did
not match, so #221 and #224 kept failing the title check after #230.

Verified: both failing titles now pass, `chore(deps)` titles still pass, and a long `feat`
title still fails.
