### PR TITLE
fix(gen): reach the type tree on a narrow screen

### DIFF
--- a/libs/gen/src/html/app/explorer.js
+++ b/libs/gen/src/html/app/explorer.js
@@ -284,6 +284,21 @@ function refreshPkgCounts(){
   });
 }
 
+// Below the drawer width the tree sits over the detail pane rather than beside it.
+function setDrawer(open){
+  var tree=document.getElementById("tree"),
+      scrim=document.getElementById("scrim"),
+      menu=document.getElementById("menu");
+  if(!tree)return;
+  tree.classList.toggle("open",open);
+  if(scrim)scrim.classList.toggle("on",open);
+  if(menu)menu.setAttribute("aria-expanded",open?"true":"false");
+}
+function drawerOpen(){
+  var tree=document.getElementById("tree");
+  return !!tree&&tree.classList.contains("open");
+}
+
 // The tree shows one kind at a time, so opening a type has to bring its tab with it or the
 // selection sits on a tab the reader cannot see.
 function setKindMode(mode){
@@ -624,6 +639,8 @@ function show(name,viaTrail){
   if(b){b.disabled=trail.length===0;
         b.title=trail.length?"Back to "+trail[trail.length-1]:"Back";}
   sel=name;
+  // Every route to a type ends here, so this is the one place the drawer has to close.
+  setDrawer(false);
   setKindMode(t.kind==="classes"?"classes":"data");
   var d=document.getElementById("detail"); d.textContent=""; d.scrollTop=0;
 
@@ -863,6 +880,8 @@ function start(data){
   document.getElementById("back").onclick=function(){
     if(!trail.length)return; show(trail.pop(),true);
   };
+  document.getElementById("menu").onclick=function(){setDrawer(!drawerOpen());};
+  document.getElementById("scrim").onclick=function(){setDrawer(false);};
   window.addEventListener("popstate",function(){
     var hh=fragment();
     if(T[hh])show(hh,true); else showNothing();
@@ -882,6 +901,7 @@ function start(data){
     var q=document.getElementById("q");
     if(e.key==="/"&&e.target!==q){e.preventDefault();q.focus();q.select();return;}
     if(e.key==="Escape"&&e.target===q){q.value="";applyFilter();q.blur();return;}
+    if(e.key==="Escape"&&drawerOpen()){setDrawer(false);return;}
     if((e.key==="Backspace"||(e.altKey&&e.key==="ArrowLeft"))&&e.target!==q){
       e.preventDefault();var b=document.getElementById("back");
       if(!b.disabled)b.click();return;}

--- a/libs/gen/src/html/app/shell.html
+++ b/libs/gen/src/html/app/shell.html
@@ -9,6 +9,7 @@
 <body>
 <div id="app">
   <header>
+    <button id="menu" title="Browse types" aria-controls="tree" aria-expanded="false">☰</button>
     <button id="back" title="Back" disabled>←</button>
     <h1 id="modelname">{{ title }}</h1>
     <span class="sub" id="hsub"></span>
@@ -30,6 +31,7 @@
       <div class="scroller" id="scroller"></div>
       <div class="scroller" id="results" hidden></div>
     </nav>
+    <div id="scrim"></div>
     <div id="split" title="Drag to resize"></div>
     <div id="detail"></div>
   </main>

--- a/libs/gen/src/html/app/styles.css
+++ b/libs/gen/src/html/app/styles.css
@@ -350,4 +350,20 @@ footer .made{display:inline-flex;align-items:center;gap:.4rem}
 footer .logo{width:15px;height:15px;display:block;opacity:.9}
 footer{padding:.4rem .9rem;background:var(--panel);border-top:1px solid var(--line);
   font-size:.72rem;color:var(--dim);display:flex;gap:1rem;flex-wrap:wrap}
-@media (max-width:60em){main{grid-template-columns:1fr}#tree{display:none}}
+/* Only shown below the drawer width. */
+#menu,#scrim{display:none}
+
+/* Narrow: the tree slides over the detail pane. One row, so a long entry scrolls in the
+   detail pane rather than being clipped by main's overflow. */
+@media (max-width:48em){
+  main{grid-template-columns:minmax(0,1fr);grid-template-rows:minmax(0,1fr);position:relative}
+  #split{display:none}
+  #menu{display:block}
+  #tree{position:absolute;inset:0 auto 0 0;z-index:2;width:min(20rem,84vw);
+    transform:translateX(-100%);transition:transform .18s ease-out}
+  #tree.open{transform:none}
+  #scrim{display:block;position:absolute;inset:0;z-index:1;background:rgba(0,0,0,.45);
+    opacity:0;pointer-events:none;transition:opacity .18s ease-out}
+  #scrim.on{opacity:1;pointer-events:auto}
+}
+@media (prefers-reduced-motion:reduce){#tree,#scrim{transition:none}}

--- a/libs/gen/test/html_generator_test.cpp
+++ b/libs/gen/test/html_generator_test.cpp
@@ -222,6 +222,23 @@ TEST_F(AnHtmlGenerator, theShellNamesFilesThatAreEmitted)
   }
 }
 
+// The control, the stylesheet and the script have to agree, and nothing else checks that they
+// do: a rule hiding the tree passes every other test in this file.
+TEST_F(AnHtmlGenerator, keepsTheTreeReachableWhenTheViewportIsNarrow)
+{
+  generate(twoClasses);
+
+  const auto& shell = file("index.html");
+  EXPECT_NE(shell.find("aria-controls=\"tree\""), std::string::npos)
+    << "the shell offers no control that reveals the tree";
+
+  const auto& styles = file("app.css");
+  EXPECT_EQ(styles.find("#tree{display:none}"), std::string::npos)
+    << "the stylesheet hides the tree outright, so a narrow viewport loses the navigation";
+
+  EXPECT_NE(file("app.js").find("setDrawer"), std::string::npos) << "the application never opens or closes the tree";
+}
+
 TEST_F(AnHtmlGenerator, theModelAndTheApplicationAgreeOnTheGlobal)
 {
   generate(twoClasses);


### PR DESCRIPTION
The tree was `display:none` below 60em, taking the search, the tabs and the filters with it,
with nothing in the page to bring them back. On a phone, and in any desktop window under
960px, that left a detail pane you could only move around by following references.

It is now a drawer over the detail pane, opened from the header and closed by picking a type,
tapping outside or pressing Escape. The breakpoint moves to 48em.
