### PR TITLE
ci: gate clang-tidy on changed lines and clear the backlog

### DIFF
--- a/.github/scripts/analysable_sources.py
+++ b/.github/scripts/analysable_sources.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# === analysable_sources.py ============================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Filters a list of paths down to the ones a compile database has a command for.
+
+clang-tidy can only analyse a translation unit it knows how to compile. Given a header, it falls
+back to a bare invocation with no include paths and no defines, and every check then reports
+nonsense: misc-include-cleaner in particular reports every symbol as unprovided, std::vector
+included. So the changed-lines lane asks this which of the changed files it may pass on.
+
+Reads paths on standard input, one per line, and writes the analysable ones to standard output.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+def analysable(compile_commands: str, paths: list[str]) -> list[str]:
+    """Returns the paths that appear as a translation unit in the compile database."""
+    with open(compile_commands, encoding="utf-8") as handle:
+        entries = json.load(handle)
+
+    # A database entry's "file" may be relative to its "directory", and either side may reach the
+    # same file by a different route, so both are resolved before comparing.
+    known = set()
+    for entry in entries:
+        path = entry["file"]
+        if not os.path.isabs(path):
+            path = os.path.join(entry.get("directory", ""), path)
+        known.add(os.path.realpath(path))
+
+    return [p for p in paths if os.path.realpath(p) in known]
+
+
+def main() -> int:
+    """Filters standard input against the given compile database."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("compile_commands", help="path to compile_commands.json")
+    args = parser.parse_args()
+
+    paths = [line.strip() for line in sys.stdin if line.strip()]
+    for path in analysable(args.compile_commands, paths):
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_analysable_sources.py
+++ b/.github/scripts/test_analysable_sources.py
@@ -1,0 +1,89 @@
+# === test_analysable_sources.py =======================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+"""Pins the filter that keeps headers out of the changed-lines clang-tidy lane.
+
+A header has no entry in the compile database, so clang-tidy falls back to a bare invocation and
+reports every symbol in it as unprovided. That failed the lane on its own pull request.
+"""
+
+import json
+
+from analysable_sources import analysable
+
+
+def write_database(tmp_path, files):
+    """Writes a compile database naming the given files, and returns its path."""
+    database = tmp_path / "compile_commands.json"
+    database.write_text(
+        json.dumps([{"directory": str(tmp_path), "file": str(f), "command": "clang++ -c"} for f in files]),
+        encoding="utf-8",
+    )
+    return str(database)
+
+
+def test_keeps_a_source_the_database_names(tmp_path):
+    """A translation unit the database has a command for is analysable."""
+    source = tmp_path / "a.cpp"
+    source.touch()
+    database = write_database(tmp_path, [source])
+
+    assert analysable(database, [str(source)]) == [str(source)]
+
+
+def test_drops_a_header_the_database_does_not_name(tmp_path):
+    """The case that failed the lane: a changed header has no compile command."""
+    source = tmp_path / "a.cpp"
+    header = tmp_path / "a.h"
+    source.touch()
+    header.touch()
+    database = write_database(tmp_path, [source])
+
+    assert analysable(database, [str(header)]) == []
+
+
+def test_keeps_the_source_and_drops_the_header_together(tmp_path):
+    """A mixed change keeps what can be analysed rather than rejecting the lot."""
+    source = tmp_path / "a.cpp"
+    header = tmp_path / "a.h"
+    source.touch()
+    header.touch()
+    database = write_database(tmp_path, [source])
+
+    assert analysable(database, [str(header), str(source)]) == [str(source)]
+
+
+def test_resolves_a_relative_entry_against_its_directory(tmp_path):
+    """A database may name a file relative to the entry's directory."""
+    source = tmp_path / "a.cpp"
+    source.touch()
+    database = tmp_path / "compile_commands.json"
+    database.write_text(
+        json.dumps([{"directory": str(tmp_path), "file": "a.cpp", "command": "clang++ -c"}]),
+        encoding="utf-8",
+    )
+
+    assert analysable(str(database), [str(source)]) == [str(source)]
+
+
+def test_matches_the_same_file_reached_by_a_different_route(tmp_path):
+    """`a/../a.cpp` and `a.cpp` are one translation unit, not two."""
+    source = tmp_path / "a.cpp"
+    source.touch()
+    database = write_database(tmp_path, [source])
+    indirect = str(tmp_path / "sub" / ".." / "a.cpp")
+    (tmp_path / "sub").mkdir()
+
+    assert analysable(database, [indirect]) == [indirect]
+
+
+def test_returns_nothing_when_no_changed_file_is_a_translation_unit(tmp_path):
+    """The lane must pass rather than analyse nothing and call it clean."""
+    source = tmp_path / "a.cpp"
+    source.touch()
+    database = write_database(tmp_path, [source])
+
+    assert analysable(database, [str(tmp_path / "README.md")]) == []

