### PR TITLE
ci: install what mkdocs needs where mike runs it

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -44,8 +44,13 @@ jobs:
       # publishing below needs write access.
       - uses: ./.github/actions/build_documentation
 
-      - name: Install mike
-        run: pip install mike==2.1.3
+      # mike runs mkdocs itself, on the runner, so the theme and plugins have to be
+      # here as well as in the image the action builds the site in. Without them it
+      # fails parsing mkdocs.yml rather than anything to do with publishing.
+      - name: Install mike and what mkdocs needs to parse the config
+        run: |
+          pip install mike==2.1.3
+          pip install -r docs/requirements.txt
 
       # Every release keeps a frozen copy. `stable` follows the newest
       # release and the site's front page opens it; `latest` follows main.


### PR DESCRIPTION
The documentation build now runs inside the image, which moved
`pip install -r docs/requirements.txt` off the runner. `mike deploy` runs mkdocs
on the runner, so it lost the theme and plugins and failed parsing `mkdocs.yml`:

    cannot find module 'material.extensions.emoji' (No module named 'material')

Reproduced locally with a mike-only virtualenv, which raises the same
ConfigurationError against the real config, and cleared by installing the
requirements alongside mike.
