### PR TITLE
ci: keep majors out of grouped security updates, and cover pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,6 +71,9 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: npm
     directory: /components/jsonrpc/clients/typescript
@@ -91,6 +94,9 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: npm
     directory: /components/webexplorer/frontend
@@ -111,6 +117,9 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: npm
     directory: /resources/syntax_highlighting/stl/vscode
@@ -131,3 +140,57 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
+
+  # The two python manifests. Same shape as the javascript projects: grouped for the
+  # updates that carry no decision, and majors left on their own.
+  - package-ecosystem: pip
+    directory: /docs
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 10
+    groups:
+      docs:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      docs-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+
+  # The two python manifests. Same shape as the javascript projects: grouped for the
+  # updates that carry no decision, and majors left on their own.
+  - package-ecosystem: pip
+    directory: /examples/apps/rest_python
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 10
+    groups:
+      rest-python-example:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      rest-python-example-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Two corrections to the grouping added in #233.

**Majors in the security groups.** Those groups had no `update-types` filter, so the first
grouped security pull requests bundled `vite` 6.4.2 to 8.2.2 and `vitest` 2.1.9 to 5.0.0
beside patch-level fixes. Those are toolchain majors that were deferred deliberately an hour
earlier. A security fix that only exists in a major is still raised, on its own, which is
how the `github-actions` entry already treats them.

**The python manifests had no entry.** `docs/requirements.txt` and
`examples/apps/rest_python/requirements.txt` were in the same position npm was in before
#233: security updates arriving one per package, version updates never arriving. Same shape
as the javascript projects.

Expect pip to raise a batch shortly after this merges, as npm did. Grouped, so a handful
rather than one per package.
