### PR TITLE
docs: the test suite does run on windows

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -414,8 +414,7 @@ compilers or Conan yourself.
     ccache masquerade directory to `PATH` before building.
 
     **Windows.** The C++ tree and the browser stack both build with MSVC, and projects run on it.
-    The automated test suite has not been wired up for Windows since the move to GitHub, so the
-    coverage that runs on Linux does not yet run there.
+    The test suite runs there too, though on fewer configurations than Linux.
 
     For enabling and running the test suite, see [Running the tests](testing.md).
 


### PR DESCRIPTION
#263 wired up an MSVC leg on 2026-09-05 and it runs on every pull request and on main. The
install page still said the suite had not been wired up for Windows, which told a Windows
contributor their changes were untested when they are.

The new wording keeps the one real caveat: Windows is a single MSVC Release leg, where Linux
covers several configurations.
