### PR TITLE
ci: fix the conan cache keys and stop invoking ccache twice

### DIFF
--- a/.github/actions/build_documentation/action.yaml
+++ b/.github/actions/build_documentation/action.yaml
@@ -28,9 +28,9 @@ runs:
         path: ~/.conan2/p
         key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs
 
-    # This keeps its cache inside the workspace, which the container mounts at the
-    # same path, so the compiler shims on PATH below reach the same directory the
-    # runner saves. Writes only on main, as above.
+    # This keeps its cache inside the workspace, which the container mounts at the same
+    # path, so what compiles inside the container writes where the runner saves from.
+    # CCACHE_DIR is set to match below. Writes only on main, as above.
     - uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639  # v1.2
       with:
         key: docs
@@ -51,15 +51,17 @@ runs:
       shell: bash
       run: |
         .github/scripts/in_image.sh <<'IN'
-        # ccache first, so the shims are found ahead of the compilers themselves.
-        export PATH="/usr/lib/ccache:$HOME/.local/bin:$PATH"
+        export PATH="$HOME/.local/bin:$PATH"
         export CCACHE_DIR="$PWD/.ccache"
         pip install --user --quiet -r docs/requirements.txt
         conan config install .conan/profiles/ --target-folder "$CONAN_HOME/profiles/"
         # --profile:all names both host and build profile. Copying one over `default`
         # instead is what makes a documented `conan install --profile=...` work here
         # and fail for a reader.
-        conan install . --profile:all=sen_build_docs --build=missing
+        # Shims for the dependencies only, and the sloppiness with them, as in standard_test.yaml.
+        PATH="/usr/lib/ccache:$PATH" \
+          CCACHE_SLOPPINESS=clang_index_store,include_file_ctime,include_file_mtime,locale,pch_defines,time_macros \
+          conan install . --profile:all=sen_build_docs --build=missing
         cmake --preset=conan-gcc-release
         # The handbook runs the built binaries to capture their command-line help, so
         # these targets pull in the six the snippets depend on.
@@ -72,27 +74,27 @@ runs:
       shell: bash
       run: |
         .github/scripts/in_image.sh <<'IN'
-        conan cache clean "*" -s -b -d
+        conan cache clean "*" -s -b -d -t
         IN
 
     # After the clean, so build folders stay out. main reaches this through
     # build_docs.yaml, which is what keeps the slice pull requests restore.
     - name: Drop the ccache entry this run replaces
-      if: always() && github.ref == 'refs/heads/main'
+      if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
       run: bash .github/scripts/drop_cache_key.sh "ccache-docs"
 
     - name: Drop the entry this save replaces
-      if: always() && github.ref == 'refs/heads/main'
+      if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
       run: bash .github/scripts/drop_cache_key.sh "conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs"
 
     - name: Save conan packages
-      if: always() && github.ref == 'refs/heads/main'
+      if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
       uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25  # v5
       with:
         path: ~/.conan2/p

--- a/.github/actions/prepare_build/action.yaml
+++ b/.github/actions/prepare_build/action.yaml
@@ -35,26 +35,30 @@ inputs:
     required: false
     default: "17"
 
+outputs:
+  cache-key:
+    description: >-
+      The primary conan cache key this lane asked for, which a restore reports unchanged whether
+      it hit, fell back or missed. A job that owns a slice saves under it.
+    value: ${{ steps.conan-cache.outputs.cache-primary-key }}
+
 runs:
   using: composite
   steps:
