### PR TITLE
ci: grant the nightly's packaging job the cache permission

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -248,6 +248,12 @@ jobs:
   # only the configuration that ships.
   packaging:
     uses: ./.github/workflows/conan.yaml
+    # A called workflow cannot hold more than its caller grants, and this one
+    # drops the cache entry its save replaces. Without this the whole nightly
+    # fails to start, with no jobs and nothing in the log to say why.
+    permissions:
+      contents: read
+      actions: write
 
   # Sen promises consumers "at least C++17", and they compile its headers in
   # their own dialect. Building Sen itself at C++20 compiles those headers the


### PR DESCRIPTION
conan.yaml asks for actions: write to drop the cache entry its save replaces. main.yaml grants that where it calls it; the nightly calls the same workflow and did not, and a called workflow cannot hold more than its caller grants. The run failed before any job existed, so nothing was logged and only the web UI named the cause.