--- a/.github/workflows/clang_tidy_diff.yaml
+++ b/.github/workflows/clang_tidy_diff.yaml
@@ -1,0 +1,192 @@
+# === clang_tidy_diff.yaml =============================================================================================
+#                                               Sen Infrastructure
+#                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+#                                    See the LICENSE.txt file for more information.
+#                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+# ======================================================================================================================
+#
+# clang-tidy on the lines a pull request changed. The nightly runs the whole tree and only over
+# the targets that opt in; this runs over the compile database, so it also covers the files that
+# never opted in.
+#
+# It configures and builds the generated headers, nothing else: clang-tidy parses the translation
+# units itself and only needs the headers a changed file may include.
+#
+# This gates. The nightly reports a violation a day after it merges, and one finding at a time
+# because ninja stops at the first failure, so it cannot keep the tree clean on its own.
+
+name: clang-tidy on changed lines
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  clang-tidy-diff:
+    name: "clang-tidy (changed lines)"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      # Only the posting step needs this. A pull request from a fork gets a read-only token
+      # whatever this says, so that step tolerates failure and the findings stay in the job log.
+      pull-requests: write
+    env:
+      CC: clang-20
+      CXX: clang++-20
+      # Release to match the nightly. Debug compiles different code -- SEN_DEBUG_ASSERT and the
+      # NDEBUG-gated paths -- so a delta checked in Debug would not agree with what the nightly
+      # analyses. The path follows the profile's build_folder_vars=['settings.compiler'].
+      BUILD_DIR: build/clang/Release
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Prepare the build
+        uses: ./.github/actions/prepare_build
+        with:
+          compiler-name: clang
+          compiler-version: 20
+          runner-label: ubuntu-24.04
+
+      # The scripts ship with the clang-tidy package. Checked rather than assumed: absent, every
+      # command below would report nothing and pass.
+      - name: Locate the clang-tidy helpers
+        shell: bash
+        run: |
+          llvm_share=/usr/lib/llvm-20/share/clang
+          command -v clang-tidy-20 > /dev/null
+          test -f "$llvm_share/clang-tidy-diff.py"
+          echo "CLANG_TIDY_DIFF=$llvm_share/clang-tidy-diff.py" >> "$GITHUB_ENV"
+          # Packaged as a binary on the path in some releases and as a script in others; the
+          # whole-tree scope below needs whichever is here.
+          if command -v run-clang-tidy-20 > /dev/null; then
+            echo "RUN_CLANG_TIDY=run-clang-tidy-20" >> "$GITHUB_ENV"
+          else
+            test -f "$llvm_share/run-clang-tidy.py"
+            echo "RUN_CLANG_TIDY=python3 $llvm_share/run-clang-tidy.py" >> "$GITHUB_ENV"
+          fi
+
+      # The generators script puts Conan's cmake and ninja on the path -- a bare cmake is
+      # whatever the runner image carries, and is a different major version.
+      - name: Configure and build the generated headers
+        shell: bash
+        run: |
+          conan install . -s "&:build_type=Release" --build=missing -o "sen/*:with_tests=True"
+          source "$BUILD_DIR/generators/conanbuild.sh"
+          cmake --preset conan-clang-release
+          # There is no aggregate target for these, so they are enumerated -- by output path,
+          # not by target name. Enumerating names missed the headers that come from a bare
+          # CUSTOM_COMMAND with no target attached, and clang-tidy then cannot parse the unit
+          # that includes one. An empty list would build nothing and pass, so it is rejected.
+          mapfile -t generated < <(
+            ninja -C "$BUILD_DIR" -t targets all \
+              | grep -vE ': (phony|CLEAN|HELP)$' \
+              | sed 's/:.*//' | grep -E '\.(h|hpp|hxx)$' | grep -v '^/' | sort -u
+          )
+          echo "generated headers: ${#generated[@]}"
+          test "${#generated[@]}" -gt 0
+          ninja -C "$BUILD_DIR" "${generated[@]}"
+
+      # The compile database is what both scopes below read. Absent, clang-tidy-diff reports
+      # nothing for every file and the lane passes without analysing a line.
+      - name: Check the compile database exists
+        shell: bash
+        run: |
+          test -s "$BUILD_DIR/compile_commands.json"
+          echo "entries: $(python3 -c "import json,sys;print(len(json.load(open('$BUILD_DIR/compile_commands.json'))))")"
+
+      # A change to the checks themselves invalidates every earlier verdict, so the lane stops
+      # being a diff and reads the whole compile database.
+      - name: Decide the scope
+        id: scope
+        shell: bash
+        env:
+          # One of these is set per event, as classify_changes is given the same way.
+          BASE_SHA: >-
+            ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+        run: |
+          if git diff --name-only "$BASE_SHA...HEAD" | grep -qxF '.clang-tidy'; then
+            echo "full=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "full=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run clang-tidy on the changed lines
+        if: steps.scope.outputs.full == 'false'
+        shell: bash
+        env:
+          BASE_SHA: >-
+            ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+        run: |
+          # Only files the compile database has a command for. A changed header has none, so
+          # clang-tidy falls back to a bare invocation with no include paths and every check
+          # reports nonsense -- include-cleaner calls even std::vector unprovided.
+          mapfile -t analysable < <(
+            git diff --name-only "$BASE_SHA...HEAD" -- '*.cpp' '*.cc' '*.cxx' \
+              | python3 .github/scripts/analysable_sources.py "$BUILD_DIR/compile_commands.json"
+          )
+          if [ "${#analysable[@]}" -eq 0 ]; then
+            echo "::notice::No changed file is a translation unit in the compile database."
+            exit 0
+          fi
+          echo "analysing ${#analysable[@]} changed translation units"
+          git diff -U0 "$BASE_SHA...HEAD" -- "${analysable[@]}" \
+            | python3 "$CLANG_TIDY_DIFF" \
+                -p1 -path "$BUILD_DIR" \
+                -clang-tidy-binary clang-tidy-20 \
+                -export-fixes clang-tidy-fixes.yaml \
+                -j "$(nproc)" \
+            | tee clang-tidy-output.txt
+
+      - name: Run clang-tidy over the whole tree
+        if: steps.scope.outputs.full == 'true'
+        shell: bash
+        run: |
+          echo "::notice::.clang-tidy changed, so every file is analysed rather than the diff."
+          $RUN_CLANG_TIDY -p "$BUILD_DIR" \
+            -export-fixes clang-tidy-fixes.yaml \
+            -j "$(nproc)" \
+            | tee clang-tidy-output.txt
+
+      # The steps above pipe into tee, so their status is tee's unless pipefail is set. Asserting
+      # on the output too, because a checker that finds defects and exits zero is the worst case.
+      - name: Fail on any finding
+        if: always() && hashFiles('clang-tidy-output.txt') != ''
+        shell: bash
+        run: |
+          # A parse failure is this lane's fault -- a missing generated header, a bad compile
+          # database -- and saying so keeps it from reading as a defect in the change.
+          if grep -nE 'error: .*\[clang-diagnostic-error\]$' clang-tidy-output.txt; then
+            echo "::error::clang-tidy could not parse a translation unit. That is a fault in this lane, not in the change."
+            exit 1
+          fi
+          if grep -nE '(warning|error): .*\[[a-z0-9-]+(,-warnings-as-errors)?\]$' clang-tidy-output.txt; then
+            echo "::error::clang-tidy reported findings on the lines this pull request changed."
+            exit 1
+          fi
+          echo "No findings on the changed lines."
+
+      # A fork's token cannot post at all, so this is allowed to fail: the findings are already in
+      # the job log and the archive, and the job has failed above if there were any.
+      - name: Post the findings as review comments
+        if: always() && hashFiles('clang-tidy-fixes.yaml') != ''
+        continue-on-error: true
+        uses: platisd/clang-tidy-pr-comments@28cfb84edafa771c044bde7e4a2a3fae57463818  # v1.8.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          clang_tidy_fixes: clang-tidy-fixes.yaml
+          request_changes: false
+
+      - name: Archive the findings
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: clang-tidy-findings
+          path: |
+            clang-tidy-fixes.yaml
+            clang-tidy-output.txt
+          if-no-files-found: ignore

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -193,6 +193,19 @@ jobs:
       # The lane drops the cache entry its save replaces.
       actions: write
 
+  clang-tidy-diff:
+    needs: detect-changes
+    if: >-
+      needs.detect-changes.outputs.code == 'true' &&
+      (github.event_name == 'push' ||
+       (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
+    uses: ./.github/workflows/clang_tidy_diff.yaml
+    permissions:
+      contents: read
+      # The lane posts its findings as review comments. A reusable workflow cannot hold more
+      # than its caller grants, and the mismatch fails at startup with no jobs and no log.
+      pull-requests: write
+
   # The only required check: every other job is skipped in some legitimate
   # case, and a required check that never reports blocks the merge forever.
   # test_main_yaml.py keeps the needs list complete.
@@ -218,6 +231,7 @@ jobs:
       - image-check
       - conan-packaging
       - pr-sanitizers
+      - clang-tidy-diff
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/apps/cli_run/browser_open.cpp
+++ b/apps/cli_run/browser_open.cpp
@@ -7,6 +7,7 @@
 
 #include "browser_open.h"
 
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <string>
@@ -56,7 +57,9 @@ constexpr auto pollInterval = std::chrono::milliseconds(100);
 #else
     const auto sock = ::socket(p->ai_family, p->ai_socktype, p->ai_protocol);
     if (sock < 0)
+    {
       continue;
+    }
     if (::connect(sock, p->ai_addr, p->ai_addrlen) == 0)
     {
       ok = true;
@@ -64,7 +67,9 @@ constexpr auto pollInterval = std::chrono::milliseconds(100);
     ::close(sock);
 #endif
     if (ok)
+    {
       break;
+    }
   }
   freeaddrinfo(res);
   return ok;
@@ -119,6 +124,9 @@ bool openInBrowser(const std::string& url)
 #else
   cmd = "xdg-open '" + url + "' >/dev/null 2>&1";
 #endif
+  // The one caller passes a compile-time constant URL, so nothing external reaches the
+  // shell. Revisit if openInBrowser is ever given a value from outside the process.
+  // NOLINTNEXTLINE(cert-env33-c)
   return std::system(cmd.c_str()) == 0;
 }
 

--- a/apps/cli_run/main.cpp
+++ b/apps/cli_run/main.cpp
@@ -42,7 +42,10 @@
 #  endif
 #  include <Windows.h>
 #else
-#  include <pthread.h>
+// <csignal> does not declare the POSIX functions used here: pthread_sigmask,
+// pthread_kill and sigwait.
+// NOLINTNEXTLINE(hicpp-deprecated-headers,modernize-deprecated-headers)
+#  include <signal.h>
 #endif
 
 // std
@@ -219,11 +222,17 @@ private:
   static inline SignalStopper* instance_ {nullptr};
   static inline sen::kernel::Kernel* kernel_ {nullptr};
 #else
+  // glibc declares this in an internal header, so the check does not connect it to the
+  // public <signal.h> included above.
+  // NOLINTNEXTLINE(misc-include-cleaner)
   sigset_t mask_ {};
   bool armed_ {false};
   std::thread waiter_;
 
   /// Whether blockEarly succeeded. Static because it runs before any instance exists.
+  // A static member reads as a global to the naming check, so the member suffix this
+  // codebase uses fails a global-variable rule.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static inline bool blocked_ {false};
 #endif
 };

--- a/components/explorer/src/event_explorer.h
+++ b/components/explorer/src/event_explorer.h
@@ -36,13 +36,13 @@ private:
   struct EventLogEntry
   {
     sen::ObjectId emitterId = {0};
-    std::string emitterName = {};
+    std::string emitterName;
     const sen::ClassType* emitterClass = nullptr;
     const sen::Event* ev = nullptr;
     sen::EventInfo eventInfo {};
-    sen::VarList args {};
-    std::string text {};
-    std::string valueText {};
+    sen::VarList args;
+    std::string text;
+    std::string valueText;
   };
 
   struct Track

--- a/components/explorer/src/method_printer.h
+++ b/components/explorer/src/method_printer.h
@@ -41,7 +41,7 @@ private:
   std::string methodName_;
   std::shared_ptr<const sen::Method> method_ = nullptr;
   std::shared_ptr<sen::Object> owner_ = nullptr;
