### PR TITLE
ci: run the sanitizer lane in the image this repository builds

### DIFF
--- a/.github/scripts/in_image.sh
+++ b/.github/scripts/in_image.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Runs a script inside the image this repository builds, so that a lane and a
+# developer use the same toolchain rather than two kept in agreement by hand.
+# The script is read from standard input, which keeps the caller free of the
+# quoting a command-line argument would need.
+#
+# As the caller's own user, because the checkout belongs to them: the image's
+# user would leave build output they cannot delete, and root would leave it
+# owned by root. That user is uid 1000 and a runner is 1001, so there is no
+# passwd entry inside and HOME has to be given -- without it conan gets HOME=/
+# and cannot write its cache.
+#
+# The workspace is mounted at the path it already has. Conan writes absolute
+# paths into what it generates, so a build folder belongs to the path that
+# configured it.
+#
+# CONAN_HOME and CCACHE_DIR are redirected for the same reason as HOME: the
+# image sets CCACHE_DIR to a directory under its own user, which is mode 750
+# and unreadable to anyone else, so a build fails on the first compile.
+set -euo pipefail
+
+: "${SEN_CI_IMAGE:?set SEN_CI_IMAGE to the image tag}"
+: "${GITHUB_WORKSPACE:?only meaningful inside a job}"
+
+mkdir -p "$HOME/.conan2" "$HOME/.ccache"
+
+docker run --rm --interactive \
+    --user "$(id -u):$(id -g)" \
+    --volume "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+    --volume "$HOME/.conan2:/conan" \
+    --volume "$HOME/.ccache:/ccache" \
+    --workdir "$GITHUB_WORKSPACE" \
+    --env HOME=/tmp \
+    --env CONAN_HOME=/conan \
+    --env CCACHE_DIR=/ccache \
+    --env CC \
+    --env CXX \
+    --security-opt seccomp=unconfined \
+    "$SEN_CI_IMAGE" \
+    bash -seuo pipefail

--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -62,9 +62,15 @@ jobs:
       # definition a developer can also run rather than a second one assembled on
       # the runner. Built here rather than pulled: publishing to the registry is
       # not available, and a runner builds for its own architecture anyway.
+      # One retry, for the same reason ci-image.yaml has one: the archives this
+      # pulls from do go quiet, and a plain re-run has cleared it before. The
+      # image also sets apt retries and timeouts, which the runner-side action
+      # this replaced did for itself.
       - name: Build the image the lane runs in
         shell: bash
-        run: docker build --target base --tag "$SEN_CI_IMAGE" tools/ci
+        run: |
+          build() { docker build --target base --tag "$SEN_CI_IMAGE" tools/ci; }
+          build || { echo "image build failed, retrying once"; build; }
 
       - name: Install the conan profiles
         shell: bash

--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -34,6 +34,7 @@ jobs:
     env:
       CC: clang-20
       CXX: clang++-20
+      SEN_CI_IMAGE: sen-ci:lane
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -57,31 +58,38 @@ jobs:
 
       # No ccache: sanitized object files must not land in the entries the
       # ordinary builds depend on. Same rule as the nightly's sanitizer lanes.
-      - name: Setup build context
-        uses: ./.github/actions/setup_build_context
-        with:
-          compiler-name: clang
-          compiler-version: 20
-          arch: x86
-
-      - name: Install additional python dependencies
+      # The lane runs in the image this repository builds, so what it uses is the
+      # definition a developer can also run rather than a second one assembled on
+      # the runner. Built here rather than pulled: publishing to the registry is
+      # not available, and a runner builds for its own architecture anyway.
+      - name: Build the image the lane runs in
         shell: bash
-        run: pip install junitparser==5.0.1
+        run: docker build --target base --tag "$SEN_CI_IMAGE" tools/ci
+
+      - name: Install the conan profiles
+        shell: bash
+        run: |
+          .github/scripts/in_image.sh <<'IN'
+          conan config install .conan/profiles/ --target-folder "$CONAN_HOME/profiles/"
+          IN
 
       # Debug also compiles the SEN_DEBUG_ASSERT invariant checks, which
       # RelWithDebInfo builds leave out.
       - name: Build with the sanitizers
         shell: bash
         run: |
+          .github/scripts/in_image.sh <<'IN'
           options='-o sen/*:with_tests=True -o sen/*:sanitizer=address'
           variables="{'SEN_SANITIZER_LOG_DIR': '$PWD/sanitizer-reports', 'SEN_SANITIZER_FAIL_FAST': 'ON'}"
