### PR TITLE
fix(cli): reject unknown arguments instead of dropping them

### DIFF
--- a/apps/cli_gen/src/cpp_cli.cpp
+++ b/apps/cli_gen/src/cpp_cli.cpp
@@ -91,7 +91,6 @@ void setupCppCli(CLI::App& app)
   auto cppExtraArgs = std::make_shared<CppExtraArgs>();
 
   auto cpp = app.add_subcommand("cpp", "Generate C++ code");
-  cpp->allow_extras();
   cpp->require_subcommand();
 
   cpp->add_option("-r, --recursive", cppExtraArgs->recursive, "Recursively generate imported packages");

--- a/apps/cli_gen/src/json_cli.cpp
+++ b/apps/cli_gen/src/json_cli.cpp
@@ -97,7 +97,6 @@ void setupGenJsonPackage(CLI::App& app)
 {
   auto pkgArgs = std::make_shared<JsonPackageArgs>();
   auto pkg = app.add_subcommand("package", "Generate JSON schemas for packages");
-  pkg->allow_extras();
   pkg->require_subcommand();
 
   auto stl = setupStlInput(*pkg,
@@ -129,7 +128,6 @@ void setupGenJsonComponent(CLI::App& app)
 {
   auto compArgs = std::make_shared<JsonComponentArgs>();
   auto comp = app.add_subcommand("component", "Generate JSON schemas for components");
-  comp->allow_extras();
   comp->require_subcommand();
 
   auto stl = setupStlInput(*comp,
@@ -161,7 +159,6 @@ void setupGenJsonSchema(CLI::App& app)
 {
   auto schemaArgs = std::make_shared<JsonSchemaArgs>();
   auto schema = app.add_subcommand("schema", "Generate JSON schemas for sen configurations");
-  schema->allow_extras();
 
   schema->add_option("schema_files", schemaArgs->schemas, "JSON schema files")->required()->check(CLI::ExistingFile);
 
@@ -192,7 +189,6 @@ void setupGenJsonSchema(CLI::App& app)
 void setupJsonCli(CLI::App& app)
 {
   auto json = app.add_subcommand("json", "Generate JSON schemas");
-  json->allow_extras();
   json->require_subcommand();
 
   setupGenJsonPackage(*json);

--- a/apps/cli_gen/src/mkdocs_cli.cpp
+++ b/apps/cli_gen/src/mkdocs_cli.cpp
@@ -61,7 +61,6 @@ void setupMkDocsCli(CLI::App& app)
 {
   auto mkdocsArgs = std::make_shared<MkDocsArgs>();
   auto mkdocs = app.add_subcommand("mkdocs", "Generate MkDocs documentation");
-  mkdocs->allow_extras();
   mkdocs->require_subcommand();
 
   auto stl = setupStlInput(*mkdocs,

--- a/apps/cli_gen/src/plantuml_cli.cpp
+++ b/apps/cli_gen/src/plantuml_cli.cpp
@@ -86,7 +86,6 @@ void setupPlantUMLCli(CLI::App& app)
 {
   auto umlArgs = std::make_shared<UmlArgs>();
   auto uml = app.add_subcommand("uml", "Generate UML diagrams");
-  uml->allow_extras();
   uml->require_subcommand();
 
   auto stl = setupStlInput(*uml,

--- a/apps/cli_gen/src/python_cli.cpp
+++ b/apps/cli_gen/src/python_cli.cpp
@@ -54,7 +54,6 @@ namespace sen::cli_gen
 void setupPythonCli(CLI::App& app)
 {
   auto py = app.add_subcommand("py", "Generate Python dataclasses");
-  py->allow_extras();
   py->require_subcommand();
 
   auto stl = setupStlInput(*py,

--- a/apps/cli_gen/src/typescript_cli.cpp
+++ b/apps/cli_gen/src/typescript_cli.cpp
@@ -51,7 +51,6 @@ namespace sen::cli_gen
 void setupTypeScriptCli(CLI::App& app)
 {
   auto ts = app.add_subcommand("ts", "Generate per-input TypeScript modules + a barrel from STL inputs");
-  ts->allow_extras();
   ts->require_subcommand();
 
   auto outDir = std::make_shared<std::string>();

--- a/apps/cli_gen/test/CMakeLists.txt
+++ b/apps/cli_gen/test/CMakeLists.txt
@@ -428,3 +428,31 @@ add_sen_integration_test(
   REQ_DEPS cli_gen
 )
 set_tests_properties(ts_gen_structure PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1")
+
+# An unrecognised flag must be rejected rather than collected and dropped. These two run as a
+# pair: the first fixes the invocation as valid, so the second can only fail because of the
+# flag. WILL_FAIL on its own cannot tell a rejected flag from a missing file.
+add_sen_cli_gen_smoke_test(
+  uml_gen_smoke_only_classes
+  COMMAND ./cli_gen uml stl ${hla_fom_gen_test_sources}/typescript/fixture.stl -o uml_smoke_only_classes.uml
+          --only-classes
+  WORKING_DIRECTORY ${working_dir}
+)
+
+add_sen_cli_gen_smoke_test(
+  uml_gen_smoke_rejects_unknown_flag
+  COMMAND ./cli_gen uml stl ${hla_fom_gen_test_sources}/typescript/fixture.stl -o uml_smoke_rejected.uml
+          --classes-only
+  WORKING_DIRECTORY ${working_dir}
+)
+set_tests_properties(uml_gen_smoke_rejects_unknown_flag PROPERTIES WILL_FAIL TRUE)
+
+# A second generator, because the flag was swallowed by whichever subcommand allowed extras and
+# every generator set that separately.
+add_sen_cli_gen_smoke_test(
+  ts_gen_smoke_rejects_unknown_flag
+  COMMAND ./cli_gen ts stl ${hla_fom_gen_test_sources}/typescript/fixture.stl -d ts_smoke_rejected
+          --not-a-real-flag
+  WORKING_DIRECTORY ${working_dir}
+)
+set_tests_properties(ts_gen_smoke_rejects_unknown_flag PROPERTIES WILL_FAIL TRUE)

--- a/apps/cli_sen/CMakeLists.txt
+++ b/apps/cli_sen/CMakeLists.txt
@@ -23,3 +23,7 @@ set_target_properties(cli_sen PROPERTIES RUNTIME_OUTPUT_NAME sen)
 sen_internal_configure_app(cli_sen)
 sen_enable_static_analysis(cli_sen)
 sen_internal_install(cli_sen)
+
+if(SEN_BUILD_TESTS)
+  add_subdirectory(test)
+endif()

--- a/apps/cli_sen/main.cpp
+++ b/apps/cli_sen/main.cpp
@@ -23,8 +23,10 @@
 #endif
 
 // std
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <exception>
 #include <filesystem>
 #include <iostream>
@@ -59,10 +61,22 @@ void runChildProcess(const char* binPath, int argc, char* argv[])
   cmdVec.push_back(nullptr);
 
 #ifdef WIN32
+  // -1 is also what a child returning -1 gives back, so errno is what separates the two. It is
+  // cleared first because a stale value from anything earlier would read as a spawn failure.
+  errno = 0;
   auto rc = _spawnv(_P_WAIT, binPath, cmdVec.data());
-  exit(rc);
+  if (rc == -1 && errno != 0)
+  {
+    std::cerr << "sen: cannot run " << binPath << ": " << std::strerror(errno) << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  exit(static_cast<int>(rc));
 #else
+  // execv returns only when the child could not be started, so anything after it is a failure
+  // path. Without this a missing binary left the caller exiting zero having done nothing.
   execv(binPath, cmdVec.data());
+  std::cerr << "sen: cannot run " << binPath << ": " << std::strerror(errno) << std::endl;
+  exit(EXIT_FAILURE);
 #endif
 }
 

--- a/apps/cli_sen/test/CMakeLists.txt
+++ b/apps/cli_sen/test/CMakeLists.txt
@@ -1,0 +1,58 @@
+# === CMakeLists.txt ===================================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+
+# `sen generate` hands over to the cli_gen binary sitting beside it, and the shortcuts do the same
+# for theirs. Running a copy from a directory where that sibling is absent is the only way to reach
+# the failure path, since the lookup goes through the running executable's own location.
+#
+# The copy is a fixture rather than part of the command, because a test runs one command.
+set(isolated_sen_dir ${CMAKE_CURRENT_BINARY_DIR}/isolated_sen)
+
+add_test(NAME sen_missing_generator_setup COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:sen::cli_sen>
+                                                  ${isolated_sen_dir}/$<TARGET_FILE_NAME:sen::cli_sen>
+)
+set_tests_properties(
+  sen_missing_generator_setup
+  PROPERTIES FIXTURES_SETUP
+             isolated_sen
+             LABELS
+             smoke
+)
+
+# Registered with a bare add_test, so it misses what the helpers give every other test. Without
+# this it carries no log_path and check_sanitizer_lane.py fails the lane, correctly: a finding
+# here would reach nobody.
+add_sanitizer_options(sen_missing_generator_setup)
+
+# Matching the diagnostic rather than gating on the exit code alone: the defect this covers
+# exited zero AND printed nothing, so an empty output must not be able to pass.
+add_sen_smoke_test(
+  sen_missing_generator_reports
+  COMMAND ${isolated_sen_dir}/$<TARGET_FILE_NAME:sen::cli_sen> generate mkdocs fom -d
+          ${CMAKE_CURRENT_BINARY_DIR} -t ${CMAKE_CURRENT_BINARY_DIR} -o ${CMAKE_CURRENT_BINARY_DIR}/unused.md
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} REQ_DEPS cli_sen
+)
+set_tests_properties(
+  sen_missing_generator_reports
+  PROPERTIES FIXTURES_REQUIRED
+             isolated_sen
+             PASS_REGULAR_EXPRESSION
+             "cannot run.*cli_gen"
+)
+
+# The copy is moved away from its libraries, so the loader needs pointing back at them. Windows
+# searches the executable's own directory and PATH and has no rpath, which is the same reason
+# add_sen_unit_test_suite appends bin/ there.
+if(WIN32)
+  append_test_env_modification(
+    sen_missing_generator_reports "PATH=path_list_prepend:$<TARGET_FILE_DIR:sen::cli_sen>"
+  )
+else()
+  append_test_env_modification(
+    sen_missing_generator_reports "LD_LIBRARY_PATH=path_list_prepend:$<TARGET_FILE_DIR:sen::cli_sen>"
+  )
+endif()


### PR DESCRIPTION
Two ways the command line reported success while doing the wrong thing.

**An unknown flag was accepted and dropped.** Every generator subcommand called
`allow_extras()`, so an argument the parser did not recognise was collected instead of
rejected, and nothing ever read what was collected. A near miss like `--classes-only`
for `--only-classes` was therefore accepted, ignored, and the generator ran with its
default mode — which for UML is "generate everything", so the output was the whole model
instead of the classes. Exit zero, no warning, and nothing to distinguish the run from a
correct one except knowing the expected file size.

The leaf subcommands never set it; the containers did, and an unrecognised flag on a leaf
bubbles up to its parent. Removing the call lets CLI11 report the flag by name.

**A missing generator looked like a successful run.** `sen generate` hands over to the
`cli_gen` binary beside it. `execv` returns only when it could not start the child, and
that return was unchecked, so a missing binary meant the callback finished and the process
exited zero having written nothing. It now reports the path it could not run and fails.
The Windows branch already exited non-zero but said nothing; it now reports too, and
distinguishes a spawn failure from a child that returned -1 by checking `errno`.

Tests: three covering flag rejection, one covering the missing binary. Each was run
against the unfixed code first and observed to fail. The positive case is deliberate —
it fixes the invocation as valid so the negative cases can only fail because of the flag,
which `WILL_FAIL` alone cannot distinguish.

The pass-through subcommands in `cli_sen` keep `allow_extras()`: `sen shell` and the other
shortcuts forward their arguments to another program and cannot know what it accepts.
`cli_run` has a weaker form of the same defect and is left for a separate change, since it
does read the extras, though only to match one literal string.
