### PR TITLE
ci: build the documentation in the image

### DIFF
--- a/.github/actions/build_documentation/action.yaml
+++ b/.github/actions/build_documentation/action.yaml
@@ -4,14 +4,23 @@ description: "Build the API reference and the handbook; the caller decides wheth
 runs:
   using: 'composite'
   steps:
+    # Not for this action, which runs python inside the image: build_docs.yaml
+    # installs mike on the runner immediately after calling it.
     - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
       with:
         python-version: 3.x
 
-    - name: Generate daily cache id
+    - name: Name the image and generate the daily cache id
       shell: bash
-      run: echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_ENV"
+      run: |
+        echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_ENV"
+        echo "SEN_CI_IMAGE=sen-ci:docs" >> "$GITHUB_ENV"
 
+    # Keyed to the image rather than the runner: a conan package id does not record
+    # which Ubuntu produced a binary, so a cache filled on a runner installs cleanly
+    # in the container and then fails at link. The hash is in the fallback prefix
+    # too, or the next change to the image restores the previous one's packages.
+    #
     # Saved only on main, as in standard_test.yaml: a cache written from a pull
     # request is private to it, and open pull requests together pass the 10 GB
     # limit.
@@ -19,11 +28,12 @@ runs:
       uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25  # v5
       with:
         path: ~/.conan2/p
-        key: conanp-docs-${{ env.cache_date }}
-        restore-keys: conanp-docs-
+        key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs-${{ env.cache_date }}
+        restore-keys: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs-
 
-    # Writes only on main, as in standard_test.yaml; main reaches this through
-    # build_docs.yaml, so the cache still gets filled.
+    # This keeps its cache inside the workspace, which the container mounts at the
+    # same path, so the compiler shims on PATH below reach the same directory the
+    # runner saves. Writes only on main, as above.
     - uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639  # v1.2
       with:
         key: docs
@@ -31,74 +41,48 @@ runs:
         verbose: 1
         save: ${{ github.ref == 'refs/heads/main' }}
 
-    - name: Install system dependencies
-      shell: bash
-      # graphviz draws the doxygen diagrams; libxext-dev is needed for clang
-      # compat with sdl2 2.24.0.
-      #
-      # apt-get, not the interactive apt. The bounds stop it waiting with no output until
-      # the job timeout kills it: twice in one day this build sat here for its whole hour,
-      # once on the dpkg lock and once on a mirror that stopped answering mid-download.
-      # They are generous on purpose. The mirror can be slow without being stuck, and the
-      # point is to end a hang well before the job cap, not to police how long apt takes.
-      run: |
-        # The runners prefer azure.archive.ubuntu.com through this mirror list. That host
-        # has been ignoring requests for us today, and apt then alternates between it and
-        # the working mirror until the bound below kills the step. Point it straight at
-        # the one that answers.
-        if [ -f /etc/apt/apt-mirrors.txt ]; then
-            sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' /etc/apt/apt-mirrors.txt
-        fi
-        sudo tee /etc/apt/apt.conf.d/99-sen-timeouts <<'CONF'
-        DPkg::Lock::Timeout "120";
-        Acquire::Retries "3";
-        Acquire::http::Timeout "30";
-        Acquire::https::Timeout "30";
-        CONF
-        timeout 1200 sudo apt-get update
-        timeout 1200 sudo apt-get install -y g++ graphviz libxext-dev
-
-    - name: Install python dependencies
+    # The documentation is built in the image this repository ships rather than on a
+    # runner assembling its own toolchain, so what CI uses is what a developer can
+    # run. One retry, as in ci-image.yaml: the archives this pulls from do go quiet.
+    - name: Build the image the documentation is built in
       shell: bash
       run: |
-        pip install conan==2.28.1
-        pip install -r docs/requirements.txt
+        build() { docker build --target base --tag "$SEN_CI_IMAGE" tools/ci; }
+        build || { echo "image build failed, retrying once"; build; }
 
-    - name: Setup conan profile
-      shell: bash
-      run: |
-        rm -f ~/.conan2/profiles/default
-        conan profile detect --force -vquiet
-        cp .conan/profiles/sen_gcc ~/.conan2/profiles/sen_gcc
-        cp .conan/profiles/sen_build_docs ~/.conan2/profiles/default
-        {
-          echo "[conf]"
-          echo "tools.system.package_manager:mode=install"
-          echo "tools.system.package_manager:sudo=True"
-        } >> ~/.conan2/profiles/default
-        conan profile show -pr default
-
-    # The handbook runs the built sen binary to capture its command-line help,
-    # so the documentation needs a full build first.
     - name: Build the documentation
       shell: bash
       run: |