-  std::vector<std::tuple<sen::Arg, sen::Var, EditablePrinterFunc, bool>> argDrawers_ {};
+  std::vector<std::tuple<sen::Arg, sen::Var, EditablePrinterFunc, bool>> argDrawers_;
   EditablePrinterMaker::PropertiesStateMap propertiesStateMap_;
 
 private:

--- a/components/explorer/src/plotter.cpp
+++ b/components/explorer/src/plotter.cpp
@@ -32,7 +32,7 @@
 //--------------------------------------------------------------------------------------------------------------
 
 Plot::Plot(std::string name, Plotter* owner, ObjectState* state, uint32_t elementId, int maxSize)
-  : maxSize_(maxSize), offset_(0U), owner_(owner), name_(std::move(name)), state_(state), elementId_(elementId)
+  : maxSize_(maxSize), owner_(owner), name_(std::move(name)), state_(state), elementId_(elementId)
 {
   data_.reserve(maxSize);
   state_->startObservingElement(elementId_, this);

--- a/components/explorer/src/plotter.h
+++ b/components/explorer/src/plotter.h
@@ -57,7 +57,7 @@ private:
 private:
   ImVector<Vec2d> data_;
   int maxSize_;
-  int offset_;
+  int offset_ = 0;
   Plotter* owner_;
   std::string name_;
   ObjectState* state_;

--- a/components/jsonrpc/test/static_file_routes_test.cpp
+++ b/components/jsonrpc/test/static_file_routes_test.cpp
@@ -82,7 +82,8 @@ struct HttpResponse
   asio::io_context ctx;
   asio::ip::tcp::socket socket {ctx};
   asio::ip::tcp::resolver resolver {ctx};
-  asio::connect(socket,
+  asio::connect(socket,  // NOLINT(misc-include-cleaner): asio's public header is included;
+                         // the check maps the symbol to an impl header
                 resolver.resolve(host, std::to_string(port)));  // NOLINT(misc-include-cleaner): asio's public header is
                                                                 // included; the check maps the symbol to an impl header
 

--- a/components/jsonrpc/test/ws_client.cpp
+++ b/components/jsonrpc/test/ws_client.cpp
@@ -152,10 +152,9 @@ void WsClient::close()
   // FIN=1, opcode=0x8 (close), MASK=1, len=0.
   const std::array<std::uint8_t, 6> frame {0x88U, 0x80U, 0x00U, 0x00U, 0x00U, 0x00U};
   asio::error_code ec;
-  std::ignore = asio::write(
-    socket_,
-    asio::buffer(frame),
-    ec);  // NOLINT(misc-include-cleaner): asio's public header is included; the check maps the symbol to an impl header
+  // asio's public header is included above; the check maps the symbol to an impl header.
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  std::ignore = asio::write(socket_, asio::buffer(frame), ec);
   std::ignore = ec;
   std::ignore = socket_.close(ec);
   std::ignore = ec;

--- a/components/recorder/src/recorder.h
+++ b/components/recorder/src/recorder.h
@@ -58,8 +58,8 @@ private:
   std::shared_ptr<sen::db::Output> out_;
   std::unique_ptr<sen::ObjectMux> mux_;
   std::unique_ptr<sen::ObjectList<Object>> trackedObjects_;
-  std::unordered_map<sen::ObjectId, std::vector<sen::ConnectionGuard>> guards_ = {};
-  std::vector<std::shared_ptr<sen::ObjectSource>> sources_ = {};
+  std::unordered_map<sen::ObjectId, std::vector<sen::ConnectionGuard>> guards_;
+  std::vector<std::shared_ptr<sen::ObjectSource>> sources_;
   bool additionsAndRemovalsEnabled_ = false;
   sen::TimeStamp lastKeyframeTime_;
   sen::kernel::RunApi* api_ = nullptr;

--- a/components/replayer/test/replayed_object_test.cpp
+++ b/components/replayer/test/replayed_object_test.cpp
@@ -50,6 +50,7 @@
 
 // std
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <memory>

--- a/libs/core/benchmark/.clang-tidy
+++ b/libs/core/benchmark/.clang-tidy
@@ -1,0 +1,10 @@
+# Checks a benchmark cannot satisfy, relaxed here and nowhere else.
+#
+# google-benchmark's loop is `for (auto _ : state)`, so every benchmark body reads as a store
+# that is never used; a benchmark walks its own fixture array with a running index; and fixture
+# data is static by nature. Everything else in the root configuration still applies.
+InheritParentConfig: true
+Checks: >
+  -cert-err58-cpp,
+  -clang-analyzer-deadcode.DeadStores,
+  -cppcoreguidelines-pro-bounds-constant-array-index

--- a/libs/core/benchmark/base/hash32_benchmark.cpp
+++ b/libs/core/benchmark/base/hash32_benchmark.cpp
@@ -11,6 +11,7 @@
 #include <benchmark/benchmark.h>
 
 // std
+#include <cstddef>
 #include <cstdint>
 #include <string>
 

--- a/libs/core/include/sen/core/base/static_vector.h
+++ b/libs/core/include/sen/core/base/static_vector.h
@@ -640,9 +640,13 @@ private:
 
 /// Checks if the contents of lhs and rhs are equal, that is, they have the same number of elements
 /// and each element in lhs compares equal with the element in rhs at the same position.
+///
+/// noexcept only when comparing T is. The trait above accepts any comparable T, so an
+/// unconditional promise would turn a throwing comparison into a call to std::terminate.
 template <typename T, std::size_t size>
-std::enable_if_t<HasOperator<T>::eq, bool> operator==(StaticVector<T, size> const& lhs,
-                                                      StaticVector<T, size> const& rhs) noexcept
+std::enable_if_t<HasOperator<T>::eq, bool> operator==(
+  StaticVector<T, size> const& lhs,
+  StaticVector<T, size> const& rhs) noexcept(noexcept(std::declval<T const&>() == std::declval<T const&>()))
 {
   if (lhs.size() != rhs.size())
   {
@@ -653,9 +657,13 @@ std::enable_if_t<HasOperator<T>::eq, bool> operator==(StaticVector<T, size> cons
 }
 
 /// Equivalent to negating operator ==.
+///
+/// Carries the same condition as operator==, which it calls.
 template <typename T, std::size_t size>
-std::enable_if_t<HasOperator<T>::ne, bool> operator!=(StaticVector<T, size> const& lhs,
-                                                      StaticVector<T, size> const& rhs) noexcept
+std::enable_if_t<HasOperator<T>::ne, bool> operator!=(
+  StaticVector<T, size> const& lhs,
+  StaticVector<T, size> const& rhs) noexcept(noexcept(std::declval<StaticVector<T, size> const&>() ==
+                                                      std::declval<StaticVector<T, size> const&>()))
 {
   return !(lhs == rhs);
 }

--- a/libs/kernel/src/bus/local_participant.cpp
+++ b/libs/kernel/src/bus/local_participant.cpp
@@ -39,6 +39,7 @@
 #include <spdlog/logger.h>
 
 // std
+#include <cstddef>
 #include <list>
 #include <memory>
 #include <mutex>

--- a/libs/kernel/src/bus/session_manager.cpp
+++ b/libs/kernel/src/bus/session_manager.cpp
@@ -229,9 +229,9 @@ SessionManager::DeletionGuard SessionManager::makeDeletionGuard(Session* session
 
 void SessionManager::sessionDeleted(Session* session)
 {
-  // Copied, because the caller is this session's destructor and the announcement below outlives
-  // the point where reading from it is safe.
-  const std::string name = session->getName();
+  // The guard that calls this is a local in ~Session, so it runs before any member is
+  // destroyed and name_ is still alive.
+  const std::string& name = session->getName();
 
   logger_->debug("SessionManager: session {} deleted started", name);
 

--- a/libs/kernel/src/posix/posix_os.cpp
+++ b/libs/kernel/src/posix/posix_os.cpp
@@ -29,7 +29,6 @@
 #include <memory>
 #include <string>
 #include <string_view>
-#include <tuple>
 #include <utility>
 
 namespace sen::kernel

--- a/libs/kernel/src/schedule_cycles.h
+++ b/libs/kernel/src/schedule_cycles.h
@@ -27,7 +27,7 @@ namespace sen::kernel
 
   // Divide before adding: the sum would overflow for a clock that jumps by decades, and an
   // overflowed count is negative, which would walk the schedule backwards.
-  return amount.count() / period.count() + (amount.count() % period.count() != 0);
+  return amount.count() / period.count() + static_cast<int64_t>(amount.count() % period.count() != 0);
 }
 
 }  // namespace sen::kernel

--- a/libs/kernel/src/type_specs_utils.cpp
+++ b/libs/kernel/src/type_specs_utils.cpp
@@ -9,7 +9,6 @@
 
 // sen
 #include "sen/core/base/assert.h"
-#include "sen/core/base/checked_conversions.h"
 #include "sen/core/base/class_helpers.h"
 #include "sen/core/base/compiler_macros.h"
 #include "sen/core/base/numbers.h"
@@ -42,7 +41,6 @@
 // std
 #include <algorithm>
 #include <cstddef>
-#include <cstdint>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -1874,184 +1872,144 @@ bool acceptsUnderCompatibilityMode(CompatibilityMode mode,
   return true;
 }
 
-std::vector<std::string> runtimeCompatible(const Type* localType,
-                                           const Type* remoteType,
-                                           std::vector<std::string>* lossy)
+namespace
 {
-  class RuntimeCompatVisitor: public FullTypeVisitor
+
+/// Walks the local type against the remote one, collecting the incompatibilities between
+/// them and, when asked, the conversions that would lose data.
+class RuntimeCompatVisitor: public FullTypeVisitor
+{
+public:
+  SEN_NOCOPY_NOMOVE(RuntimeCompatVisitor)
+
+public:
+  RuntimeCompatVisitor(const Type* remoteType, std::vector<std::string>& problems, std::vector<std::string>* lossy)
+    : remoteType_(remoteType), problems_(problems), lossy_(lossy)
   {
-  public:
-    SEN_NOCOPY_NOMOVE(RuntimeCompatVisitor)
+  }
 
-  public:
-    RuntimeCompatVisitor(const Type* remoteType, std::vector<std::string>& problems, std::vector<std::string>* lossy)
-      : remoteType_(remoteType), problems_(problems), lossy_(lossy)
+  ~RuntimeCompatVisitor() override = default;
+
+public:
+  using FullTypeVisitor::apply;
+
+  // root type
+  void apply(const Type& type) override { std::ignore = type; }
+
+  void apply(const VoidType& type) override
+  {
+    std::ignore = type;
+
+    if (!remoteType_->isVoidType())
     {
+      problems_.emplace_back(logIncompatible(type.getName().data()));
+    }
+  }
+
+  void apply(const NativeType& type) override
+  {
+    auto isCompatible = remoteType_->isNativeType() || remoteType_->isEnumType() || remoteType_->isQuantityType();
+
+    // remote type is not native, not enum and not quantity
+    if (!isCompatible)
+    {
+      problems_.emplace_back(logIncompatible(type.getName().data()));
+      return;
     }
 
-    ~RuntimeCompatVisitor() override = default;
-
-  public:
-    using FullTypeVisitor::apply;
-
-    // root type
-    void apply(const Type& type) override { std::ignore = type; }
-
-    void apply(const VoidType& type) override
+    // the data arrives from the remote side, so that is the direction to grade
+    if (lossy_ != nullptr)
     {
-      std::ignore = type;
+      checkForLoss(*remoteType_, type);
+    }
+  }
 
-      if (!remoteType_->isVoidType())
-      {
-        problems_.emplace_back(logIncompatible(type.getName().data()));
-      }
+  void apply(const ::sen::IntegralType& type) override { apply(static_cast<const NativeType&>(type)); }
+
+  void apply(const ::sen::RealType& type) override { apply(static_cast<const NativeType&>(type)); }
+
+  void apply(const ::sen::NumericType& type) override { apply(static_cast<const NativeType&>(type)); }
+
+  void apply(const BoolType& type) override { apply(static_cast<const NativeType&>(type)); }
+
+  void apply(const UInt8Type& type) override { apply(static_cast<const NativeType&>(type)); }
+
+  void apply(const Int16Type& type) override { apply(static_cast<const ::sen::IntegralType&>(type)); }
+
+  void apply(const UInt16Type& type) override { apply(static_cast<const ::sen::IntegralType&>(type)); }
+
+  void apply(const Int32Type& type) override { apply(static_cast<const ::sen::IntegralType&>(type)); }
+
+  void apply(const UInt32Type& type) override { apply(static_cast<const ::sen::IntegralType&>(type)); }
+
+  void apply(const Int64Type& type) override { apply(static_cast<const ::sen::IntegralType&>(type)); }
+
+  void apply(const UInt64Type& type) override { apply(static_cast<const ::sen::IntegralType&>(type)); }
+
+  void apply(const Float32Type& type) override { apply(static_cast<const ::sen::RealType&>(type)); }
+
+  void apply(const Float64Type& type) override { apply(static_cast<const ::sen::RealType&>(type)); }
+
+  void apply(const DurationType& type) override
+  {
+    if (!remoteType_->isDurationType())
+    {
+      problems_.emplace_back(logIncompatible(type.getName().data()));
+    }
+  }
+
+  void apply(const TimestampType& type) override
+  {
+    if (!remoteType_->isTimestampType())
+    {
+      problems_.emplace_back(logIncompatible(type.getName().data()));
+    }
+  }
+
+  void apply(const StringType& type) override { apply(static_cast<const NativeType&>(type)); }
+
+  // custom types
+  void apply(const CustomType& type) override { apply(static_cast<const Type&>(type)); }
+
+  void apply(const EnumType& type) override
+  {
+    // remote type is not native and not enum
+    if (!remoteType_->isNativeType() && !remoteType_->isEnumType())
+    {
+      problems_.emplace_back(logIncompatible(type.getName().data()));
+      return;
     }
 
-    void apply(const NativeType& type) override
+    // an enumerator is carried in the storage type, which can narrow like any other number
+    const auto* remoteEnum = remoteType_->asEnumType();
+    if (lossy_ != nullptr && remoteEnum != nullptr)
     {
-      auto isCompatible = remoteType_->isNativeType() || remoteType_->isEnumType() || remoteType_->isQuantityType();
+      checkForLoss(remoteEnum->getStorageType(), type.getStorageType());
+    }
+  }
 
-      // remote type is not native, not enum and not quantity
-      if (!isCompatible)
-      {
-        problems_.emplace_back(logIncompatible(type.getName().data()));
-        return;
-      }
-
-      // the data arrives from the remote side, so that is the direction to grade
-      if (lossy_ != nullptr)
-      {
-        checkForLoss(*remoteType_, type);
-      }
+  void apply(const StructType& type) override
+  {
+    // remote type is not a struct
+    if (!remoteType_->isStructType())
+    {
+      problems_.emplace_back(logIncompatible(type.getName().data()));
+      return;
     }
 
-    void apply(const ::sen::IntegralType& type) override { apply(static_cast<const NativeType&>(type)); }
-
-    void apply(const ::sen::RealType& type) override { apply(static_cast<const NativeType&>(type)); }
-
-    void apply(const ::sen::NumericType& type) override { apply(static_cast<const NativeType&>(type)); }
-
-    void apply(const BoolType& type) override { apply(static_cast<const NativeType&>(type)); }
-
-    void apply(const UInt8Type& type) override { apply(static_cast<const NativeType&>(type)); }
-
-    void apply(const Int16Type& type) override { apply(static_cast<const ::sen::IntegralType&>(type)); }
-
-    void apply(const UInt16Type& type) override { apply(static_cast<const ::sen::IntegralType&>(type)); }
-
-    void apply(const Int32Type& type) override { apply(static_cast<const ::sen::IntegralType&>(type)); }
-
-    void apply(const UInt32Type& type) override { apply(static_cast<const ::sen::IntegralType&>(type)); }
-
-    void apply(const Int64Type& type) override { apply(static_cast<const ::sen::IntegralType&>(type)); }
-
-    void apply(const UInt64Type& type) override { apply(static_cast<const ::sen::IntegralType&>(type)); }
-
-    void apply(const Float32Type& type) override { apply(static_cast<const ::sen::RealType&>(type)); }
-
-    void apply(const Float64Type& type) override { apply(static_cast<const ::sen::RealType&>(type)); }
-
-    void apply(const DurationType& type) override
+    const auto* remoteStruct = remoteType_->asStructType();
+    for (const auto& remoteField: remoteStruct->getAllFields())
     {
-      if (!remoteType_->isDurationType())
+      if (const auto* localField = type.getFieldFromName(remoteField.name); localField != nullptr)
       {
-        problems_.emplace_back(logIncompatible(type.getName().data()));
-      }
-    }
-
-    void apply(const TimestampType& type) override
-    {
-      if (!remoteType_->isTimestampType())
-      {
-        problems_.emplace_back(logIncompatible(type.getName().data()));
-      }
-    }
-
-    void apply(const StringType& type) override { apply(static_cast<const NativeType&>(type)); }
-
-    // custom types
-    void apply(const CustomType& type) override { apply(static_cast<const Type&>(type)); }
-
-    void apply(const EnumType& type) override
-    {
-      // remote type is not native and not enum
-      if (!remoteType_->isNativeType() && !remoteType_->isEnumType())
-      {
-        problems_.emplace_back(logIncompatible(type.getName().data()));
-        return;
-      }
-
-      // an enumerator is carried in the storage type, which can narrow like any other number
-      const auto* remoteEnum = remoteType_->asEnumType();
-      if (lossy_ != nullptr && remoteEnum != nullptr)
-      {
-        checkForLoss(remoteEnum->getStorageType(), type.getStorageType());
-      }
-    }
-
-    void apply(const StructType& type) override
-    {
-      // remote type is not a struct
-      if (!remoteType_->isStructType())
-      {
-        problems_.emplace_back(logIncompatible(type.getName().data()));
-        return;
-      }
-
-      const auto* remoteStruct = remoteType_->asStructType();
-      for (const auto& remoteField: remoteStruct->getAllFields())
-      {
-        if (const auto* localField = type.getFieldFromName(remoteField.name); localField != nullptr)
-        {
-          if (const auto fieldProblems = runtimeCompatible(localField->type.type(), remoteField.type.type(), lossy_);
-              !fieldProblems.empty())
-          {
-            std::string error;
-            {
-              error.append("Found incompatible matching fields with name ");
-              error.append(localField->name);
-              error.append(" in struct type ");
-              error.append(type.getName());
-            }
-            problems_.emplace_back(error);
-
-            concatProblems(fieldProblems);
-          }
-        }
-      }
-    }
-
-    void apply(const VariantType& type) override
-    {
-      // remote type is not a variant
-      if (!remoteType_->isVariantType())
-      {
-        problems_.emplace_back(logIncompatible(type.getName().data()));
-        return;
-      }
-
-      // TODO: review if we can accept types contained in the variant
-      const auto* remoteVariant = remoteType_->asVariantType();
-
-      // An alternative is addressed by its key, which is not its position: keys come from the
-      // model and need not start at zero or run consecutively. An alternative the other side does
-      // not declare is skipped, the way a property is.
-      for (const auto& localField: type.getFields())
-      {
-        const auto* remoteField = remoteVariant->getFieldFromKey(localField.key);
-        if (remoteField == nullptr)
-        {
-          continue;
-        }
-
-        if (const auto fieldProblems = runtimeCompatible(localField.type.type(), remoteField->type.type(), lossy_);
+        if (const auto fieldProblems = runtimeCompatible(localField->type.type(), remoteField.type.type(), lossy_);
             !fieldProblems.empty())
         {
           std::string error;
           {
-            error.append("Found incompatible matching variant fields with key ");
-            error.append(std::to_string(localField.key));
-            error.append(" in variant type ");
+            error.append("Found incompatible matching fields with name ");
+            error.append(localField->name);
+            error.append(" in struct type ");
             error.append(type.getName());
           }
           problems_.emplace_back(error);
@@ -2060,264 +2018,311 @@ std::vector<std::string> runtimeCompatible(const Type* localType,
         }
       }
     }
+  }
 
-    void apply(const SequenceType& type) override
+  void apply(const VariantType& type) override
+  {
+    // remote type is not a variant
+    if (!remoteType_->isVariantType())
     {
-
-      // remote type is not a sequence
-      if (!remoteType_->isSequenceType())
-      {
-        problems_.emplace_back(logIncompatible(type.getName().data()));
-        return;
-      }
-
-      const auto* remoteSequence = remoteType_->asSequenceType();
-      // check the element type
-      concatProblems(runtimeCompatible(type.getElementType().type(), remoteSequence->getElementType().type(), lossy_));
+      problems_.emplace_back(logIncompatible(type.getName().data()));
+      return;
     }
 
-    // NOLINTNEXTLINE
-    void apply(const ClassType& type) override
+    // TODO: review if we can accept types contained in the variant
+    const auto* remoteVariant = remoteType_->asVariantType();
+
+    // An alternative is addressed by its key, which is not its position: keys come from the
+    // model and need not start at zero or run consecutively. An alternative the other side does
+    // not declare is skipped, the way a property is.
+    for (const auto& localField: type.getFields())
     {
-
-      // remote is not a class
-      if (!remoteType_->isClassType())
+      const auto* remoteField = remoteVariant->getFieldFromKey(localField.key);
+      if (remoteField == nullptr)
       {
-        problems_.emplace_back(logIncompatible(type.getName().data()));
-        return;
+        continue;
       }
 
-      const auto* remoteClass = remoteType_->asClassType();
-      // check properties
-      for (const auto& remoteProp: remoteClass->getProperties(allParents))
+      if (const auto fieldProblems = runtimeCompatible(localField.type.type(), remoteField->type.type(), lossy_);
+          !fieldProblems.empty())
       {
-        if (const auto* localProp = type.searchPropertyByName(remoteProp->getName()); localProp != nullptr)
+        std::string error;
         {
-          if (const auto propProblems =
-                runtimeCompatible(localProp->getType().type(), remoteProp->getType().type(), lossy_);
-              !propProblems.empty())
-          {
-            std::string error;
-            {
-              error.append("Found incompatible property with name ");
-              error.append(localProp->getName());
-              error.append(" in class ");
-              error.append(type.getName());
-              error.append(". Local type is ");
-              error.append(localProp->getType()->getName());
-              error.append(" and remote type is ");
-              error.append(remoteProp->getType()->getName());
-            }
-            problems_.emplace_back(error);
-
-            concatProblems(propProblems);
-          }
+          error.append("Found incompatible matching variant fields with key ");
+          error.append(std::to_string(localField.key));
+          error.append(" in variant type ");
+          error.append(type.getName());
         }
-      }
+        problems_.emplace_back(error);
 
-      // check events
-      for (const auto& remoteEvent: remoteClass->getEvents(allParents))
-      {
-        if (const auto* localEvent = type.searchEventByName(remoteEvent->getName()); localEvent != nullptr)
-        {
-          for (const auto& remoteArg: remoteEvent->getArgs())
-          {
-            if (const auto& localArg = localEvent->getArgFromName(remoteArg.name); localArg != nullptr)
-            {
-              if (const auto eventProblems = runtimeCompatible(localArg->type.type(), remoteArg.type.type(), lossy_);
-                  !eventProblems.empty())
-              {
-                std::string error;
-                {
-                  error.append("Found incompatible argument with name ");
-                  error.append(localArg->name);
-                  error.append(" in event ");
-                  error.append(localEvent->getName());
-                  error.append(" in class ");
-                  error.append(type.getName());
-                  error.append(". Local type is ");
-                  error.append(localArg->type->getName());
-                  error.append(" and remote type is ");
-                  error.append(remoteArg.type->getName());
-                }
-                problems_.emplace_back(error);
-
-                concatProblems(eventProblems);
-              }
-            }
-          }
-        }
-      }
-
-      // check methods
-      for (const auto& remoteMethod: remoteClass->getMethods(allParents))
-      {
-        if (const auto* localMethod = type.searchMethodByName(remoteMethod->getName()); localMethod != nullptr)
-        {
-          // check return type
-          auto localReturnType = localMethod->getReturnType();
-          auto remoteReturnType = remoteMethod->getReturnType();
-
-          concatProblems(runtimeCompatible(localReturnType.type(), remoteReturnType.type(), lossy_));
-
-          // check args
-          for (const auto& localArg: localMethod->getArgs())
-          {
-            if (const auto* remoteArg = remoteMethod->getArgFromName(localArg.name); remoteArg != nullptr)
-            {
-              // we supply the arguments, so for them the loss runs from us to the writer
-              if (lossy_ != nullptr)
-              {
-                std::ignore = runtimeCompatible(remoteArg->type.type(), localArg.type.type(), lossy_);
-              }
-
-              if (const auto argProblems = runtimeCompatible(localArg.type.type(), remoteArg->type.type());
-                  !argProblems.empty())
-              {
-                std::string error;
-                {
-                  error.append("Found incompatible argument with name ");
-                  error.append(localArg.name);
-                  error.append(" in method ");
-                  error.append(localMethod->getName());
-                  error.append(" in class ");
-                  error.append(type.getName());
-                  error.append(". Local type is ");
-                  error.append(localArg.type->getName());
-                  error.append(" and remote type is ");
-                  error.append(remoteArg->type->getName());
-                }
-                problems_.emplace_back(error);
-
-                concatProblems(argProblems);
-              }
-            }
-          }
-        }
+        concatProblems(fieldProblems);
       }
     }
+  }
 
-    void apply(const QuantityType& type) override
+  void apply(const SequenceType& type) override
+  {
+
+    // remote type is not a sequence
+    if (!remoteType_->isSequenceType())
     {
-      // remote is another quantity
-      if (const auto* remoteQuantity = remoteType_->asQuantityType(); remoteQuantity != nullptr)
-      {
-        const auto localUnit = type.getUnit();
-        const auto remoteUnit = remoteQuantity->getUnit();
+      problems_.emplace_back(logIncompatible(type.getName().data()));
+      return;
+    }
 
-        if (!localUnit && remoteUnit)
+    const auto* remoteSequence = remoteType_->asSequenceType();
+    // check the element type
+    concatProblems(runtimeCompatible(type.getElementType().type(), remoteSequence->getElementType().type(), lossy_));
+  }
+
+  // NOLINTNEXTLINE
+  void apply(const ClassType& type) override
+  {
+
+    // remote is not a class
+    if (!remoteType_->isClassType())
+    {
+      problems_.emplace_back(logIncompatible(type.getName().data()));
+      return;
+    }
+
+    const auto* remoteClass = remoteType_->asClassType();
+    // check properties
+    for (const auto& remoteProp: remoteClass->getProperties(allParents))
+    {
+      if (const auto* localProp = type.searchPropertyByName(remoteProp->getName()); localProp != nullptr)
+      {
+        if (const auto propProblems =
+              runtimeCompatible(localProp->getType().type(), remoteProp->getType().type(), lossy_);
+            !propProblems.empty())
         {
           std::string error;
           {
-            error.append("Found incompatible local unit (non-dimensional) and remote unit ");
-            error.append(remoteUnit.value()->getName());
+            error.append("Found incompatible property with name ");
+            error.append(localProp->getName());
+            error.append(" in class ");
+            error.append(type.getName());
+            error.append(". Local type is ");
+            error.append(localProp->getType()->getName());
+            error.append(" and remote type is ");
+            error.append(remoteProp->getType()->getName());
+          }
+          problems_.emplace_back(error);
+
+          concatProblems(propProblems);
+        }
+      }
+    }
+
+    // check events
+    for (const auto& remoteEvent: remoteClass->getEvents(allParents))
+    {
+      if (const auto* localEvent = type.searchEventByName(remoteEvent->getName()); localEvent != nullptr)
+      {
+        for (const auto& remoteArg: remoteEvent->getArgs())
+        {
+          if (const auto& localArg = localEvent->getArgFromName(remoteArg.name); localArg != nullptr)
+          {
+            if (const auto eventProblems = runtimeCompatible(localArg->type.type(), remoteArg.type.type(), lossy_);
+                !eventProblems.empty())
+            {
+              std::string error;
+              {
+                error.append("Found incompatible argument with name ");
+                error.append(localArg->name);
+                error.append(" in event ");
+                error.append(localEvent->getName());
+                error.append(" in class ");
+                error.append(type.getName());
+                error.append(". Local type is ");
+                error.append(localArg->type->getName());
+                error.append(" and remote type is ");
+                error.append(remoteArg.type->getName());
+              }
+              problems_.emplace_back(error);
+
+              concatProblems(eventProblems);
+            }
+          }
+        }
+      }
+    }
+
+    // check methods
+    for (const auto& remoteMethod: remoteClass->getMethods(allParents))
+    {
+      if (const auto* localMethod = type.searchMethodByName(remoteMethod->getName()); localMethod != nullptr)
+      {
+        // check return type
+        auto localReturnType = localMethod->getReturnType();
+        auto remoteReturnType = remoteMethod->getReturnType();
+
+        concatProblems(runtimeCompatible(localReturnType.type(), remoteReturnType.type(), lossy_));
+
+        // check args
+        for (const auto& localArg: localMethod->getArgs())
+        {
+          if (const auto* remoteArg = remoteMethod->getArgFromName(localArg.name); remoteArg != nullptr)
+          {
+            // we supply the arguments, so for them the loss runs from us to the writer
+            if (lossy_ != nullptr)
+            {
+              std::ignore = runtimeCompatible(remoteArg->type.type(), localArg.type.type(), lossy_);
+            }
+
+            if (const auto argProblems = runtimeCompatible(localArg.type.type(), remoteArg->type.type());
+                !argProblems.empty())
+            {
+              std::string error;
+              {
+                error.append("Found incompatible argument with name ");
+                error.append(localArg.name);
+                error.append(" in method ");
+                error.append(localMethod->getName());
+                error.append(" in class ");
+                error.append(type.getName());
+                error.append(". Local type is ");
+                error.append(localArg.type->getName());
+                error.append(" and remote type is ");
+                error.append(remoteArg->type->getName());
+              }
+              problems_.emplace_back(error);
+
+              concatProblems(argProblems);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  void apply(const QuantityType& type) override
+  {
+    // remote is another quantity
+    if (const auto* remoteQuantity = remoteType_->asQuantityType(); remoteQuantity != nullptr)
+    {
+      const auto localUnit = type.getUnit();
+      const auto remoteUnit = remoteQuantity->getUnit();
+
+      if (!localUnit && remoteUnit)
+      {
+        std::string error;
+        {
+          error.append("Found incompatible local unit (non-dimensional) and remote unit ");
+          error.append(remoteUnit.value()->getName());
+          error.append(" in type ");
+          error.append(type.getName());
+        }
+
+        problems_.emplace_back(error);
+        return;
+      }
+
+      if (localUnit && !remoteUnit)
+      {
+        std::string error;
+        {
+          error.append("Found incompatible local unit ");
+          error.append(type.getName());
+          error.append(" and remote unit (non-dimensional) in type ");
+          error.append(type.getName());
+        }
+
+        problems_.emplace_back(error);
+        return;
+      }
+
+      if (localUnit)
+      {
+        const auto localCategory = localUnit.value()->getCategory();
+        const auto remoteCategory = remoteUnit.value()->getCategory();
+
+        if (localCategory != remoteCategory)
+        {
+          std::string error;
+          {
+            error.append("Found incompatible local unit category ");
+            error.append(Unit::getCategoryString(localCategory));
+            error.append(" and remote unit category ");
+            error.append(Unit::getCategoryString(remoteCategory));
             error.append(" in type ");
             error.append(type.getName());
           }
 
           problems_.emplace_back(error);
-          return;
         }
-
-        if (localUnit && !remoteUnit)
-        {
-          std::string error;
-          {
-            error.append("Found incompatible local unit ");
-            error.append(type.getName());
-            error.append(" and remote unit (non-dimensional) in type ");
-            error.append(type.getName());
-          }
-
-          problems_.emplace_back(error);
-          return;
-        }
-
-        if (localUnit)
-        {
-          const auto localCategory = localUnit.value()->getCategory();
-          const auto remoteCategory = remoteUnit.value()->getCategory();
-
-          if (localCategory != remoteCategory)
-          {
-            std::string error;
-            {
-              error.append("Found incompatible local unit category ");
-              error.append(Unit::getCategoryString(localCategory));
-              error.append(" and remote unit category ");
-              error.append(Unit::getCategoryString(remoteCategory));
-              error.append(" in type ");
-              error.append(type.getName());
-            }
-
-            problems_.emplace_back(error);
-          }
-        }
-
-        // the unit says what the number means; the number itself can still narrow
-        if (lossy_ != nullptr)
-        {
-          checkForLoss(*remoteQuantity->getElementType().type(), *type.getElementType().type());
-        }
-
-        return;
       }
 
-      // remote is not numeric or string
-      if (!remoteType_->isNumericType() && !remoteType_->isStringType())
-      {
-        problems_.emplace_back(logIncompatible(type.getName().data()));
-      }
-    }
-
-    void apply(const AliasType& type) override
-    {
-      apply(static_cast<const CustomType&>(type));
-
-      // an alias is transparent, so a conversion behind one loses just as much
+      // the unit says what the number means; the number itself can still narrow
       if (lossy_ != nullptr)
       {
-        const auto* remoteAlias = remoteType_->asAliasType();
-        checkForLoss(remoteAlias != nullptr ? *remoteAlias->getAliasedType().type() : *remoteType_,
-                     *type.getAliasedType().type());
-      }
-    }
-
-    void apply(const OptionalType& type) override
-    {
-      concatProblems(runtimeCompatible(type.getType().type(), remoteType_, lossy_));
-    }
-
-  private:
-    /// Records a conversion that is allowed but can drop a value.
-    void checkForLoss(const Type& from, const Type& to)
-    {
-      if (lossy_ == nullptr || !conversionLosesData(from, to))
-      {
-        return;
+        checkForLoss(*remoteQuantity->getElementType().type(), *type.getElementType().type());
       }
 
-      std::string diff;
-      diff.append("reading ");
-      diff.append(from.getName());
-      diff.append(" as ");
-      diff.append(to.getName());
-      diff.append(" can lose a value");
-
-      lossy_->emplace_back(std::move(diff));
+      return;
     }
 
-    void concatProblems(const std::vector<std::string>& problems)
+    // remote is not numeric or string
+    if (!remoteType_->isNumericType() && !remoteType_->isStringType())
     {
-      problems_.insert(problems_.end(), problems.begin(), problems.end());
+      problems_.emplace_back(logIncompatible(type.getName().data()));
+    }
+  }
+
+  void apply(const AliasType& type) override
+  {
+    apply(static_cast<const CustomType&>(type));
+
+    // an alias is transparent, so a conversion behind one loses just as much
+    if (lossy_ != nullptr)
+    {
+      const auto* remoteAlias = remoteType_->asAliasType();
+      checkForLoss(remoteAlias != nullptr ? *remoteAlias->getAliasedType().type() : *remoteType_,
+                   *type.getAliasedType().type());
+    }
+  }
+
+  void apply(const OptionalType& type) override
+  {
+    concatProblems(runtimeCompatible(type.getType().type(), remoteType_, lossy_));
+  }
+
+private:
+  /// Records a conversion that is allowed but can drop a value.
+  void checkForLoss(const Type& from, const Type& to)
+  {
+    if (lossy_ == nullptr || !conversionLosesData(from, to))
+    {
+      return;
     }
 
-  private:
-    const Type* remoteType_;
-    std::vector<std::string>& problems_;
-    std::vector<std::string>* lossy_;
-  };
+    std::string diff;
+    diff.append("reading ");
+    diff.append(from.getName());
+    diff.append(" as ");
+    diff.append(to.getName());
+    diff.append(" can lose a value");
 
+    lossy_->emplace_back(std::move(diff));
+  }
+
+  void concatProblems(const std::vector<std::string>& problems)
+  {
+    problems_.insert(problems_.end(), problems.begin(), problems.end());
+  }
+
+private:
+  const Type* remoteType_;
+  std::vector<std::string>& problems_;
+  std::vector<std::string>* lossy_;
+};
+
+}  // namespace
+
+std::vector<std::string> runtimeCompatible(const Type* localType,
+                                           const Type* remoteType,
+                                           std::vector<std::string>* lossy)
+{
   // always runtime compatible if equivalent
   if (equivalent(localType, remoteType))
   {

--- a/libs/kernel/test/integration/transport/transport_1/src/transport.cpp
+++ b/libs/kernel/test/integration/transport/transport_1/src/transport.cpp
@@ -20,6 +20,7 @@
 // generated code
 #include "stl/sen/kernel/kernel_objects.stl.h"
 #include "stl/transport/transport.stl.h"
+#include "test_helpers/test_helpers.stl.h"
 
 // spdlog
 #include <spdlog/sinks/stdout_color_sinks.h>

--- a/libs/kernel/test/integration/transport/transport_2/src/transport.cpp
+++ b/libs/kernel/test/integration/transport/transport_2/src/transport.cpp
@@ -20,6 +20,7 @@
 // generated code
 #include "stl/sen/kernel/kernel_objects.stl.h"
 #include "stl/transport/transport.stl.h"
+#include "test_helpers/test_helpers.stl.h"
 
 // spdlog
 #include <spdlog/sinks/stdout_color_sinks.h>

--- a/libs/kernel/test/unit/precision_sleeper_test.cpp
+++ b/libs/kernel/test/unit/precision_sleeper_test.cpp
@@ -9,9 +9,6 @@
 #include "precision_sleeper.h"
 #include "wall_clock.h"
 
-// stl
-#include "stl/sen/kernel/basic_types.stl.h"
-
 // gtest
 #include <gtest/gtest.h>
 
@@ -19,13 +16,6 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
-#include <fstream>
-#include <string>
-#include <tuple>
-
-#if defined(__linux__)
-#  include <sys/prctl.h>
-#endif
 
 namespace
 {

--- a/libs/kernel/test/unit/thread_priority_test.cpp
+++ b/libs/kernel/test/unit/thread_priority_test.cpp
@@ -18,10 +18,14 @@
 // gtest
 #  include <gtest/gtest.h>
 
+// os
+#  include <sched.h>
+
 // std
 #  include <atomic>
 #  include <memory>
 #  include <string>
+#  include <thread>
 
 namespace
 {

--- a/libs/kernel/test/unit/type_specs_utils_test.cpp
+++ b/libs/kernel/test/unit/type_specs_utils_test.cpp
@@ -7,55 +7,57 @@
 
 // sen
 #include "sen/core/meta/alias_type.h"
-#include "sen/core/meta/callable.h"
 #include "sen/core/meta/class_type.h"
+#include "sen/core/meta/custom_type.h"
 #include "sen/core/meta/enum_type.h"
 #include "sen/core/meta/event.h"
 #include "sen/core/meta/method.h"
 #include "sen/core/meta/native_types.h"
 #include "sen/core/meta/optional_type.h"
+#include "sen/core/meta/property.h"
 #include "sen/core/meta/quantity_type.h"
 #include "sen/core/meta/sequence_type.h"
 #include "sen/core/meta/struct_type.h"
+#include "sen/core/meta/time_types.h"
+#include "sen/core/meta/type.h"
 #include "sen/core/meta/type_registry.h"
 #include "sen/core/meta/unit.h"
 #include "sen/core/meta/unit_registry.h"
 #include "sen/core/meta/variant_type.h"
 #include "sen/kernel/type_specs_utils.h"
+#include "stl/sen/kernel/basic_types.stl.h"
+#include "stl/sen/kernel/type_specs.stl.h"
 
 // gtest
 #include <gtest/gtest.h>
 
 // std
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <set>
 #include <string>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace
 {
 
-using sen::AliasSpec;
 using sen::AliasType;
 using sen::ClassSpec;
 using sen::ClassType;
 using sen::ConstTypeHandle;
 using sen::Enumerator;
-using sen::EnumSpec;
 using sen::EnumType;
 using sen::OptionalSpec;
 using sen::OptionalType;
-using sen::QuantitySpec;
 using sen::QuantityType;
-using sen::StructSpec;
 using sen::StructType;
 using sen::UnitCategory;
 using sen::UnitSpec;
 using sen::VariantField;
-using sen::VariantSpec;
 using sen::VariantType;
 
 /// Every generated class carries a constructor; a hand-built one without it is not realistic.
@@ -202,7 +204,8 @@ TEST(RuntimeCompatibility, GradesEveryNativePair)
   {
     for (const auto& [toName, toType]: natives)
     {
-      const auto key = fromName + ">" + toName;
+      std::string key = fromName;
+      key.append(">").append(toName);
       const bool expectedLossless = (fromName == toName) || lossless.count(key) != 0;
       const bool reported = !lossyReading(fromType, toType).empty();
 

--- a/libs/util/benchmark/.clang-tidy
+++ b/libs/util/benchmark/.clang-tidy
@@ -1,0 +1,10 @@
+# Checks a benchmark cannot satisfy, relaxed here and nowhere else.
+#
+# google-benchmark's loop is `for (auto _ : state)`, so every benchmark body reads as a store
+# that is never used; a benchmark walks its own fixture array with a running index; and fixture
+# data is static by nature. Everything else in the root configuration still applies.
+InheritParentConfig: true
+Checks: >
+  -cert-err58-cpp,
+  -clang-analyzer-deadcode.DeadStores,
+  -cppcoreguidelines-pro-bounds-constant-array-index

--- a/libs/util/benchmark/dr/dead_reckoner_benchmark.cpp
+++ b/libs/util/benchmark/dr/dead_reckoner_benchmark.cpp
@@ -12,6 +12,7 @@
 #include "sen/util/dr/detail/dead_reckoner_impl.h"
 
 // implementation
+#include "constants.h"
 #include "utils.h"
 
 // 3rd party
@@ -22,6 +23,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 
 namespace sen::util
 {

--- a/libs/util/test/dead_reckoner_test.cpp
+++ b/libs/util/test/dead_reckoner_test.cpp
@@ -13,16 +13,16 @@
 
 // implementation
 #include "constants.h"
+#include "quat.h"
 #include "utils.h"
 
 // gtest
 #include <gtest/gtest.h>
 
 // std
+#include <algorithm>
 #include <chrono>
 #include <cmath>
-#include <iomanip>
-#include <iostream>
 
 namespace sen::util
 {
@@ -367,48 +367,55 @@ Situation referenceSituation(const GeodeticSituation& value)
 }
 
 // Equator, two mid latitudes and both poles beside the date line, to take both branches in toEcef.
-const GeodeticSituation geodeticSamples[] = {
-  {false,
-   initialTimeStamp,
-   {0.0, 0.0, 0.0},
-   {0.1, 0.2, 0.3},
-   {10, -20, 35},
-   {0.01, 0.02, 0.03},
-   {1.0, -2.0, 0.5},
-   {0.001, 0.002, 0.003}},
-  {false,
-   initialTimeStamp,
-   {48.8566, 2.3522, 35.0},
-   {1.2, -0.4, 2.9},
-   {-120, 45, -8},
-   {0.2, 0.0, -0.1},
-   {-1.5, 0.25, 3.0},
-   {0.03, -0.01, 0.0}},
-  {false,
-   initialTimeStamp,
-   {-33.8688, 151.2093, 120.0},
-   {-2.0, 0.9, -1.1},
-   {300, 0, 12},
-   {0.0, 0.5, 0.0},
-   {0.0, 0.0, -9.81},
-   {0.0, 0.2, 0.0}},
-  {false,
-   initialTimeStamp,
-   {89.5, -179.5, 11000.0},
-   {0.5, 0.5, 0.5},
-   {5, 5, 5},
-   {0.1, 0.1, 0.1},
-   {1.0, 1.0, 1.0},
-   {0.01, 0.01, 0.01}},
-  {false,
-   initialTimeStamp,
-   {-89.9, 179.9, -50.0},
-   {3.0, -1.5, 0.2},
-   {-7, 3, 90},
-   {-0.3, 0.0, 0.4},
-   {2.0, -2.0, 0.0},
-   {0.0, -0.05, 0.02}},
-};
+// Behind a function so the samples are built on first use: Quantity range-checks in its
+// constructor, so at namespace scope this would be dynamic initialisation that can throw.
+const auto& geodeticSamples()
+{
+  static const GeodeticSituation samples[] = {
+    {false,
+     initialTimeStamp,
+     {0.0, 0.0, 0.0},
+     {0.1, 0.2, 0.3},
+     {10, -20, 35},
+     {0.01, 0.02, 0.03},
+     {1.0, -2.0, 0.5},
+     {0.001, 0.002, 0.003}},
+    {false,
+     initialTimeStamp,
+     {48.8566, 2.3522, 35.0},
+     {1.2, -0.4, 2.9},
+     {-120, 45, -8},
+     {0.2, 0.0, -0.1},
+     {-1.5, 0.25, 3.0},
+     {0.03, -0.01, 0.0}},
+    {false,
+     initialTimeStamp,
+     {-33.8688, 151.2093, 120.0},
+     {-2.0, 0.9, -1.1},
+     {300, 0, 12},
+     {0.0, 0.5, 0.0},
+     {0.0, 0.0, -9.81},
+     {0.0, 0.2, 0.0}},
+    {false,
+     initialTimeStamp,
+     {89.5, -179.5, 11000.0},
+     {0.5, 0.5, 0.5},
+     {5, 5, 5},
+     {0.1, 0.1, 0.1},
+     {1.0, 1.0, 1.0},
+     {0.01, 0.01, 0.01}},
+    {false,
+     initialTimeStamp,
+     {-89.9, 179.9, -50.0},
+     {3.0, -1.5, 0.2},
+     {-7, 3, 90},
+     {-0.3, 0.0, 0.4},
+     {2.0, -2.0, 0.0},
+     {0.0, -0.05, 0.02}},
+  };
+
+  return samples;
+}
 
 void expectSameOrientation(const Orientation& expected, const Orientation& actual)
 {
@@ -417,6 +424,9 @@ void expectSameOrientation(const Orientation& expected, const Orientation& actua
   EXPECT_EQ(expected.phi.get(), actual.phi.get());
 }
 
+// gtest's EXPECT_ macros expand to branches, so this flat list of per-field assertions
+// trips the complexity threshold with no control flow of its own.
+// NOLINTNEXTLINE(readability-function-size)
 void expectSameSituation(const Situation& expected, const Situation& actual)
 {
   EXPECT_EQ(expected.isFrozen, actual.isFrozen);
@@ -439,6 +449,9 @@ void expectSameSituation(const Situation& expected, const Situation& actual)
   EXPECT_EQ(expected.angularAcceleration.z.get(), actual.angularAcceleration.z.get());
 }
 
+// gtest's EXPECT_ macros expand to branches, so this flat list of per-field assertions
+// trips the complexity threshold with no control flow of its own.
+// NOLINTNEXTLINE(readability-function-size)
 void expectSameGeodeticSituation(const GeodeticSituation& expected, const GeodeticSituation& actual)
 {
   EXPECT_EQ(expected.isFrozen, actual.isFrozen);
@@ -468,7 +481,7 @@ void expectSameGeodeticSituation(const GeodeticSituation& expected, const Geodet
 /// @requirements(SEN-1058)
 TEST(DeadReckonerTest, geodeticConversionUnchangedBySharedRotation)
 {
-  for (const auto& sample: geodeticSamples)
+  for (const auto& sample: geodeticSamples())
   {
     const auto ecefSample = referenceSituation(sample);
     expectSameGeodeticSituation(referenceGeodeticSituation(ecefSample), impl::toGeodeticSituation(ecefSample));
@@ -480,7 +493,7 @@ TEST(DeadReckonerTest, geodeticConversionUnchangedBySharedRotation)
 /// @requirements(SEN-1058)
 TEST(DeadReckonerTest, ecefConversionUnchangedBySharedRotation)
 {
-  for (const auto& sample: geodeticSamples)
+  for (const auto& sample: geodeticSamples())
   {
     const auto expected = referenceSituation(sample);
     expectSameSituation(expected, impl::toSituation(sample));

--- a/libs/util/test/quat_test.cpp
+++ b/libs/util/test/quat_test.cpp
@@ -14,13 +14,11 @@
 #include "utils.h"
 #include "vec3.h"
 
-// sen
-#include "sen/core/base/numbers.h"
-
 // gtest
 #include <gtest/gtest.h>
 
 // std
+#include <algorithm>
 #include <cmath>
 
 using namespace sen::util;  // NOLINT

--- a/test/util/cmake_packages/level1/src/level1_class_s.h
+++ b/test/util/cmake_packages/level1/src/level1_class_s.h
@@ -11,6 +11,9 @@
 #include "level0_class.h"
 #include "stl/level1.stl.h"
 
+// The name is package identity, not just a symbol: the yaml these fixtures load
+// names level1S.Level1ClassImpl, so renaming it would fail at run time, not compile time.
+// NOLINTNEXTLINE(readability-identifier-naming)
 namespace level1S
 {
 

--- a/test/util/cmake_packages/level2/src/level2_class_s.h
+++ b/test/util/cmake_packages/level2/src/level2_class_s.h
@@ -11,6 +11,9 @@
 #include "level1_class_s.h"
 #include "stl/level2.stl.h"
 
+// The name is package identity, not just a symbol: the yaml these fixtures load
+// names level2S.Level2ClassImpl, so renaming it would fail at run time, not compile time.
+// NOLINTNEXTLINE(readability-identifier-naming)
 namespace level2S
 {
 


### PR DESCRIPTION
**Adds `clang_tidy_diff.yaml`**, running clang-tidy over the lines a pull request changes and failing on any finding, wired into `CI OK`. It reads the compile database rather than the opt-in target list, so it covers many translation units where the nightly covers 31 targets.

**Clears what that wider scope exposes.** A sweep of the whole compile database found 76 distinct defects. This takes them to two, both inside imgui's own bindings in the conan cache — which no diff can contain, and which `explorer_imgui` never opted in to analyse.

**Benchmarks get their own configuration.** 41 of the 76 were google-benchmark's idiom, not defects: `for (auto _ : state)` reads as a dead store, a benchmark indexes its own fixture array with a running counter, and fixture data is static. A `.clang-tidy` in the two benchmark directories relaxes exactly those three checks. The `misc-include-cleaner` findings in the same files are fixed, not waived.