### PR TITLE
ci: fall back to a source mirror when an origin is down

### DIFF
--- a/.github/actions/build_documentation/action.yaml
+++ b/.github/actions/build_documentation/action.yaml
@@ -55,6 +55,11 @@ runs:
         export CCACHE_DIR="$PWD/.ccache"
         pip install --user --quiet -r docs/requirements.txt
         conan config install .conan/profiles/ --target-folder "$CONAN_HOME/profiles/"
+        # A dependency's upstream tarball host going down fails any build with a cold cache.
+        # xapian-core, under doxygen, did on 2026-09-08 and blocked the merge queue. Conan
+        # tries ConanCenter's mirror of the same sources first, then the origin.
+        printf 'core.sources:download_urls=["https://c3i.jfrog.io/artifactory/conan-center-backup-sources/", "origin"]\n' \
+            >> "$CONAN_HOME/global.conf"
         # --profile:all names both host and build profile. Copying one over `default`
         # instead is what makes a documented `conan install --profile=...` work here
         # and fail for a reader.

--- a/.github/actions/setup_build_context/action.yaml
+++ b/.github/actions/setup_build_context/action.yaml
@@ -89,6 +89,10 @@ runs:
         # how the arm leg ended up refusing to install libgl.
         printf 'tools.system.package_manager:mode=install\ntools.system.package_manager:sudo=True\n' \
             >> ~/.conan2/global.conf
+        # Same reason as the docs action: an upstream tarball host going down fails any
+        # build with a cold cache, so try ConanCenter's mirror of the sources first.
+        printf 'core.sources:download_urls=["https://c3i.jfrog.io/artifactory/conan-center-backup-sources/", "origin"]\n' \
+            >> ~/.conan2/global.conf
         conan profile show -pr default
       env:
         COMPILER: ${{ inputs.compiler-name }}


### PR DESCRIPTION
The docs lane went to a cold conan cache when #285 changed tools/ci/Dockerfile, because that cache is keyed on the Dockerfile hash with no restore-key fallback. A cold cache builds dependencies from source, and xapian-core — pulled in by doxygen — fetches its tarball from oligarchy.co.uk, which is down. That failed the docs build on main and is blocking the merge queue.

ConanCenter mirrors the same sources. This points conan at the mirror first and the origin second, in the docs action and in the shared build context every matrix lane uses.

Verified: the mirror serves the exact sha256 the xapian recipe expects.