### PR TITLE
ci: keep one cache entry per family

### DIFF
--- a/.github/actions/build_documentation/action.yaml
+++ b/.github/actions/build_documentation/action.yaml
@@ -83,14 +83,14 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-      run: .github/scripts/drop_cache_key.sh "ccache-docs"
+      run: bash .github/scripts/drop_cache_key.sh "ccache-docs"
 
     - name: Drop the entry this save replaces
       if: always() && github.ref == 'refs/heads/main'
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-      run: .github/scripts/drop_cache_key.sh "conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs"
+      run: bash .github/scripts/drop_cache_key.sh "conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs"
 
     - name: Save conan packages
       if: always() && github.ref == 'refs/heads/main'

--- a/.github/actions/build_documentation/action.yaml
+++ b/.github/actions/build_documentation/action.yaml
@@ -10,11 +10,9 @@ runs:
       with:
         python-version: 3.x
 
-    - name: Name the image and generate the daily cache id
+    - name: Name the image
       shell: bash
-      run: |
-        echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_ENV"
-        echo "SEN_CI_IMAGE=sen-ci:docs" >> "$GITHUB_ENV"
+      run: echo "SEN_CI_IMAGE=sen-ci:docs" >> "$GITHUB_ENV"
 
     # Keyed to the image rather than the runner: a conan package id does not record
     # which Ubuntu produced a binary, so a cache filled on a runner installs cleanly
@@ -28,8 +26,7 @@ runs:
       uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25  # v5
       with:
         path: ~/.conan2/p
-        key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs-${{ env.cache_date }}
-        restore-keys: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs-
+        key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs
 
     # This keeps its cache inside the workspace, which the container mounts at the
     # same path, so the compiler shims on PATH below reach the same directory the
@@ -37,6 +34,7 @@ runs:
     - uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639  # v1.2
       with:
         key: docs
+        append-timestamp: false
         max-size: 1G
         verbose: 1
         save: ${{ github.ref == 'refs/heads/main' }}
@@ -80,9 +78,23 @@ runs:
 
     # After the clean, so build folders stay out. main reaches this through
     # build_docs.yaml, which is what keeps the slice pull requests restore.
+    - name: Drop the ccache entry this run replaces
+      if: always() && github.ref == 'refs/heads/main'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: .github/scripts/drop_cache_key.sh "ccache-docs"
+
+    - name: Drop the entry this save replaces
+      if: always() && github.ref == 'refs/heads/main'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: .github/scripts/drop_cache_key.sh "conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs"
+
     - name: Save conan packages
       if: always() && github.ref == 'refs/heads/main'
       uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25  # v5
       with:
         path: ~/.conan2/p
-        key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs-${{ env.cache_date }}
+        key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs

--- a/.github/scripts/drop_cache_key.sh
+++ b/.github/scripts/drop_cache_key.sh
@@ -1,25 +1,12 @@
 #!/usr/bin/env bash
-# Removes the cache entry a save is about to replace, so a family keeps one entry
-# rather than accumulating a copy per merge.
+# Deletes the cache entry a save is about to replace. Keys are immutable, so a save
+# can only add: without this every merge leaves another copy and the repository
+# passes GitHub's 10 GB limit, after which entries are evicted at random.
 #
-# Cache keys are immutable: a save can only add, never update. Anything that saves
-# on every merge therefore grows until the repository passes GitHub's 10 GB limit
-# and eviction starts removing entries nobody chose -- the conan ones first, since
-# they are written least often and are what decides whether a lane takes five
-# minutes or twenty-eight.
-#
-# Two things here are load-bearing rather than defensive.
-#
-# It refuses to run anywhere but main. Every save this accompanies is gated to
-# main, and a delete that is not gated the same way removes the shared entry from
-# any branch and puts nothing back -- measured, and the run reports success, so
-# there is no red check to catch it. Enforcing that here means a workflow that
-# forgets the condition is harmless instead of destructive.
-#
-# It confirms the entry is gone. actions/cache downgrades a failed save to a
-# warning, so a delete that quietly stopped working would leave every later save a
-# silent no-op and freeze the cache -- builds slowly getting worse with nothing
-# red. Failing here is what turns that into something visible.
+# Refuses to run off main, because the saves it accompanies run only there and an
+# ungated delete would take the shared entry from any branch. Checks the entry is
+# gone afterwards, because a failed save is only a warning.
+
 set -euo pipefail
 
 key="${1:?usage: drop_cache_key.sh <key>}"
