### PR TITLE
ci: clear the cache entries left by a bare trailing dash

### DIFF
--- a/.github/scripts/drop_cache_key.sh
+++ b/.github/scripts/drop_cache_key.sh
@@ -36,10 +36,12 @@ if ! before=$(list_entries 2>&1); then
     exit 1
 fi
 
-# The exact key, and anything under it carrying the date a save appends. Matched
-# by shape so a family whose name merely extends this one is not caught.
+# The exact key, anything under it carrying the date a save appends, and the bare
+# trailing dash left by a brief spell of append-timestamp: false. Matched by shape,
+# and each alternative ends the string, so a family whose name merely extends this
+# one is not caught.
 doomed=$(printf '%s\n' "$before" \
-    | grep -E " ${key}$| ${key}-([0-9]{4}-[0-9]{2}-[0-9]{2}T|[0-9]{8}$)" || true)
+    | grep -E " ${key}$| ${key}-$| ${key}-([0-9]{4}-[0-9]{2}-[0-9]{2}T|[0-9]{8}$)" || true)
 
 if [ -z "$doomed" ]; then
     echo "nothing under '$key'"


### PR DESCRIPTION
Two entries will never be cleaned:

    759 MB  ccache-ubuntu-22.04-gcc-12-17-Release-
    967 MB  ccache-ubuntu-24.04-clang-20-17-Debug-

They date from the short period when `append-timestamp: false` was set, which
produced keys ending in a dash with nothing after it. The drop matches the exact
key or `key-<date>`, and a bare trailing dash is neither, so 1.7 GB would sit
there until it aged out.

The pattern now has a third alternative for that shape. Each alternative ends the
string, so a sibling such as `...-Release-extra` is still left alone.