-    # A daily key: dependencies are rebuilt at most once a day, and a restore
-    # key still finds yesterday's entry.
-    - name: Generate daily cache id
-      id: cache-id
-      shell: bash
-      run: echo "date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_OUTPUT"
-
-    # The key scheme matches standard_test.yaml, so a lane restores what the
-    # day's builds already populated. No ccache anywhere in the nightly lanes:
-    # sanitized and instrumented objects must not mix into the slices that the
-    # pull-request builds keep, and each lane compiles every file once anyway.
-    - name: Cache conan packages
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+    # Restore only, under the key standard_test.yaml and conan.yaml write on a push to main, so a
+    # lane reads what a merge already built. No date in the key: drop_cache_key.sh can delete an
+    # entry, so a save can replace one.
+    #
+    # No ccache in any lane reaching this action: the nightly's sanitized and instrumented objects
+    # must not mix into the slices the pull-request builds keep, and these lanes compile Sen's
+    # tree once per run.
+    - name: Restore conan packages
+      id: conan-cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: ~/.conan2/p
-        key: conanp-${{ inputs.runner-label }}-${{ inputs.compiler-name }}-${{ inputs.compiler-version }}-${{ inputs.std }}-${{ steps.cache-id.outputs.date }}
-        restore-keys: conanp-${{ inputs.runner-label }}-${{ inputs.compiler-name }}-${{ inputs.compiler-version }}-${{ inputs.std }}-
+        key: conanp-${{ inputs.runner-label }}-${{ inputs.compiler-name }}-${{ inputs.compiler-version }}-${{ inputs.std }}
+        restore-keys: conanp-${{ inputs.runner-label }}-${{ inputs.compiler-name }}-${{ inputs.compiler-version }}-
 
     - name: Setup build context
       uses: ./.github/actions/setup_build_context

--- a/.github/scripts/drop_cache_key.sh
+++ b/.github/scripts/drop_cache_key.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Deletes the cache entries a save is about to replace. Keys are immutable, so a
-# save can only add: without this every merge leaves another copy and the
-# repository passes GitHub's 10 GB limit, after which entries are evicted at
-# random.
+# Deletes the cache entries a save is about to replace. A key is immutable, so a
+# save can never overwrite one. Where the key varies -- the ccache timestamp -- every
+# merge leaves another copy until the repository passes GitHub's 10 GB limit and
+# entries are evicted at random. Where it is fixed, the save is refused instead, and
+# the entry never refreshes.
 #
 # Refuses to run off main, because the saves it accompanies run only there and an
 # ungated delete would take the shared entry from any branch. Fails rather than

--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -98,6 +98,12 @@ jobs:
             for tool in llvm-profdata llvm-cov; do
                 test -x "/usr/lib/llvm-20/bin/$tool" || { echo "missing: $tool"; exit 1; }
             done
+            # ccache reaches a dependency build through these masquerade shims and through
+            # nothing else. The ccache package creates them by apt trigger, so a compiler
+            # installed in a later transaction than ccache silently gets none.
+            for shim in gcc-12 g++-12 clang-20 clang++-20; do
+                test -x "/usr/lib/ccache/$shim" || { echo "missing shim: $shim"; exit 1; }
+            done
             # Coverage and the sanitizers need the clang runtime library, which
             # --no-install-recommends leaves out unless it is asked for.
             printf "int main(){return 0;}" > /tmp/probe.cpp

--- a/.github/workflows/conan.yaml
+++ b/.github/workflows/conan.yaml
@@ -92,22 +92,22 @@ jobs:
         run: echo "Pushing package (fake entry)"
 
       - name: Remove unwanted parts from conan cache before backup
-        if: always()
+        if: ${{ !cancelled() }}
         shell: bash
         run: |
-          conan remove sen --confirm
-          conan cache clean "*" -s -b -d
+          conan remove "sen/*" --confirm
+          conan cache clean "*" -s -b -d -t
 
       # After the clean, so sen itself and the build folders stay out.
       - name: Drop the entry this save replaces
-        if: always() && github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/drop_cache_key.sh "conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}"
 
       - name: Save conan packages
-        if: always() && github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.conan2/p

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -302,6 +302,10 @@ jobs:
     name: "Newest gcc and newer consumer standards"
     runs-on: ubuntu-24.04
     timeout-minutes: 150
+    permissions:
+      contents: read
+      # Dropping the cache entry the save below replaces.
+      actions: write
     env:
       CC: gcc-14
       CXX: g++-14