@@ -36,11 +23,8 @@ keys_matching() {
         --jq ".actions_caches[] | select(.key | startswith(\"$1\")) | .key" 2>/dev/null || true
 }
 
-# A stable key has one entry. Anything else sharing its prefix is a leftover from
-# when the key carried a timestamp or a date, so this drops them too -- otherwise
-# the first run after the change would trip over entries the change exists to stop
-# creating. The suffix is matched exactly rather than by prefix alone, so a family
-# whose name merely begins with this one cannot be caught by it.
+# Leftovers from when the key carried a date. The suffix shape is matched exactly,
+# so a family whose name begins with this one is not caught by it.
 siblings=$(keys_matching "$key" \
     | grep -E "^${key}-([0-9]{4}-[0-9]{2}-[0-9]{2}T|[0-9]{8}$)" || true)
 if [ -n "$siblings" ]; then
@@ -52,12 +36,11 @@ if [ -n "$siblings" ]; then
     done <<< "$siblings"
 fi
 
-# Anything else sharing the prefix is not a leftover and not expected. Report it
-# rather than guess: a key nobody predicted is worth a human reading it.
+# Shares the prefix and is not a dated leftover. Stop and let someone look.
 unexpected=$(keys_matching "$key" | grep -vx "$key" \
     | grep -Ev "^${key}-([0-9]{4}-[0-9]{2}-[0-9]{2}T|[0-9]{8}$)" || true)
 if [ -n "$unexpected" ]; then
-    echo "entries share the prefix '$key' and are neither it nor dated leftovers:" >&2
+    echo "unexpected entries sharing the prefix '$key':" >&2
     echo "$unexpected" | sed 's/^/  /' >&2
     exit 1
 fi
@@ -70,8 +53,7 @@ fi
 gh cache delete "$key" -R "$repo"
 
 if [ -n "$(keys_matching "$key" | grep -x "$key" || true)" ]; then
-    echo "'$key' survived the delete: the save that follows would be a silent" >&2
-    echo "no-op and the cache would freeze. Failing rather than continuing." >&2
+    echo "'$key' survived the delete; the save after it would do nothing" >&2
     exit 1
 fi
 

