### PR TITLE
test(package): check a component loads from the package

### DIFF
--- a/.conan/test_packages/package/conanfile.py
+++ b/.conan/test_packages/package/conanfile.py
@@ -6,9 +6,12 @@
 # ======================================================================================================================
 """Module that defines a test_package test to consume conan package in conan v2 way."""
 
+from os.path import join
+
 from conan import ConanFile
 from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain
+from conan.tools.env import Environment
 
 
 class TestPackageConan(ConanFile):
@@ -37,6 +40,14 @@ class TestPackageConan(ConanFile):
         """Defines a few test calls to ensure Sen works."""
         if not cross_building(self):
             self.run("sen --version", env="conanrun")
-            # TODO(SEN-1185): enable tests when possible
-            # self.run("sen run test_configs/my_package.yaml --start-stop", env="conanrun")
-            # ...
+
+            # my_package is built here, not shipped in the Sen package, and components are
+            # opened by bare name -- so this build tree has to be on the loader's search path
+            # or the kernel cannot find it. Both directories are listed because the build tree
+            # puts shared objects in bin/ today; a package that puts them in lib/ still works.
+            env = Environment()
+            for output_dir in (join(self.build_folder, "bin"), join(self.build_folder, "lib")):
+                env.prepend_path("LD_LIBRARY_PATH", output_dir)
+                env.prepend_path("PATH", output_dir)
+            with env.vars(self, scope="run").apply():
+                self.run("sen run test_configs/my_package.yaml --start-stop", env="conanrun")

--- a/.github/scripts/check_package_archive.py
+++ b/.github/scripts/check_package_archive.py
@@ -36,6 +36,16 @@ REQUIRED_DIRECTORIES = (
     "resources/syntax_highlighting",
 )
 
+# Named without prefix or extension because those differ by platform: libcore.so,
+# libcore.dylib, core.dll. Nothing above covers a shared library, so an archive shipping none
+# satisfied every entry.
+#
+# core is linked by the sen executable. shell is a component, and a missing component is the
+# silent case: components are opened by name only when a config asks for one. shell ships in
+# basic and full; a barebones package has none.
+REQUIRED_LIBRARY_DIR = "bin"
+REQUIRED_LIBRARIES = ("core", "shell")
+
 # sen-<version>-<processor>-<system>-<compiler>-<version>-<build type>, lower
 # case. The version is a tag or "latest", and a tag may carry an -rc suffix.
 NAME_PATTERN = re.compile(r"^sen-[^-]+(?:-rc\d+)?-[^-]+-[^-]+-[^-]+-[^-]+-(release|debug)$")
@@ -82,7 +92,25 @@ def missing_entries(entries: list[str]) -> list[str]:
     present = set(entries)
     missing = [name for name in REQUIRED_FILES if name not in present and f"{name}.exe" not in present]
     missing += [name for name in REQUIRED_DIRECTORIES if not any(entry.startswith(f"{name}/") for entry in entries)]
+    missing += [
+        f"{REQUIRED_LIBRARY_DIR}/{name} (shared library)"
+        for name in REQUIRED_LIBRARIES
+        if not any(_is_shared_library(entry, name) for entry in entries)
+    ]
     return missing
+
+
+def _is_shared_library(entry: str, name: str) -> bool:
+    """Whether an archive entry is the shared library `name`, in any platform's spelling.
+
+    Matches a versioned suffix (libcore.so.0.0.0) as well as the bare name, since the
+    versioned file is the real one and the bare name is a symlink to it.
+    """
+    stem = entry.rsplit("/", 1)[-1]
+    if entry != f"{REQUIRED_LIBRARY_DIR}/{stem}":
+        return False
+
+    return stem in (f"{name}.dll", f"lib{name}.dylib") or stem.startswith(f"lib{name}.so")
 
 
 def check_archive(archive: Path) -> list[str]:

--- a/.github/scripts/test_check_package_archive.py
+++ b/.github/scripts/test_check_package_archive.py
@@ -25,7 +25,8 @@ WINDOWS_NAME = "sen-0.6.0-amd64-windows-msvc-19.44.35228.0-release"
 LINUX_MEMBERS = (
     "LICENSE.txt",
     "bin/sen",
-    "bin/libkernel.so.0.0.0",
+    "bin/libcore.so.0.0.0",
+    "bin/libshell.so",
     "cmake/sen/sen_targets.cmake",
     "cmake/sen/SenConfigVersion.cmake",
     "cmake/sen/util/sen_utils.cmake",
@@ -33,7 +34,14 @@ LINUX_MEMBERS = (
     "resources/syntax_highlighting/stl.tmLanguage.json",
 )
 
-WINDOWS_MEMBERS = tuple("bin/sen.exe" if member == "bin/sen" else member for member in LINUX_MEMBERS)
+# Windows spells the same archive differently: an .exe, and DLLs with no lib prefix.
+WINDOWS_SPELLINGS = {
+    "bin/sen": "bin/sen.exe",
+    "bin/libcore.so.0.0.0": "bin/core.dll",
+    "bin/libshell.so": "bin/shell.dll",
+}
+
+WINDOWS_MEMBERS = tuple(WINDOWS_SPELLINGS.get(member, member) for member in LINUX_MEMBERS)
 
 
 def write_archive(directory: Path, stem: str, members, suffix: str = ".tar.gz") -> Path:
@@ -131,3 +139,31 @@ def test_a_symlinked_executable_ships(tmp_path):
                 tar.add(payload, f"{LINUX_NAME}/{member}")
 
     assert check_archive(archive) == []
+
+
+def test_archive_without_shared_libraries_is_rejected(tmp_path):
+    """The gap this check closes: everything else present, no library shipped."""
+    members = tuple(m for m in LINUX_MEMBERS if not m.startswith("bin/lib"))
+    problems = check_archive(write_archive(tmp_path, LINUX_NAME, members))
+    assert any("shared library" in problem for problem in problems)
+
+
+def test_versioned_and_bare_library_names_both_satisfy(tmp_path):
+    """libcore.so is a symlink to libcore.so.0.0.0; either spelling is the library."""
+    for spelling in ("bin/libcore.so", "bin/libcore.so.0.0.0"):
+        members = tuple(m for m in LINUX_MEMBERS if not m.startswith("bin/libcore")) + (spelling,)
+        assert check_archive(write_archive(tmp_path, LINUX_NAME, members)) == []
+
+
+def test_windows_and_macos_library_spellings_are_accepted(tmp_path):
+    """The name has no prefix or extension precisely because these three differ."""
+    for spelling in ("bin/core.dll", "bin/libcore.dylib"):
+        members = tuple(m for m in WINDOWS_MEMBERS if not m.startswith(("bin/core", "bin/libcore"))) + (spelling,)
+        assert check_archive(write_archive(tmp_path, WINDOWS_NAME, members, ".zip")) == []
+
+
+def test_a_library_outside_the_library_directory_does_not_count(tmp_path):
+    """Shipping it somewhere the loader will not look is the failure, not the fix."""
+    members = tuple(m for m in LINUX_MEMBERS if not m.startswith("bin/libcore")) + ("lib/libcore.so",)
+    problems = check_archive(write_archive(tmp_path, LINUX_NAME, members))
+    assert any("shared library" in problem for problem in problems)


### PR DESCRIPTION
**A component now loads from the installed package.** The conan `test_package` built a
consumer against Sen.

**The archive check now asserts a shared library ships.** It pinned `bin/sen` and a header
directory, so an archive containing no libraries at all satisfied every entry. Two
representatives: `core`, which the `sen` executable links and which ships in every mode, and
`shell`, a component. Components are the silent case — opened by name only when a
configuration asks for one, so a missing one is invisible until someone runs a config that
wants it.

The library names carry no prefix or extension because those differ per platform
(`libcore.so`, `libcore.dylib`, `core.dll`), and a versioned suffix satisfies the check since
the bare name is a symlink to it.