### PR TITLE
ci: run the sanitizer lane on pushes to main

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -162,14 +162,17 @@ jobs:
     with:
       pull_request_subset: ${{ github.event_name == 'pull_request' }}
 
-  # A pull request only. The tree is clean under both sanitizers, so a finding
-  # is a regression this change introduced; the nightly keeps the wider sweep.
+  # Pull requests, plus pushes to main -- the only place this lane's conan cache can
+  # be filled, since one written from a pull request is private to it. Not the merge
+  # queue, whose ref is not main: it would pay for the lane again and save nothing.
+  # The tree is clean under both sanitizers, so a finding is a regression this change
+  # introduced; the nightly keeps the wider sweep.
   pr-sanitizers:
     needs: detect-changes
     if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.draft == false &&
-      needs.detect-changes.outputs.code == 'true'
+      needs.detect-changes.outputs.code == 'true' &&
+      (github.event_name == 'push' ||
+       (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
     uses: ./.github/workflows/pr_sanitizers.yaml
 
   # The only required check: every other job is skipped in some legitimate


### PR DESCRIPTION
The sanitizer lane restores a conan cache keyed to the image it builds in. A cache
written from a pull request is private to that pull request, so main is the only
place one can be filled. The lane ran on pull requests only, so its save step never
executed and every run started cold at about 28 minutes.

This adds pushes to main. The merge queue is left out on purpose: its ref is not
main, so it would run the lane again and still save nothing.