@@ -311,6 +315,7 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare the build
+        id: prepare
         uses: ./.github/actions/prepare_build
         with:
           compiler-name: gcc
@@ -341,9 +346,38 @@ jobs:
               echo "::endgroup::"
           done
 
-  # The pull-request pipeline measures coverage but keeps the report as a run
-  # artifact, which nobody looks at. The clang leg does not run on main, so
-  # measuring here once a day is what gives the report a stable home.
+      # No merge-path leg builds gcc-14, so this job owns its slice. conan create leaves Sen's
+      # sources and build folders behind, and none of that can serve a restore.
+      #
+      # sen/* because the bare name raises when the recipe is absent; -t because conan leaves a
+      # failed build's folders out of its database, where no other flag reaches them.
+      - name: Remove unwanted parts from the conan cache before saving
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          conan remove "sen/*" --confirm
+          conan cache clean "*" -s -b -d -t
+
+      # A key is immutable, so while the old entry exists the save is refused, quietly, and the
+      # slice would never refresh. Neither step runs unless the restore succeeded and the run was
+      # not cancelled: the delete would land and the upload would not.
+      - name: Drop the entry this save replaces
+        if: ${{ !cancelled() && steps.prepare.outcome == 'success' && github.ref == 'refs/heads/main' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/drop_cache_key.sh "${{ steps.prepare.outputs.cache-key }}"
+
+      - name: Save conan packages
+        if: ${{ !cancelled() && steps.prepare.outcome == 'success' && github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.conan2/p
+          key: ${{ steps.prepare.outputs.cache-key }}
+
+  # The pull-request pipeline measures coverage and gates on it, but keeps the report as
+  # a run artifact, which nobody looks at. Measuring here once a day is what gives the
+  # report a stable home to be published from.
   coverage:
     name: "Coverage report"
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -42,10 +42,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      # prepare_build would be the obvious thing to reuse here, but it saves at the
-      # end of the job, and a cache written from a pull request is private to it:
-      # every open pull request storing its own slice puts the repository past
-      # GitHub's 10 GB limit. So this restores always and saves from main only.
+      # prepare_build is not reused here: it keys on the runner and compiler, and this lane
+      # needs the image instead, for the reason below. A cache written from a pull request is
+      # private to it, and every open pull request storing its own slice puts the repository
+      # past GitHub's 10 GB limit. So this restores always and saves from main only.
       # Keyed to the image, not the runner: a conan package id does not distinguish
       # one Ubuntu from another, and the runner's cache holds 24.04 binaries whose
       # libstdc++ is newer than the image's -- they install here and fail at link.
@@ -142,22 +142,22 @@ jobs:
       # sen recipe first; this lane never exports one, because it installs and builds
       # rather than creating the package, so asking would fail on a missing recipe.
       - name: Clean the conan cache before saving
-        if: always() && github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         shell: bash
         run: |
           .github/scripts/in_image.sh <<'IN'
-          conan cache clean "*" -s -b -d
+          conan cache clean "*" -s -b -d -t
           IN
 
       - name: Drop the entry this save replaces
-        if: always() && github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/drop_cache_key.sh "conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17"
 
       - name: Save conan packages
-        if: always() && github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.conan2/p

--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -42,7 +42,9 @@ jobs:
       # Generous on purpose: a cold cache builds every dependency from
       # source. The cap ends a hang, it does not police duration. Measured
       # 2026-08-20 on a run whose conan cache missed and whose ccache hit 1.3
-      # per cent: 20 to 30 minutes, so this is around four times the work.
+      # per cent: 20 to 30 minutes, so this is around four times the work. That
+      # predates the scoping of the ccache shims, so a cold run should now be
+      # faster than the figure this cap was set from.
     timeout-minutes: 120
     strategy:
       # One failing configuration used to cancel the others, so a pull request
@@ -71,6 +73,9 @@ jobs:
           path: ~/.conan2/p
           key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}
 
+      # Sen's targets reach ccache through CMAKE_<LANG>_COMPILER_LAUNCHER (sen_utils.cmake), so
+      # the shims must not also be on PATH while it builds: the launcher would invoke a shim and
+      # store every object twice. 631 compile edges drew 1223 ccache calls, run 34117054695.
       - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
         if: runner.os == 'Linux'
         with:
@@ -109,10 +114,19 @@ jobs:
       - name: Compile base libraries
         shell: bash
         run: |
-          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-
           # & applies build_type to the sen package only; dependencies stay at
           # the profiles' Release default, which is what binary remotes serve.
+          #
+          # Dependencies build in their own systems and never see the launcher, so the shims are
+          # their only route to ccache; on the conan build below they would be a second one. The
+          # sloppiness rides with the launcher, so this route needs its own: conan extracts a
+          # dependency's sources just before compiling them, and the default mtime check calls
+          # that too new to store.
+          if [ "$RUNNER_OS" = Linux ] && [ ! -x "/usr/lib/ccache/$CXX" ]; then
+            echo "::warning::no /usr/lib/ccache/$CXX, so dependency builds are not cached"
+          fi
+          PATH="/usr/lib/ccache:$PATH" \
+          CCACHE_SLOPPINESS=clang_index_store,include_file_ctime,include_file_mtime,locale,pch_defines,time_macros \
           conan install . -s "&:build_type=${{ matrix.build_type }}" \
             -s "&:compiler.cppstd=${{ matrix.std }}" --build=missing \
             -o "sen/*:with_tests=True" \
@@ -162,7 +176,6 @@ jobs:
         env:
           TESTCONTAINERS_RYUK_DISABLED: "true"
         run: |
-          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           # Same reason as the first of these, in standard_test.yaml. Conan writes
           # .bat rather than .sh on Windows, where cmake takes the generator's path
           # from the cache instead.
@@ -189,7 +202,6 @@ jobs:
         timeout-minutes: 20
         shell: bash
         run: |
-          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           # Same reason as the first of these, in standard_test.yaml.
           source build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/generators/conanbuild.sh
           cmake --build build/${{ matrix.compiler.name }}/${{ matrix.build_type }}/ \
@@ -270,29 +282,29 @@ jobs:
       #     token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Remove unwanted parts from conan cache before backup
-        if: always()
+        if: ${{ !cancelled() }}
         shell: bash
         run: |
-          conan cache clean "*" -s -b -d
+          conan cache clean "*" -s -b -d -t
 
       # After the clean, so build folders stay out. always() keeps what a
       # cancelled run already built.
       - name: Drop the ccache entry this run replaces
-        if: always() && runner.os == 'Linux' && github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() && runner.os == 'Linux' && github.ref == 'refs/heads/main' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/drop_cache_key.sh "ccache-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ matrix.build_type }}"
 
       - name: Drop the entry this save replaces
-        if: always() && github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/drop_cache_key.sh "conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}"
 
       - name: Save conan packages
-        if: always() && github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.conan2/p

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -410,8 +410,12 @@ compilers or Conan yourself.
 
     **Time.** The first full-mode build compiles every third-party dependency plus the whole
     tree; on a typical developer machine expect on the order of half an hour to an hour.
-    Subsequent builds are incremental. `ccache` shortens rebuilds. CI simply prepends the
-    ccache masquerade directory to `PATH` before building.
+    Subsequent builds are incremental. Sen's own tree wires `ccache` in through
+    `CMAKE_<LANG>_COMPILER_LAUNCHER` whenever it is installed, so there is nothing to
+    configure. Dependencies build inside their own projects and never see that, so to
+    cache them too, put your distribution's ccache shim directory — `/usr/lib/ccache` on
+    Debian and Ubuntu — ahead of the compilers on `PATH` for the `conan install` step
+    only, which is what CI does.
 
     **Windows.** The C++ tree and the browser stack both build with MSVC, and projects run on it.
     The test suite runs there too, though on fewer configurations than Linux.

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -217,29 +217,49 @@ when Windows tests are enabled. The lockfile check job resolves a Debug
 consumer graph and fails if any dependency left the Release default.
 
 **Caches.** Conan packages: one Actions cache entry per runner and compiler
-(`conanp-<runner>-<compiler>-<version>-<std>-<date>`). All build types share
-it, because dependencies always build as Release. It is restored by prefix,
-so the newest entry wins, and sources and build folders are cleaned before
-saving.
+(`conanp-<runner>-<compiler>-<version>-<std>`), plus two keyed on the CI image
+instead, for the lanes that build inside it (`conanp-image-<hash>-<...>`). All build types share it,
+because dependencies always build as Release. The key carries no date. An
+Actions key is immutable, so refreshing an entry means deleting it and saving
+again, which `.github/scripts/drop_cache_key.sh` does immediately before each
+save; sources and build folders are cleaned first. `prepare_build` restores without
+saving, and is the one place with a fallback: if its exact key is missing it takes the
+newest entry for the same runner and compiler, whatever standard the entry was built
+for. Dependencies are Release-only and every leg is C++17, so today that fallback can
+only reach an entry with identical contents.
 
-**Entries are written only on pushes to main.** A cache written from a pull
-request is private to that pull request, so if every open pull request saved
-its own copy, the repository would pass GitHub's 10 GB limit and GitHub would
-evict continuously.
+**Entries are written only from `main`.** A cache written from a pull request
+is private to that pull request, so if every open pull request saved its own
+copy, the repository would pass GitHub's 10 GB limit and GitHub would evict
+continuously. Every save is guarded on `github.ref == 'refs/heads/main'`, which
+a push to main satisfies and so does the nightly schedule, since a scheduled run
+uses the default branch. A `workflow_dispatch` from a branch does not, and writes
+nothing. The nightly therefore writes several entries: the newest-gcc lane owns `conanp-ubuntu-24.04-gcc-14-17`, and the
+packaging and documentation jobs it calls rewrite the shared runner keys and the
+image-keyed ones. That last part is a known race — those are keys the nightly's own
+lanes restore, so a lane reaching its restore inside the window between a delete and
+the matching save builds its dependencies from source instead.
 
 That rule has a consequence which is easy to miss. **A configuration that
-never runs on main never gets an entry at all.** The arm configuration is in
-that position today: it is not selected by the packaging workflow, it is not
-selected on main, and no nightly job covers it, so nothing writes its entry.
-It therefore builds every dependency from source on every pull request, which
-takes far longer than the other configurations and depends on the upstream
-source servers being reachable at that moment.
+never runs on main never gets an entry at all**, and pays a full source build
+of every dependency on every run. Every configuration a pull request runs also runs
+on main, which `test_generate_matrix_jobs.py` pins for the test matrix, so
+everything a pull request needs is written. The converse does not hold: packaging
+builds four configurations on main and only the shipping one on a pull request. The
+exposure is a compiler that appears solely in a nightly lane, which is why that lane
+writes its own entry rather than restoring one nothing produces. A configuration
+without an entry does not merely build slowly — it fetches every dependency from the
+upstream source servers, and depends on those being reachable at that moment.
 
-ccache: one entry per runner, compiler, build type and run. The action that
-writes it puts a timestamp in the key, so every run on main leaves a new entry
-and the previous one stays until it is evicted.
+ccache: one entry per runner, compiler, build type and run, its key carrying a
+timestamp, and the previous entry deleted before each save as the conan entries
+are. Compilation reaches ccache through `CMAKE_<LANG>_COMPILER_LAUNCHER`, set in
+`cmake/util/sen_utils.cmake`. The masquerade shims in `/usr/lib/ccache` go on
+`PATH` only while conan builds dependencies, which compile in their own projects
+and never see the launcher; in front of Sen's own build they would add a second
+ccache to the chain and store every object twice.
 
-**Only the test workflow keeps a ccache.** `conan create` compiles in a folder
+**Packaging keeps no ccache.** `conan create` compiles in a folder
 whose name changes every run, so its object files never match the ones a test
 build produces, and the two workflows shared a key. Whichever wrote last won, and
 because the nightly runs the packaging workflow without the test workflow, the
@@ -389,7 +409,7 @@ implying the container covers every platform.
 | packaging         | `conan create` for every packaged configuration             | the pull request builds only the shipping configuration |
 | public headers under C++20 | sen itself built at C++20                            | its own sources have to compile under a newer standard, not only C++17 |
 | newest gcc        | whole tree with the newest gcc on a runner, then the sample consumer at C++20 and C++23 | pull requests build with the oldest supported compiler and only C++17 |
-| coverage          | clang Debug build with coverage, report published to `<site>/coverage/` | the clang job does not run on main, so the report is produced here instead |
+| coverage          | clang Debug build with coverage, report published to `<site>/coverage/` | the clang Debug leg measures coverage on every pull request and gates on it; this job exists to publish the report, and repeats the build to do so |
 
 When a nightly job fails, it creates or updates a single tracking issue, so
 all nightly failures are collected in one place.
@@ -477,7 +497,9 @@ crash), `.ruff.toml` per-file ignores (tutorial scripts),
   on, so moving it is a coordinated change to both images and is done by hand.
 - **Add a benchmark or a nightly job**: follow the existing shape; a new
   nightly job joins the `needs` list of the tracking-issue job, so its
-  failures are reported.
+  failures are reported. If it builds a configuration no merge-path leg builds,
+  it must also save that configuration's conan entry, or it restores nothing for
+  as long as it exists.
 
 ## Landing a change
 
@@ -561,9 +583,8 @@ stack**, and the pull request it blocks is not necessarily the one being merged.
   The last is excluded because duplicate test module names there break the
   run.
 - A fresh runner builds all dependencies from source once per cache
-  lifetime; the first run of a day (or after the cache was removed) is the
-  slow one. The arm configuration pays it on every run, because nothing
-  writes its cache entry; see the caches paragraph under Dependencies.
+  lifetime; a run whose entry was evicted, or never written, is the slow one.
+  See the caches paragraph under Dependencies.
 - `pre-commit/action` caches the hook environments itself, and its key includes
   the interpreter path. Both call sites have to ask `setup-python` for the same
   version, or a pull request cannot restore what the nightly saved.


### PR DESCRIPTION
## Why

`prepare_build` keyed on the UTC date and saved under it, with a fallback rung ending in a dash.
The merge path writes the same key without a date, and a fallback key is a prefix, so the two
could never meet.

Separately, the workflow put the `/usr/lib/ccache` shims on `PATH` as well as setting
`CMAKE_<LANG>_COMPILER_LAUNCHER`, so the launcher's ccache invoked a shim rather than the
compiler and stored every object twice.

## What changed

- `prepare_build` restores only, under the key the merge path writes, and publishes that key.
- The newest-gcc lane owns `conanp-ubuntu-24.04-gcc-14-17`; no merge-path leg builds gcc-14.
- The shims move to the `conan install` command, carrying the sloppiness the launcher supplies.
  Dependencies compile in their own build systems and never see the launcher; Sen's targets do.
- Three fixes applied to every lane rather than one: `conan remove "sen/*"`, because the bare name
  raises when the recipe is absent; `conan cache clean -t`, because a failed build's folders are
  not in conan's database; and `!cancelled()` on drop-and-save, because a cancelled run landed the
  delete and lost the upload.
- `ci-image.yaml` asserts the shims exist, without which this silently does nothing.

## Result

gcc-x86 Debug, run 34117054695 before and this pull request after:

| | before | after |
|---|---|---|
| cacheable calls | 1223 | 631 |
| hit rate | 5.72% | 42.95% |
| direct hits | 0.82% | 25.67% |
| cleanups | 82 | 26 |

631 is the ninja compile-edge count, so the doubling is gone exactly. `Cleanups` is not zero:
`max-size: 1G` is now the binding constraint rather than the duplication.

The documentation described the dated scheme; correcting it also fixed three statements that were
already false — arm having no cache writer, the clang leg not running on main, and the ccache
entry never being deleted.
