### PR TITLE
fix(ether): stop entering discovery under the transport lock

### DIFF
--- a/cmake/util/tsan_ignorelist.txt
+++ b/cmake/util/tsan_ignorelist.txt
@@ -7,9 +7,6 @@ deadlock:sen::kernel::impl::RemoteParticipant::onObjectsAdded*
 # TODO(SEN-1505):  fix deadlock
 deadlock:sen::kernel::impl::Bus::isObjectNameUsedLocally*
 
-# TODO(SEN-1506):  fix deadlock
-deadlock:sen::components::ether::EtherTransport::detectedNewProcess*
-
 # TODO(SEN-1510): fix thread leak
 thread:sen::components::ether::EtherTransport::start*
 

--- a/components/ether/src/ether_transport.cpp
+++ b/components/ether/src/ether_transport.cpp
@@ -151,12 +151,15 @@ EtherTransport::~EtherTransport() { logger_->debug("transport: deleted"); }
 
 void EtherTransport::stop() noexcept
 {
+  logger_->debug("transport: stop started");
+
+  // Outside procMutex_: discovery notifies its listeners under its own lock and those callbacks
+  // come back here for procMutex_, so holding it across these two inverts the order.
+  discovery_->removeListener(this, false);
+  discovery_->stopBeaming(ownInfo_);
+
   {
     Lock procLock(procMutex_);
-
-    logger_->debug("transport: stop started");
-    discovery_->removeListener(this, false);
-    discovery_->stopBeaming(ownInfo_);
 
     // signal the i/o to stop accepting new requests
     if (io_)


### PR DESCRIPTION
`EtherTransport::procMutex_` and `DiscoverySystem::usageMutex_` were taken in both orders:

    EtherTransport::stop()
      Lock procLock(procMutex_);
      discovery_->removeListener(this, false);      // wants usageMutex_

    DiscoverySystem::removeBeam()
      Lock lock(usageMutex_);
      for (auto* listener: listeners_) listener->beamLost(processInfo);
                        // -> EtherTransport::beamLost -> lostExistingProcess -> procMutex_

`stop()` is the only site taking them in that order; the other two calls into discovery, in `start()`, hold no lock. Moving them above the block removes the edge rather than moving it. Neither needs `procMutex_`, which guards `processes_`, `busMap_` and `readyProcesses_`.

Deregistering first also stops events arriving while the state below is dismantled. `removeListener` still returns only after a callback in flight has finished, since every notification loop in `discovery.cpp` runs under `usageMutex_`.

Having discovery copy its listener list and notify after releasing the lock would not work: `DiscoveryEventListener::~DiscoveryEventListener()` calls `removeListener`, so that lock is what keeps a listener alive across the callback.
