### PR TITLE
ci: fix two gaps in the cache-drop step

### DIFF
--- a/.github/scripts/drop_cache_key.sh
+++ b/.github/scripts/drop_cache_key.sh
@@ -18,6 +18,9 @@ set -euo pipefail
 key="${1:?usage: drop_cache_key.sh <key>}"
 : "${GH_TOKEN:?GH_TOKEN must be set}"
 repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+# Endpoints have no leading slash: this runs on Windows too, where git bash
+# rewrites a leading-slash argument into a filesystem path and gh is handed
+# "C:/Program Files/Git/repos/...".
 
 if [ "${GITHUB_REF:-}" != "refs/heads/main" ]; then
     echo "not on main (${GITHUB_REF:-unset}); leaving '$key' alone"
@@ -25,7 +28,7 @@ if [ "${GITHUB_REF:-}" != "refs/heads/main" ]; then
 fi
 
 list_entries() {
-    gh api "/repos/$repo/actions/caches" --paginate \
+    gh api "repos/$repo/actions/caches" --paginate \
         --jq '.actions_caches[] | "\(.id) \(.key)"'
 }
 
@@ -50,7 +53,7 @@ fi
 
 printf '%s\n' "$doomed" | while read -r id name; do
     [ -z "$id" ] && continue
-    if gh api -X DELETE "/repos/$repo/actions/caches/$id" >/dev/null 2>&1; then
+    if gh api -X DELETE "repos/$repo/actions/caches/$id" >/dev/null 2>&1; then
         echo "  dropped $name"
     else
         echo "  already gone, or another job took it: $name"

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -16,6 +16,8 @@ on:
 
 permissions:
   contents: read
+  # build_documentation drops the cache entries its saves replace.
+  actions: write
 
 jobs:
   build_docs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -143,6 +143,9 @@ jobs:
       needs.detect-changes.outputs.docs == 'true' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     uses: ./.github/workflows/docs_check.yaml
+    permissions:
+      contents: read
+      actions: write
 
   # A change to the build environment has to prove the image still builds and
   # still holds the tools it promises. ci-ok needs this job, so a broken image

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -243,6 +243,9 @@ jobs:
   # watch, for example doxygen comments in headers.
   docs-build:
     uses: ./.github/workflows/docs_check.yaml
+    permissions:
+      contents: read
+      actions: write
 
   # Every packaged configuration, which a pull request does not run: it builds
   # only the configuration that ships.


### PR DESCRIPTION
The endpoints passed to gh began with a slash, which git bash reads as an
absolute path and rewrites, so gh was handed a filesystem path. The script then
reported that it could not list caches and failed the step, as it is meant to
when it cannot tell an empty cache from a refused call. That has failed every
push to main since the drop step landed.

Separately, build_documentation also drops cache entries and so needs
actions: write, which neither caller of docs_check.yaml granted. It stayed
hidden because the script exits early off main and main.yaml's docs job does not
run on push, so only the nightly reached it. docs_check.yaml now declares the
permission, which turns a silent mid-build failure into a startup one.
