### PR TITLE
fix(cli_run): declare --stopped instead of scanning for it

### DIFF
--- a/apps/cli_run/main.cpp
+++ b/apps/cli_run/main.cpp
@@ -73,6 +73,7 @@ struct RunArgs
   std::string preset;
   bool printConfig = false;
   bool noBrowser = false;
+  bool stopped = false;
 };
 
 constexpr auto webExplorerUrl = "http://127.0.0.1:8080/explorer/";
@@ -91,8 +92,7 @@ constexpr auto webExplorerReadyTimeout = std::chrono::seconds(15);
   return true;
 }
 
-std::unique_ptr<sen::kernel::Bootloader> makeBootloader(const std::shared_ptr<RunArgs>& args,
-                                                        [[maybe_unused]] CLI::App& app)
+std::unique_ptr<sen::kernel::Bootloader> makeBootloader(const std::shared_ptr<RunArgs>& args)
 {
   if (args->preset.empty())
   {
@@ -140,16 +140,8 @@ std::unique_ptr<sen::kernel::Bootloader> makeBootloader(const std::shared_ptr<Ru
 #ifdef SEN_CLI_RUN_HAS_REPLAY_PRESET
   if (!presetMatched && args->preset == "replay")
   {
-    bool autoPlay = true;
     const auto autoOpen = args->configFile.string();
-
-    for (const auto& elem: app.remaining())
-    {
-      if (elem == "--stopped")
-      {
-        autoPlay = false;
-      }
-    }
+    const bool autoPlay = !args->stopped;
 
     presetContents = sen::decompressSymbolToString(replay, replaySize);
     std::ignore = replace(presetContents, "$autoOpen", autoOpen);
@@ -347,13 +339,13 @@ void SignalStopper::watch(sen::kernel::Kernel& kernel) noexcept
 //   3       other std::exception escaped from the kernel
 //   4       unknown exception escaped from the kernel
 //   other   kernel.run() returned a non-zero exit code (kernel-defined)
-[[nodiscard]] int runKernel(const std::shared_ptr<RunArgs>& args, CLI::App& app)
+[[nodiscard]] int runKernel(const std::shared_ptr<RunArgs>& args)
 {
   int exitCode = EXIT_FAILURE;
 
   try
   {
-    auto bootloader = makeBootloader(args, app);
+    auto bootloader = makeBootloader(args);
 
     if (!bootloader->getConfig().getParams().crashReportDisabled)
     {
@@ -465,7 +457,6 @@ int runApp(int argc, char* argv[])
 
   CLI::App app {"Run a sen kernel\n"};
   app.name("sen run");
-  app.allow_extras();
   app.get_formatter()->column_width(35);
 
   app.add_option("config", args->configFile, "Configuration file")->check(CLI::ExistingPath);
@@ -491,11 +482,14 @@ int runApp(int argc, char* argv[])
 #ifdef SEN_CLI_RUN_HAS_WEBEXPLORER_PRESET
   app.add_flag("--no-browser", args->noBrowser, "With --preset web-explorer: don't auto-open the URL in a browser");
 #endif
+#ifdef SEN_CLI_RUN_HAS_REPLAY_PRESET
+  app.add_flag("--stopped", args->stopped, "With --preset replay: start paused");
+#endif
   app.add_flag("--print-config", args->printConfig, "Print the configuration that will be used");
 
   CLI11_PARSE(app, argc, argv)
 
-  return runKernel(args, app);
+  return runKernel(args);
 }
 
 }  // namespace


### PR DESCRIPTION
`--stopped` is documented at `docs/components/replaying.md:15` and reaches the replay preset
through the `sen replay` shortcut, but it was never declared as an option. `allow_extras()`
collected it and this scanned the leftovers for the literal string:

    for (const auto& elem: app.remaining())
    {
      if (elem == "--stopped") { autoPlay = false; }
    }

So it never appeared in `sen run --help`, and `--stoppd` was accepted and ignored: the replay
started playing when you asked for it paused.

It is now declared beside `--no-browser`, which is the same shape of preset-specific flag:

    #ifdef SEN_CLI_RUN_HAS_REPLAY_PRESET
      app.add_flag("--stopped", args->stopped, "With --preset replay: start paused");
    #endif

With nothing reading the leftovers, `allow_extras()` comes off and an unrecognised argument is
reported by name. The only flag any documentation passes to `sen run` or its shortcuts is
`--stopped` itself, so nothing documented starts failing.

`makeBootloader` and `runKernel` also lose a `CLI::App&` parameter that existed only to reach
`remaining()`; it was already `[[maybe_unused]]` and is now unused in every configuration.

Measured against a real config:

    --stoppd    exit 109, "The following argument was not expected: --stoppd"
    --stopped   parsed, kernel starts
    --help      now lists the flag

Same defect as #272 fixed in the generators. That one was a plain deletion because nothing read
the extras; here something did, which is why it was left for its own change.
