### PR TITLE
fix(mcp_gateway): set the per-call timeout and fix error names

### DIFF
--- a/apps/mcp_gateway/src/errors.ts
+++ b/apps/mcp_gateway/src/errors.ts
@@ -6,17 +6,27 @@
 // =====================================================================================================================
 
 export class GatewayError extends Error {
+  // Declared per class rather than taken from new.target.name, which is the class's runtime name
+  // and so whatever a minifier chose. Audit entries record this, and a mangled one says nothing.
+  static readonly errorName: string = "GatewayError";
+
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
-    this.name = new.target.name;
+    this.name = new.target.errorName;
   }
 }
 
-export class GatewayInputError extends GatewayError {}
+export class GatewayInputError extends GatewayError {
+  static override readonly errorName: string = "GatewayInputError";
+}
 
-export class GatewayStateError extends GatewayError {}
+export class GatewayStateError extends GatewayError {
+  static override readonly errorName: string = "GatewayStateError";
+}
 
 export class KernelDisconnectedError extends GatewayStateError {
+  static override readonly errorName: string = "KernelDisconnectedError";
+
   constructor(kernelName: string) {
     super(`kernel '${kernelName}' is not connected (was it disconnected? call listKernels)`);
   }
@@ -25,6 +35,8 @@ export class KernelDisconnectedError extends GatewayStateError {
 // Shares KernelDisconnectedError's surface message so callers see one uniform diagnostic
 // regardless of which race (never-registered vs. disconnected) the gateway lost.
 export class KernelNotFoundError extends GatewayStateError {
+  static override readonly errorName: string = "KernelNotFoundError";
+
   constructor(kernelName: string) {
     super(`kernel '${kernelName}' is not connected (was it disconnected? call listKernels)`);
   }

--- a/apps/mcp_gateway/src/instructions.ts
+++ b/apps/mcp_gateway/src/instructions.ts
@@ -80,6 +80,12 @@ INTERESTS
   \`invokeMethod\`, event subscriptions) takes the interest name as a handle. Always
   \`releaseInterest\` when done; otherwise the server keeps streaming updates for nothing.
 
+  \`declareInterest\` returns once the interest is registered, which is not the same as its
+  match-set being full: the \`matched\` it returns is a snapshot and can be short, or empty,
+  for an object that is about to appear. Naming an object that is not in it yet fails with
+  "object not in interest match-set". If the object you want is missing from \`matched\`, call
+  \`listObjects\` until it appears rather than treating the absence as final.
+
   If you plan to write or invoke, declare the interest with \`withSchemas: true\` so every type
   involved in matched objects ships with its JSON-Schema. You can then shape values and
   arguments correctly without an extra \`getType\` round-trip per type.
@@ -188,8 +194,10 @@ WORKED EXAMPLE (illustrative; the shape your kernel returns will reflect its own
   -> declareInterest({ name: "primaryStudents",
                        query: "SELECT school.Student FROM school.primary",
                        withSchemas: true })
-  <- { "kernel": "local", "name": "primaryStudents",
-       "matched": [{ "name": "alice", "className": "school.Student" }] }
+  <- { "kernel": "local", "name": "primaryStudents", "matched": [] }
+  -> listObjects({ name: "primaryStudents" })          # alice was not in the snapshot yet
+  <- { "interest": "primaryStudents",
+       "objects": [{ "name": "alice", "className": "school.Student" }] }
   -> getProperty({ interestName: "primaryStudents", objectName: "alice",
                    propertyName: "focusLevel" })
   <- { "object": "alice", "property": "focusLevel", "value": 0.72 }

--- a/apps/mcp_gateway/src/kernel.ts
+++ b/apps/mcp_gateway/src/kernel.ts
@@ -26,6 +26,12 @@ export const EVENT_BUFFER_BYTE_CAP = 8 * 1024 * 1024;
 
 export const INTEREST_CAP_PER_KERNEL = 64;
 
+// Per-call ceiling for the tools' kernel calls. @sen/client defaults to 2s, which expires on a
+// kernel that is merely slow: `declareInterest` with `withSchemas` fetches a schema per
+// newly-seen type on top of the query. Bounded rather than removed, so a wedged kernel fails the
+// call instead of hanging the tool.
+export const CALL_TIMEOUT_MS = 30_000;
+
 // An AbortSignal never warns about its listener count until something sets a ceiling, so this
 // call is the only thing that would report a reintroduced leak.
 //
@@ -105,6 +111,7 @@ export class Kernel {
       this.clientPromise = connect({
         url: this.url,
         openTimeoutMs: this.openTimeoutMs,
+        defaultTimeoutMs: CALL_TIMEOUT_MS,
         onError: (err) => this.log(`[${this.name}] client error: ${err.message}`),
       })
         .then((c) => {

--- a/apps/mcp_gateway/src/tools.ts
+++ b/apps/mcp_gateway/src/tools.ts
@@ -84,6 +84,8 @@ async function audited<T>(ctx: GatewayContext, entry: AuditEntry, effect: () => 
     ctx.audit({ ...entry, outcome: "ok" });
     return result;
   } catch (err) {
+    // The name only. An error message can quote the value that was rejected, and no audit entry
+    // carries values; @sen/client sets literal names so this survives minification.
     ctx.audit({ ...entry, outcome: "failed", error: err instanceof Error ? err.name : "unknown" });
     throw err;
   }

--- a/apps/mcp_gateway/test/integration/sen_tools.test.ts
+++ b/apps/mcp_gateway/test/integration/sen_tools.test.ts
@@ -19,6 +19,7 @@ if (!GATEWAY_ENTRYPOINT) {
 }
 
 type ToolText = { type: "text"; text: string };
+type ToolResult = { content: unknown; isError?: boolean };
 
 function textOf(result: { content: unknown }): string {
   const arr = result.content as ToolText[];
@@ -36,15 +37,27 @@ describe("sen-mcp-gateway against a real Sen", () => {
   let client: Client;
   let transport: StdioClientTransport;
 
+  // Checked here rather than after the wait: a failed declareInterest otherwise surfaces
+  // inside waitForObjects as a JSON parse error on "no interest open with name", which names
+  // neither the call that failed nor the reason it did.
+  async function declareInterest(args: Record<string, unknown>): Promise<ToolResult> {
+    const result = (await client.callTool({ name: "declareInterest", arguments: args })) as ToolResult;
+    const detail = `declareInterest ${JSON.stringify(args)} failed: ${JSON.stringify(result.content)}`;
+    expect(result.isError ?? false, detail).toBe(false);
+    return result;
+  }
+
   // declareInterest returns once the interest is registered; its match-set fills
   // asynchronously, so a call naming the object straight afterwards can fail with
   // "object not in interest match-set".
   async function waitForObjects(interestName: string, names: readonly string[], timeoutMs = 10_000): Promise<void> {
     const deadline = Date.now() + timeoutMs;
     for (;;) {
-      const listed = jsonOf<{ objects: Array<{ name: string }> }>(
-        await client.callTool({ name: "listObjects", arguments: { name: interestName } }),
-      );
+      const raw = (await client.callTool({ name: "listObjects", arguments: { name: interestName } })) as ToolResult;
+      if (raw.isError === true) {
+        throw new Error(`listObjects("${interestName}") failed: ${JSON.stringify(raw.content)}`);
+      }
+      const listed = jsonOf<{ objects: Array<{ name: string }> }>(raw);
       const have = new Set(listed.objects.map((o) => o.name));
       if (names.every((n) => have.has(n))) return;
       if (Date.now() >= deadline) {
@@ -65,8 +78,15 @@ describe("sen-mcp-gateway against a real Sen", () => {
     });
     client = new Client({ name: "sen-mcp-gateway-test", version: "0.0.0" }, { capabilities: {} });
     await client.connect(transport);
-    // Single kernel for the whole file; tools omit `kernel` and auto-resolve.
-    await client.callTool({ name: "connectToKernel", arguments: { name: "test", url: senUrl } });
+    // Single kernel for the whole file; tools omit `kernel` and auto-resolve. Checked, because
+    // a failure here makes every test in the file fail on something further downstream.
+    const connected = (await client.callTool({
+      name: "connectToKernel",
+      arguments: { name: "test", url: senUrl },
+    })) as ToolResult;
+    expect(connected.isError ?? false, `connectToKernel ${senUrl} failed: ${JSON.stringify(connected.content)}`).toBe(
+      false,
+    );
   });
 
   afterAll(async () => {
@@ -115,12 +135,8 @@ describe("sen-mcp-gateway against a real Sen", () => {
   });
 
   it("declareInterest -> listObjects -> getProperty -> releaseInterest happy path", async () => {
-    const declared = await client.callTool({
-      name: "declareInterest",
-      arguments: { name: "primary", query: "SELECT * FROM test.primary" },
-    });
+    const declared = await declareInterest({ name: "primary", query: "SELECT * FROM test.primary" });
     await waitForObjects("primary", ["instance1"]);
-    expect(declared.isError ?? false).toBe(false);
     const declaredPayload = jsonOf<{ name: string; matched: Array<{ name: string; className: string }> }>(declared);
     expect(declaredPayload.name).toBe("primary");
     expect(declaredPayload.matched).toEqual(
@@ -156,12 +172,8 @@ describe("sen-mcp-gateway against a real Sen", () => {
   });
 
   it("declareInterest with a name already in use returns isError without disturbing the prior interest", async () => {
-    const first = await client.callTool({
-      name: "declareInterest",
-      arguments: { name: "dup", query: "SELECT * FROM test.primary" },
-    });
+    const first = await declareInterest({ name: "dup", query: "SELECT * FROM test.primary" });
     await waitForObjects("dup", ["instance1"]);
-    expect(first.isError ?? false).toBe(false);
 
     const conflict = await client.callTool({
       name: "declareInterest",
@@ -188,10 +200,7 @@ describe("sen-mcp-gateway against a real Sen", () => {
     };
     expect((await interestNames()).has("tracked")).toBe(false);
 
-    await client.callTool({
-      name: "declareInterest",
-      arguments: { name: "tracked", query: "SELECT * FROM test.primary" },
-    });
+    await declareInterest({ name: "tracked", query: "SELECT * FROM test.primary" });
     expect((await interestNames()).has("tracked")).toBe(true);
 
     await client.callTool({ name: "releaseInterest", arguments: { name: "tracked" } });
@@ -201,10 +210,7 @@ describe("sen-mcp-gateway against a real Sen", () => {
   it("setProperty round-trips through getProperty", async () => {
     // prop7 is i32 [writable] and stable (unlike prop5 which auto-increments). The impl
     // gates accepted sets to [-5, 5] via prop7AcceptsSet; 3 is in range.
-    await client.callTool({
-      name: "declareInterest",
-      arguments: { name: "rw", query: "SELECT * FROM test.primary", withSchemas: true },
-    });
+    await declareInterest({ name: "rw", query: "SELECT * FROM test.primary", withSchemas: true });
     await waitForObjects("rw", ["instance1"]);
     try {
       const setResult = await client.callTool({
@@ -228,10 +234,7 @@ describe("sen-mcp-gateway against a real Sen", () => {
   });
 
   it("setProperty on a static property returns isError without changing state", async () => {
-    await client.callTool({
-      name: "declareInterest",
-      arguments: { name: "ro", query: "SELECT * FROM test.primary" },
-    });
+    await declareInterest({ name: "ro", query: "SELECT * FROM test.primary" });
     await waitForObjects("ro", ["instance1"]);
     try {
       // prop1 is [static]; the wire setter rejects writes.
@@ -247,10 +250,7 @@ describe("sen-mcp-gateway against a real Sen", () => {
 
   it("invokeMethod returns the parsed return value", async () => {
     // addNumbers(a:i32, b:i32) -> i32 is inherited by instance2.
-    await client.callTool({
-      name: "declareInterest",
-      arguments: { name: "calc", query: "SELECT * FROM test.secondary", withSchemas: true },
-    });
+    await declareInterest({ name: "calc", query: "SELECT * FROM test.secondary", withSchemas: true });
     await waitForObjects("calc", ["instance2"]);
     try {
       const result = await client.callTool({

--- a/components/jsonrpc/clients/typescript/src/errors.ts
+++ b/components/jsonrpc/clients/typescript/src/errors.ts
@@ -31,7 +31,9 @@ export type JsonRpcErrorCode = (typeof JsonRpcErrorCode)[keyof typeof JsonRpcErr
 export class SenClientError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
-    this.name = new.target.name;
+    // Literal rather than new.target.name: the library ships minified, so the runtime class
+    // name is whatever the bundler chose. Subclasses set their own.
+    this.name = "SenClientError";
   }
 }
 
@@ -47,6 +49,7 @@ export class JsonRpcError extends SenClientError {
     options?: ErrorOptions,
   ) {
     super(message, options);
+    this.name = "JsonRpcError";
   }
 }
 
@@ -54,6 +57,7 @@ export class JsonRpcError extends SenClientError {
 export class TransportError extends SenClientError {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
+    this.name = "TransportError";
   }
 }
 
@@ -65,6 +69,7 @@ export class TimeoutError extends SenClientError {
     options?: ErrorOptions,
   ) {
     super(message, options);
+    this.name = "TimeoutError";
   }
 }
 
@@ -80,5 +85,6 @@ export class InterestReleasedError extends SenClientError {
     options?: ErrorOptions,
   ) {
     super(`Interest "${interestName}" is released; ${operation} is no longer valid`, options);
+    this.name = "InterestReleasedError";
   }
 }


### PR DESCRIPTION
Fixes the ASan+UBSan failure on #218.

The gateway passed `openTimeoutMs` when connecting but never `defaultTimeoutMs`, so every
kernel call ran on `@sen/client`'s 2s default. `declareInterest` with `withSchemas` fetches a
JSON-Schema per newly-seen type on top of the query. On the sanitizer lane the successful one
took 1.6s and the next reached the ceiling at 2.003s.

Error classes took their name from `new.target.name`. The client ships minified, so the audit
entry for the failing call recorded `"error":"Q"`. Both packages declare their names now,
checked present as literals in the built bundles.

The integration test checked `isError` only after waiting for objects, so the failed
`declareInterest` surfaced as a JSON parse error when `listObjects` replied `no interest open
with name`. It checks at the call now.

The worked example in the gateway's instructions read an object straight from the snapshot
`declareInterest` returns, which is the race it now warns about.

Not covered here: nothing guards the error names, and a test over the TypeScript source cannot
-- the names are right there and wrong only in the bundle. Other `@sen/client` consumers still
take the 2s per-call default.
