### PR TITLE
ci: drop a conan remove that has no recipe to remove

### DIFF
--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -141,13 +141,14 @@ jobs:
           path: sanitizer-reports/
           if-no-files-found: ignore
 
-      # sen itself and the build folders stay out, as in conan.yaml.
+      # Sources and build folders stay out of the entry. conan.yaml also removes the
+      # sen recipe first; this lane never exports one, because it installs and builds
+      # rather than creating the package, so asking would fail on a missing recipe.
       - name: Clean the conan cache before saving
         if: always() && github.ref == 'refs/heads/main'
         shell: bash
         run: |
           .github/scripts/in_image.sh <<'IN'
-          conan remove sen --confirm
           conan cache clean "*" -s -b -d
           IN
 


### PR DESCRIPTION
The sanitizer lane's cache clean ran `conan remove sen --confirm` before
`conan cache clean`, copied from the packaging lane where it is needed. That lane
creates the package and so exports a recipe; this one installs and builds, and
exports nothing. The removal fails with `Recipe 'sen' not found`, which ends the
step before the clean runs, and the save then stores an entry that still holds the
sources and build folders.

Main is red on every push until this lands, because the step runs on all of them.