-          # shellcheck disable=SC2086
-          conan install . -s "&:build_type=Debug" --build=missing $options \
+          # --profile:all names both host and build profile. The action this replaced
+          # copied one over `default` instead, which is the arrangement that makes a
+          # documented `conan install --profile=...` work here and fail for a reader.
+          conan install . --profile:all=sen_clang_x86 -s "&:build_type=Debug" --build=missing $options \
             -c "tools.cmake.cmaketoolchain:extra_variables=$variables"
           # conan build regenerates the toolchain, so it needs the same options.
-          # shellcheck disable=SC2086
-          conan build . -s "&:build_type=Debug" $options \
+          conan build . --profile:all=sen_clang_x86 -s "&:build_type=Debug" $options \
             -c "tools.cmake.cmaketoolchain:extra_variables=$variables"
+          IN
 
       # A lane that reports nothing looks the same whether it found nothing or looked
       # at nothing, so this fails unless a deliberate finding of each kind reaches the
@@ -89,18 +97,22 @@ jobs:
       - name: Check the sanitizers detect
         shell: bash
         run: |
+          .github/scripts/in_image.sh <<'IN'
           # Conan provides cmake and ninja; the check calls ctest, so it needs the same
-          # environment the step below does rather than whatever the runner ships.
+          # environment the step below does rather than whatever the image ships.
           source build/clang/Debug/generators/conanbuild.sh
           python3 .github/scripts/check_sanitizer_lane.py build/clang/Debug address
+          IN
 
       - name: Run tests
         shell: bash
         run: |
+          .github/scripts/in_image.sh <<'IN'
           # Conan provides cmake and ninja; entering its environment is what puts
           # them ahead of whatever else is on PATH, the image's own pair included.
           source build/clang/Debug/generators/conanbuild.sh
           cmake --build build/clang/Debug/ --target run_tests
+          IN
 
       # Always: the findings are what the failure is about, so they have to be
       # reported on the run that failed.

--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -44,17 +44,19 @@ jobs:
         shell: bash
         run: echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_ENV"
 
-      # Restore only, never save. prepare_build would be the obvious thing to
-      # reuse here, but it saves at the end of the job, and a cache written from
-      # a pull request is private to it: every open pull request storing its own
-      # slice puts the repository past GitHub's 10 GB limit. The nightly can use
-      # it because the nightly only runs on main.
+      # prepare_build would be the obvious thing to reuse here, but it saves at the
+      # end of the job, and a cache written from a pull request is private to it:
+      # every open pull request storing its own slice puts the repository past
+      # GitHub's 10 GB limit. So this restores always and saves from main only.
+      # Keyed to the image, not the runner: a conan package id does not distinguish
+      # one Ubuntu from another, and the runner's cache holds 24.04 binaries whose
+      # libstdc++ is newer than the image's -- they install here and fail at link.
       - name: Restore conan packages
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.conan2/p
-          key: conanp-ubuntu-24.04-clang-20-17-${{ env.cache_date }}
-          restore-keys: conanp-ubuntu-24.04-clang-20-17-
+          key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17-${{ env.cache_date }}
+          restore-keys: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17-
 
       # No ccache: sanitized object files must not land in the entries the
       # ordinary builds depend on. Same rule as the nightly's sanitizer lanes.
@@ -138,3 +140,20 @@ jobs:
           name: pr-sanitizer-reports
           path: sanitizer-reports/
           if-no-files-found: ignore
+
+      # sen itself and the build folders stay out, as in conan.yaml.
+      - name: Clean the conan cache before saving
+        if: always() && github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          .github/scripts/in_image.sh <<'IN'
+          conan remove sen --confirm
+          conan cache clean "*" -s -b -d
+          IN
+
+      - name: Save conan packages
+        if: always() && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.conan2/p
+          key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17-${{ env.cache_date }}

--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -58,7 +58,16 @@ ENV LANG=C.UTF-8 \
 RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
         > /etc/apt/apt.conf.d/99-sen-retries
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# apt gives up on the first refusal by default, and a fetch from apt.llvm.org that
+# cannot resolve fails the whole image. The action this image replaces on the runners
+# carried the same settings for the same reason: the hosts involved do go quiet.
+RUN printf '%s\n' \
+        'Acquire::Retries "3";' \
+        'Acquire::http::Timeout "30";' \
+        'Acquire::https::Timeout "30";' \
+        'DPkg::Lock::Timeout "120";' \
+        > /etc/apt/apt.conf.d/99-sen-timeouts \
+    && apt-get update && apt-get install -y --no-install-recommends \
         bats \
         ca-certificates \
         ccache \


### PR DESCRIPTION
The pull-request sanitizer lane now runs inside the image this repository
builds, instead of installing its own toolchain with apt and pip.

That toolchain install was a second definition of the build environment, kept
in agreement with the image by hand. This removes it. It is not a speed
change: the setup takes 35 seconds on a real run and the image build takes
about 50.