### PR TITLE
ci: run every check on main, not two of five

### DIFF
--- a/.github/scripts/generate_matrix_jobs.py
+++ b/.github/scripts/generate_matrix_jobs.py
@@ -77,6 +77,9 @@ class JobSelector:
     include_in_conan_workflow: bool
     include_in_conan_workflow_on_pull_requests: bool
     include_in_standard_test_workflow: bool
+    # True on every leg, and a test holds it that way: main has to run what a
+    # pull request runs, or a merge that bypasses the queue lands a combination
+    # nothing has tested.
     include_in_standard_test_workflow_also_main: bool
 
 
@@ -102,7 +105,7 @@ SPECIFIED_JOBS = [
         include_in_conan_workflow=True,
         include_in_conan_workflow_on_pull_requests=False,
         include_in_standard_test_workflow=True,
-        include_in_standard_test_workflow_also_main=False,
+        include_in_standard_test_workflow_also_main=True,
     ),
     JobSelector(
         job_spec=JobSpecification(
@@ -163,7 +166,7 @@ SPECIFIED_JOBS = [
         include_in_conan_workflow=True,
         include_in_conan_workflow_on_pull_requests=False,
         include_in_standard_test_workflow=True,
-        include_in_standard_test_workflow_also_main=False,
+        include_in_standard_test_workflow_also_main=True,
     ),
     # Add arm jobs
     JobSelector(
@@ -182,7 +185,7 @@ SPECIFIED_JOBS = [
         include_in_conan_workflow=False,
         include_in_conan_workflow_on_pull_requests=False,
         include_in_standard_test_workflow=True,
-        include_in_standard_test_workflow_also_main=False,
+        include_in_standard_test_workflow_also_main=True,
     ),
 ]
 

--- a/.github/scripts/test_generate_matrix_jobs.py
+++ b/.github/scripts/test_generate_matrix_jobs.py
@@ -30,10 +30,17 @@ def test_standard_test_job_set():
     assert job_keys(jobs) == [CLANG_COVERAGE, GCC_DEBUG, GCC_RELEASE, ARM_DEBUG, MSVC_RELEASE]
 
 
-def test_standard_test_main_job_set():
-    """Post-merge main builds run the coverage leg and the shipping leg."""
-    jobs = compute_jobs(release=False, conan=False, standard_test=True, target_main=True)
-    assert job_keys(jobs) == [CLANG_COVERAGE, GCC_RELEASE]
+def test_main_runs_what_pull_requests_run():
+    """A push to main runs the same legs as a pull request.
+
+    A pull request is tested against main as it was. What lands is that change
+    combined with whatever main became since, and only a run on main sees that
+    combination. The merge queue would test it too, but a merge that bypasses
+    the queue leaves no other lane that does.
+    """
+    on_pull_request = compute_jobs(release=False, conan=False, standard_test=True, target_main=False)
+    on_main = compute_jobs(release=False, conan=False, standard_test=True, target_main=True)
+    assert job_keys(on_main) == job_keys(on_pull_request)
 
 
 def test_conan_job_set():


### PR DESCRIPTION
A pull request is tested against main as it was. What lands is that change
combined with whatever main became since, and only a run on main sees that
combination.

The merge queue tests it as well: a queue branch is `gh-readonly-queue/...`,
which does not match the `refs/heads/main` check, so the queue runs the full
matrix. That made the reduced run on main a cheap re-check rather than a gap.

Merges here bypass the queue, which removes the only lane that tested the merged
combination. #255, #263, #270 and #271 have no `added_to_merge_queue` event;
#127 does, so the event is recorded when the queue is used.

So Windows, arm and the gcc Debug leg now run on main too. #263 is the case that
makes it concrete: it enabled Windows testing and landed without the Windows leg
running against its own merge result.

The test now asserts the two sets are equal rather than listing them, so the
main set cannot drift away from the pull-request set unnoticed.