-        export PATH="/usr/lib/ccache:$PATH"
-        conan install . --build=missing
+        .github/scripts/in_image.sh <<'IN'
+        # ccache first, so the shims are found ahead of the compilers themselves.
+        export PATH="/usr/lib/ccache:$HOME/.local/bin:$PATH"
+        export CCACHE_DIR="$PWD/.ccache"
+        pip install --user --quiet -r docs/requirements.txt
+        conan config install .conan/profiles/ --target-folder "$CONAN_HOME/profiles/"
+        # --profile:all names both host and build profile. Copying one over `default`
+        # instead is what makes a documented `conan install --profile=...` work here
+        # and fail for a reader.
+        conan install . --profile:all=sen_build_docs --build=missing
         cmake --preset=conan-gcc-release
-        cmake --build build/gcc/Release/
+        # The handbook runs the built binaries to capture their command-line help, so
+        # these targets pull in the six the snippets depend on.
         cmake --build build/gcc/Release/ --target doxydocs
         cmake --build build/gcc/Release/ --target mkdocs
+        IN
 
     - name: Remove unwanted parts from conan cache before backup
+      if: github.ref == 'refs/heads/main'
       shell: bash
-      run: conan cache clean "*" -s -b -d
+      run: |
+        .github/scripts/in_image.sh <<'IN'
+        conan cache clean "*" -s -b -d
+        IN
 
-    # After the clean, so build folders stay out. main gets here through
+    # After the clean, so build folders stay out. main reaches this through
     # build_docs.yaml, which is what keeps the slice pull requests restore.
     - name: Save conan packages
       if: always() && github.ref == 'refs/heads/main'
       uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25  # v5
       with:
         path: ~/.conan2/p
-        key: conanp-docs-${{ env.cache_date }}
+        key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs-${{ env.cache_date }}

--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -30,6 +30,7 @@ ARG CONAN_VERSION=2.28.1
 ARG JUNITPARSER_VERSION=5.0.1
 ARG PYTEST_VERSION=9.1.1
 ARG PRECOMMIT_VERSION=4.5.1
+ARG PLANTUML_VERSION=1.2026.7
 # Both must equal the versions conanfile.py tool-requires, and nothing checks that
 # they do. The header says why the image carries them at all.
 ARG CMAKE_VERSION=3.31.10
@@ -72,10 +73,12 @@ RUN printf '%s\n' \
         ca-certificates \
         ccache \
         curl \
+        default-jre-headless \
         g++-12 \
         gcc-12 \
         gcovr \
         git \
+        graphviz \
         lcov \
         libgl1-mesa-dev \
         libxext-dev \
@@ -88,6 +91,16 @@ RUN printf '%s\n' \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100 \
     && rm -rf /var/lib/apt/lists/*
+
+# plantuml renders the diagram the handbook embeds. Ubuntu's package is from 2020 and
+# pulls a full JDK, 218 packages against 40 for a headless JRE and the jar. CMake finds it
+# with find_program by name, so the wrapper is what has to be on PATH.
+RUN curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
+        -o /opt/plantuml.jar \
+        "https://github.com/plantuml/plantuml/releases/download/v${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar" \
+    && printf '%s\n' '#!/bin/sh' 'exec java -jar /opt/plantuml.jar "$@"' > /usr/local/bin/plantuml \
+    && chmod 0755 /usr/local/bin/plantuml \
+    && plantuml -version
 
 # clang from apt.llvm.org: the matrix's clang leg and the clang-tidy lane
 # both use this major version. The repository is added directly instead of
@@ -147,8 +160,7 @@ WORKDIR /workspace
 
 # CLion, VS Code and Visual Studio detect a toolchain by looking for cmake, a build
 # tool and a debugger inside the environment; base carries the first two, so this
-# stage adds the debugger. graphviz is here for the cmake_target_graph target, which
-# otherwise warns that 'dot' is missing.
+# stage adds the debugger.
 FROM base AS dev
 
 # Names again, for the same reason as in the base stage: this user exists in
@@ -157,7 +169,6 @@ FROM base AS dev
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gdb \
-        graphviz \
     && rm -rf /var/lib/apt/lists/*
 # hadolint ignore=DL3066
 USER sen


### PR DESCRIPTION
The documentation lane installed its own toolchain on the runner with apt, so what
CI used was a second environment kept in agreement with the image by hand. It now
builds inside the image, which gains plantuml and a headless JRE.