--- a/.github/scripts/drop_cache_key.sh
+++ b/.github/scripts/drop_cache_key.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Removes the cache entry a save is about to replace, so a family keeps one entry
+# rather than accumulating a copy per merge.
+#
+# Cache keys are immutable: a save can only add, never update. Anything that saves
+# on every merge therefore grows until the repository passes GitHub's 10 GB limit
+# and eviction starts removing entries nobody chose -- the conan ones first, since
+# they are written least often and are what decides whether a lane takes five
+# minutes or twenty-eight.
+#
+# Two things here are load-bearing rather than defensive.
+#
+# It refuses to run anywhere but main. Every save this accompanies is gated to
+# main, and a delete that is not gated the same way removes the shared entry from
+# any branch and puts nothing back -- measured, and the run reports success, so
+# there is no red check to catch it. Enforcing that here means a workflow that
+# forgets the condition is harmless instead of destructive.
+#
+# It confirms the entry is gone. actions/cache downgrades a failed save to a
+# warning, so a delete that quietly stopped working would leave every later save a
+# silent no-op and freeze the cache -- builds slowly getting worse with nothing
+# red. Failing here is what turns that into something visible.
+set -euo pipefail
+
+key="${1:?usage: drop_cache_key.sh <key>}"
+: "${GH_TOKEN:?GH_TOKEN must be set}"
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+
+if [ "${GITHUB_REF:-}" != "refs/heads/main" ]; then
+    echo "not on main (${GITHUB_REF:-unset}); leaving '$key' alone"
+    exit 0
+fi
+
+keys_matching() {
+    gh api "/repos/$repo/actions/caches" --paginate \
+        --jq ".actions_caches[] | select(.key | startswith(\"$1\")) | .key" 2>/dev/null || true
+}
+
+# A stable key has one entry. Anything else sharing its prefix is a leftover from
+# when the key carried a timestamp or a date, so this drops them too -- otherwise
+# the first run after the change would trip over entries the change exists to stop
+# creating. The suffix is matched exactly rather than by prefix alone, so a family
+# whose name merely begins with this one cannot be caught by it.
+siblings=$(keys_matching "$key" \
+    | grep -E "^${key}-([0-9]{4}-[0-9]{2}-[0-9]{2}T|[0-9]{8}$)" || true)
+if [ -n "$siblings" ]; then
+    echo "dated leftovers under '$key', removing:"
+    while IFS= read -r old_key; do
+        [ -z "$old_key" ] && continue
+        echo "  $old_key"
+        gh cache delete "$old_key" -R "$repo" >/dev/null 2>&1 || true
+    done <<< "$siblings"
+fi
+
+# Anything else sharing the prefix is not a leftover and not expected. Report it
+# rather than guess: a key nobody predicted is worth a human reading it.
+unexpected=$(keys_matching "$key" | grep -vx "$key" \
+    | grep -Ev "^${key}-([0-9]{4}-[0-9]{2}-[0-9]{2}T|[0-9]{8}$)" || true)
+if [ -n "$unexpected" ]; then
+    echo "entries share the prefix '$key' and are neither it nor dated leftovers:" >&2
+    echo "$unexpected" | sed 's/^/  /' >&2
+    exit 1
+fi
+
+if [ -z "$(keys_matching "$key" | grep -x "$key" || true)" ]; then
+    echo "no entry under '$key'; nothing to drop"
+    exit 0
+fi
+
+gh cache delete "$key" -R "$repo"
+
+if [ -n "$(keys_matching "$key" | grep -x "$key" || true)" ]; then
+    echo "'$key' survived the delete: the save that follows would be a silent" >&2
+    echo "no-op and the cache would freeze. Failing rather than continuing." >&2
+    exit 1
+fi
+
+echo "dropped '$key'"

--- a/.github/workflows/conan.yaml
+++ b/.github/workflows/conan.yaml
@@ -102,7 +102,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: .github/scripts/drop_cache_key.sh "conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}"
+        run: bash .github/scripts/drop_cache_key.sh "conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}"
 
       - name: Save conan packages
         if: always() && github.ref == 'refs/heads/main'

--- a/.github/workflows/conan.yaml
+++ b/.github/workflows/conan.yaml
@@ -57,10 +57,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate daily cache id
-        shell: bash
-        run: echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_ENV"
-
       # Same key scheme as standard_test.yaml so both workflows share one
       # dependency slice per compiler (dependencies are always Release), and
       # the same save-only-on-main split, for the same reason.
@@ -68,8 +64,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.conan2/p
-          key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ env.cache_date }}
-          restore-keys: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-
+          key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}
 
       - name: Setup build context
         uses: ./.github/actions/setup_build_context
@@ -102,9 +97,16 @@ jobs:
           conan cache clean "*" -s -b -d
 
       # After the clean, so sen itself and the build folders stay out.
+      - name: Drop the entry this save replaces
+        if: always() && github.ref == 'refs/heads/main'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: .github/scripts/drop_cache_key.sh "conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}"
+
       - name: Save conan packages
         if: always() && github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.conan2/p
