### PR TITLE
fix(kernel): stop a throwing accessor escaping a noexcept sleep

### DIFF
--- a/libs/kernel/src/executor.cpp
+++ b/libs/kernel/src/executor.cpp
@@ -112,8 +112,7 @@ void Executor::startUp(bool tryToLockPages, bool tryToLimitCpuIdleLatency)
     // applies to the whole machine, for as long as the descriptor is held.
     if (tryToLimitCpuIdleLatency && cpuIdleLatencyFd_ == -1)
     {
-      cpuIdleLatencyFd_ =
-        ::open("/dev/cpu_dma_latency", O_WRONLY | O_CLOEXEC);  // NOLINT(cppcoreguidelines-pro-type-vararg)
+      cpuIdleLatencyFd_ = ::open("/dev/cpu_dma_latency", O_WRONLY | O_CLOEXEC);  // NOLINT(hicpp-vararg)
       const int32_t noLatency = 0;
       if (cpuIdleLatencyFd_ == -1 || ::write(cpuIdleLatencyFd_, &noLatency, sizeof(noLatency)) != sizeof(noLatency))
       {

--- a/libs/kernel/src/precision_sleeper.h
+++ b/libs/kernel/src/precision_sleeper.h
@@ -271,7 +271,7 @@ inline PrecisionSleeper::PrecisionSleeper(WallClock& wallClock, const std::strin
   // Linux pads every timer request with 50us of slack by default, which lands inside the window
   // this class protects. Asking for none of it shortens how early the spin has to start.
 #if defined(__linux__)
-  std::ignore = ::prctl(PR_SET_TIMERSLACK, 1UL, 0UL, 0UL, 0UL);
+  std::ignore = ::prctl(PR_SET_TIMERSLACK, 1UL, 0UL, 0UL, 0UL);  // NOLINT(hicpp-vararg)
 #endif
 
   // Seed once the configured times have settled, from the sleep about to be measured: a seed above
@@ -287,7 +287,10 @@ inline void PrecisionSleeper::doSleepWithPrecision(NanoSecs duration) noexcept
 
   SystemSleepOps ops {*this, wallClock_};
 
-  auto& cost = sleepCost_.value();
+  // Engaged by the constructor before anything can reach here, and never reset, so the checked
+  // accessor only adds a throw this noexcept function would have to terminate on.
+  SEN_DEBUG_ASSERT(sleepCost_.has_value());
+  auto& cost = *sleepCost_;
   cost.decay();
 
   duration = stepDownWith(duration, precisionSleepTimes_.coarseGrain, cost, ops);


### PR DESCRIPTION
The nightly's clang-tidy lane fails to build on three errors in kernel code. Two are
suppressions that never worked; one is a real path to `std::terminate`.

**A throwing accessor inside a `noexcept` function.** `PrecisionSleeper::doSleepWithPrecision` is `noexcept` and read the sleep cost through `std::optional::value()`, which throws `std::bad_optional_access` on an empty optional — and a throw escaping a `noexcept` function terminates. Every other call it makes is `noexcept`, so that was the only escape.

The optional is always engaged when this runs: `sleepFunc_` is bound in the constructor's initialiser list, `sleepCost_.emplace` happens in the constructor body, it is never reset, and the function is only reachable through `sleep()` on a constructed object. So the unchecked accessor is correct, with a `SEN_DEBUG_ASSERT` recording the invariant. `senCheckImpl` is itself `noexcept`, so the assert cannot reintroduce the escape it guards.