### PR TITLE
fix(util): drop an include nothing in the file uses

### DIFF
--- a/libs/util/src/dr/dead_reckoner_impl.cpp
+++ b/libs/util/src/dr/dead_reckoner_impl.cpp
@@ -8,7 +8,6 @@
 #include "sen/util/dr/detail/dead_reckoner_impl.h"
 
 // sen
-#include "sen/core/base/checked_conversions.h"
 #include "sen/core/base/numbers.h"
 #include "sen/util/dr/algorithms.h"
 


### PR DESCRIPTION
The dead reckoner stopped using checked_conversions when the orientation
conversions were reworked, and the include stayed. It is the only finding on the
nightly's clang-tidy lane.

Verified beyond the tool's word: no symbol from that header appears in the file,
the full build succeeds without it, and the dead-reckoning tests pass.