-          key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ env.cache_date }}
+          key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}

--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -40,10 +40,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate daily cache id
-        shell: bash
-        run: echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_ENV"
-
       # prepare_build would be the obvious thing to reuse here, but it saves at the
       # end of the job, and a cache written from a pull request is private to it:
       # every open pull request storing its own slice puts the repository past
@@ -55,8 +51,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.conan2/p
-          key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17-${{ env.cache_date }}
-          restore-keys: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17-
+          key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17
 
       # No ccache: sanitized object files must not land in the entries the
       # ordinary builds depend on. Same rule as the nightly's sanitizer lanes.
@@ -152,9 +147,16 @@ jobs:
           conan cache clean "*" -s -b -d
           IN
 
+      - name: Drop the entry this save replaces
+        if: always() && github.ref == 'refs/heads/main'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: .github/scripts/drop_cache_key.sh "conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17"
+
       - name: Save conan packages
         if: always() && github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.conan2/p
-          key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17-${{ env.cache_date }}
+          key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17

--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -152,7 +152,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: .github/scripts/drop_cache_key.sh "conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17"
+        run: bash .github/scripts/drop_cache_key.sh "conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17"
 
       - name: Save conan packages
         if: always() && github.ref == 'refs/heads/main'

--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -57,10 +57,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate daily cache id
-        shell: bash
-        run: echo "cache_date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_ENV"
-
       # Dependencies are always Release, so one slice serves the Debug and
       # Release jobs of a compiler alike.
       #
@@ -71,13 +67,13 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.conan2/p
-          key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ env.cache_date }}
-          restore-keys: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-
+          key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}
 
       - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
         if: runner.os == 'Linux'
         with:
           key: ${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ matrix.build_type }}
+          append-timestamp: false
           max-size: 1G
           verbose: 1
           # Same reasoning as the conan cache above.
@@ -258,9 +254,23 @@ jobs:
 
       # After the clean, so build folders stay out. always() keeps what a
       # cancelled run already built.
+      - name: Drop the ccache entry this run replaces
+        if: always() && runner.os == 'Linux' && github.ref == 'refs/heads/main'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: .github/scripts/drop_cache_key.sh "ccache-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ matrix.build_type }}"
+
+      - name: Drop the entry this save replaces
+        if: always() && github.ref == 'refs/heads/main'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: .github/scripts/drop_cache_key.sh "conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}"
+
       - name: Save conan packages
         if: always() && github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.conan2/p
-          key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ env.cache_date }}
+          key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}

--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -259,14 +259,14 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: .github/scripts/drop_cache_key.sh "ccache-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ matrix.build_type }}"
+        run: bash .github/scripts/drop_cache_key.sh "ccache-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ matrix.build_type }}"
 
       - name: Drop the entry this save replaces
         if: always() && github.ref == 'refs/heads/main'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: .github/scripts/drop_cache_key.sh "conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}"
+        run: bash .github/scripts/drop_cache_key.sh "conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}"
 
       - name: Save conan packages
         if: always() && github.ref == 'refs/heads/main'


### PR DESCRIPTION
GitHub cache keys are immutable: a save can only add an entry, never update one.
Both cache families carried a date or a timestamp in the key, so every merge to
main left another copy. The repository reached 11.71 GB against a 10 GB limit
today, past which entries are evicted at random, and the conan ones go first
because they are written least often.

The keys are now stable and the entry is deleted immediately before the save that
replaces it, so each family holds one. Entries left over from the dated scheme are
removed on the first run, matching the date suffix exactly so that a family whose
name begins with another is not caught by it.

`drop_cache_key.sh` refuses to run anywhere but main: an ungated delete takes the
shared entry from any branch, and the run still reports success. It also checks the
entry is gone afterwards, because a failed save is only a warning and would leave
the cache frozen with nothing to show for it.
