### PR TITLE
feat(gen): add a typst generator

### DIFF
--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -88,9 +88,15 @@ jobs:
             set -e
             for tool in conan python3 pip3 ccache git make g++-12 gcc-12 \
                         clang++-20 clang-tidy-20 gcovr lcov genhtml \
-                        pytest junitparser bats objdump; do
+                        pytest junitparser bats objdump plantuml typst; do
                 command -v "$tool" > /dev/null || { echo "missing: $tool"; exit 1; }
             done
+            # The reference typst sets is set in Liberation Sans. Without it the document
+            # silently repaginates and the tree connectors stop lining up. A missing font
+            # is not a missing command, and there is no fontconfig here to ask, so the
+            # check is for the file typst reads.
+            test -f /usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf \
+                || { echo "missing: Liberation Sans"; exit 1; }
             conan --version | grep -F "'"$conan_version"'"
             python3 -c "import junitparser, pytest"
             # The coverage report target calls these by their versioned names

--- a/apps/cli_gen/src/CMakeLists.txt
+++ b/apps/cli_gen/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set(cli_gen_sources
     plantuml_cli.cpp
     python_cli.cpp
     typescript_cli.cpp
+    typst_cli.cpp
     main.cpp
 )
 

--- a/apps/cli_gen/src/main.cpp
+++ b/apps/cli_gen/src/main.cpp
@@ -30,6 +30,7 @@ void setupMkDocsCli(CLI::App& app);
 void setupPlantUMLCli(CLI::App& app);
 void setupPythonCli(CLI::App& app);
 void setupTypeScriptCli(CLI::App& app);
+void setupTypstCli(CLI::App& app);
 }  // namespace sen::cli_gen
 
 //--------------------------------------------------------------------------------------------------------------
@@ -56,6 +57,7 @@ int runApp(int argc, char* argv[])
     setupHtmlCli(app);
     setupJsonCli(app);
     setupTypeScriptCli(app);
+    setupTypstCli(app);
 
     app.footer("For help on specific commands run 'sen generate <command> --help'");
 

--- a/apps/cli_gen/src/typst_cli.cpp
+++ b/apps/cli_gen/src/typst_cli.cpp
@@ -1,0 +1,142 @@
+// === typst_cli.cpp ===================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+// app
+#include "cli_input.h"
+#include "io.h"
+
+// lib
+#include "sen/gen/typst.h"
+
+// sen
+#include "sen/core/lang/fom_parser.h"
+#include "sen/core/lang/stl_resolver.h"
+
+// cli11
+#include <CLI/App.hpp>
+// NOLINTNEXTLINE (misc-include-cleaner): cli11 needs all headers to correctly link required vtables
+#include <CLI/CLI.hpp>
+
+// std
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <tuple>
+
+namespace
+{
+
+struct TypstArgs
+{
+  std::filesystem::path outputDir;
+  sen::gen::TypstOptions options;
+};
+
+// What goes in the document is the caller's decision, never something inferred from the
+// shape of the model: two runs over the same model must be able to produce two documents.
+void setupTypstArgs(CLI::App& app, TypstArgs& args)
+{
+  auto& options = args.options;
+  app.add_option("-o, --output", args.outputDir, "Directory to write the document into")->required();
+  app.add_option("-t, --title", options.title, "Name of the model, shown on the running header");
+
+  app.add_option("--include-package", options.includePackages, "Only document this package; repeatable")
+    ->allow_extra_args(false);
+  app.add_option("--exclude-package", options.excludePackages, "Leave this package out; repeatable")
+    ->allow_extra_args(false);
+
+  app.add_flag("!--no-overview", options.overview, "Drop the model overview");
+  app.add_flag("!--no-hierarchy", options.hierarchy, "Drop the class hierarchy");
+  app.add_flag("!--no-summaries", options.summaries, "Drop the per-package summary lists");
+  app.add_flag("!--no-index", options.index, "Drop the index of every type");
+  app.add_flag("!--no-used-by", options.usedBy, "Drop the list of what refers to each type");
+  app.add_flag("!--no-flag-legend", options.flagLegend, "Drop the explanation of the property flags");
+  app.add_flag("!--no-built-ins", options.builtIns, "Drop the list of the language's built-in types");
+
+  app.add_option("--front-matter", options.frontMatter, "Typst file to include before the reference, as a title page")
+    ->check(CLI::ExistingFile);
+  app.add_option("--before-reference", options.beforeReference, "Typst file to include after the front matter")
+    ->check(CLI::ExistingFile);
+  app.add_option("--after-reference", options.afterReference, "Typst file to include after the reference")
+    ->check(CLI::ExistingFile);
+  app.add_option("--style", options.style, "Typst file defining the look, replacing the one shipped")
+    ->check(CLI::ExistingFile);
+}
+
+// Typst resolves an include against the directory holding the document and refuses a path
+// that climbs out of it, so a page can only be named by a bare filename. Copying the
+// caller's pages in beside the document is what lets them keep theirs wherever they like.
+void writeOutput(const sen::lang::TypeSetContext& typeSets, const TypstArgs& args)
+{
+  auto options = args.options;
+  std::vector<std::filesystem::path> pages;
+  for (auto* point: {&options.frontMatter, &options.beforeReference, &options.afterReference, &options.style})
+  {
+    if (!point->empty())
+    {
+      pages.push_back(*point);
+      *point = point->filename();
+    }
+  }
+
+  sen::gen::TypstGenerator generator;
+  const auto files = generator.generate(typeSets, options);
+
+  for (const auto& [relPath, body]: files)
+  {
+    writeFile(args.outputDir / relPath, body);
+  }
+
+  std::filesystem::create_directories(args.outputDir);
+  for (const auto& page: pages)
+  {
+    std::filesystem::copy_file(
+      page, args.outputDir / page.filename(), std::filesystem::copy_options::overwrite_existing);
+  }
+
+  std::cout << "stl|typst> " << files.size() << " files in " << args.outputDir << std::endl;
+  std::cout << "           compile with: typst compile " << (args.outputDir / "document.typ").string() << std::endl;
+}
+
+}  // namespace
+
+namespace sen::cli_gen
+{
+
+void setupTypstCli(CLI::App& app)
+{
+  auto typstArgs = std::make_shared<TypstArgs>();
+  auto typst = app.add_subcommand("typst", "Generate a typesettable reference for the data model");
+  typst->require_subcommand();
+
+  auto stl = setupStlInput(*typst,
+                           [typstArgs](auto args)
+                           {
+                             sen::lang::TypeSetContext typeSets;
+                             for (const auto& fileName: args->inputs)
+                             {
+                               std::ignore = sen::lang::readTypesFile(fileName, args->includePaths, typeSets, {});
+                             }
+                             writeOutput(typeSets, *typstArgs);
+                           });
+
+  setupTypstArgs(*stl, *typstArgs);
+
+  auto fom = setupFomInput(*typst,
+                           [typstArgs](auto args)
+                           {
+                             const sen::lang::TypeSetContext typeSets =
+                               sen::lang::parseFomDocuments(args->paths, args->mappingFiles, {});
+                             writeOutput(typeSets, *typstArgs);
+                           });
+
+  setupTypstArgs(*fom, *typstArgs);
+  stl->excludes(fom);
+}
+
+}  // namespace sen::cli_gen

--- a/apps/cli_gen/src/typst_cli.cpp
+++ b/apps/cli_gen/src/typst_cli.cpp
@@ -18,6 +18,7 @@
 
 // cli11
 #include <CLI/App.hpp>
+#include <CLI/Validators.hpp>
 // NOLINTNEXTLINE (misc-include-cleaner): cli11 needs all headers to correctly link required vtables
 #include <CLI/CLI.hpp>
 
@@ -27,6 +28,7 @@
 #include <memory>
 #include <string>
 #include <tuple>
+#include <vector>
 
 namespace
 {

--- a/cmake/util/sen_codegen_utils.cmake
+++ b/cmake/util/sen_codegen_utils.cmake
@@ -882,6 +882,222 @@ function(sen_generate_html)
   endif()
 endfunction()
 
+# Generates a typesettable reference from STL or HLA FOM files.
+# Creates a custom target that runs the generator on demand, and with PDF a second
+# step that compiles the result.
+#
+# sen_generate_typst(
+#   TARGET <name>
+#     Name of the custom CMake target that triggers generation.
+#
+#   OUT <dir>
+#     Directory the document is written into. Like the HTML generator this is a
+#     directory: document.typ, reference.typ and style.typ are written side by side.
+#
+#   [TITLE <text>]
+#     Name of the model, shown on the running header. Defaults to the generator's own.
+#
+#   [PDF]
+#     Also compile the document. Requires the typst program on PATH; without it the
+#     target still writes the .typ files and the compile step is skipped with a note,
+#     so a machine that cannot typeset is not a build failure.
+#
+#   [FRONT_MATTER <file>]
+#   [BEFORE_REFERENCE <file>]
+#   [AFTER_REFERENCE <file>]
+#     Typst files included at those points, for a title page and any pages of your own.
+#     Paths are resolved when the document is compiled, not when it is generated.
+#
+#   [STYLE <file>]
+#     Typst file defining the look, replacing the one Sen ships.
+#
+#   [BASE_PATH <path>]
+#     Root directory for import resolution. Defaults to CMAKE_CURRENT_SOURCE_DIR.
+#
+#   [IMPORT_PATHS <dirs...>]
+#     Further roots for import resolution, for a model whose packages are rooted in more
+#     than one place. Searched in addition to BASE_PATH.
+#
+#   [STL_FILES <files...>]
+#     Sen Type Language (.stl) files to document. Mutually exclusive with HLA_FOM_DIRS.
+#
+#   [HLA_FOM_DIRS <dirs...>]
+#     Directories containing HLA FOM XML files to document.
+#     Mutually exclusive with STL_FILES.
+#
+#   [HLA_MAPPINGS_FILE <files...>]
+#     HLA mapping files forwarded to the generator. Requires HLA_FOM_DIRS.
+function(sen_generate_typst)
+
+  set(_options PDF)
+  set(_one_value_args
+      TARGET
+      BASE_PATH
+      OUT
+      TITLE
+      FRONT_MATTER
+      BEFORE_REFERENCE
+      AFTER_REFERENCE
+      STYLE
+  )
+  set(_multi_value_args
+      STL_FILES
+      HLA_FOM_DIRS
+      HLA_MAPPINGS_FILE
+      IMPORT_PATHS
+  )
+
+  cmake_parse_arguments(
+    _arg
+    "${_options}"
+    "${_one_value_args}"
+    "${_multi_value_args}"
+    ${ARGN}
+  )
+
+  if(NOT _arg_TARGET)
+    message(FATAL_ERROR "sen_generate_typst: no TARGET set")
+  endif()
+
+  if(NOT _arg_OUT)
+    message(FATAL_ERROR "sen_generate_typst: no OUT set")
+  endif()
+
+  if(_arg_STL_FILES AND _arg_HLA_FOM_DIRS)
+    message(FATAL_ERROR "sen_generate_typst: STL_FILES and HLA_FOM_DIRS cannot be present at the same time")
+  endif()
+
+  if(_arg_HLA_MAPPINGS_FILE AND NOT _arg_HLA_FOM_DIRS)
+    message(FATAL_ERROR "sen_generate_typst: HLA_MAPPINGS_FILE is defined, but no HLA_FOM_DIRS were specified")
+  endif()
+
+  set(_opts)
+  if(_arg_TITLE)
+    list(
+      APPEND
+      _opts
+      --title
+      ${_arg_TITLE}
+    )
+  endif()
+
+  # Absolute, so the page is found from the build directory. The generator copies it in
+  # beside the document, because typst resolves an include against the document's own
+  # directory and refuses a path that climbs out of it.
+  foreach(
+    _point
+    FRONT_MATTER
+    BEFORE_REFERENCE
+    AFTER_REFERENCE
+    STYLE
+  )
+    if(_arg_${_point})
+      get_filename_component(_abs_point ${_arg_${_point}} ABSOLUTE)
+      string(TOLOWER ${_point} _flag)
+      string(
+        REPLACE "_"
+                "-"
+                _flag
+                ${_flag}
+      )
+      list(
+        APPEND
+        _opts
+        --${_flag}
+        ${_abs_point}
+      )
+    endif()
+  endforeach()
+
+  if(_arg_BASE_PATH)
+    get_filename_component(_abs_base_path ${_arg_BASE_PATH} ABSOLUTE)
+  else()
+    set(_abs_base_path ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
+
+  # A model whose packages are rooted in more than one place needs more than one
+  # root: each component resolves its imports against its own directory. Repeating
+  # the flag rather than relying on one greedy -i, which would swallow what follows.
+  set(_abs_import_paths)
+  foreach(_import_path ${_arg_IMPORT_PATHS})
+    get_filename_component(_abs_import_path ${_import_path} ABSOLUTE)
+    list(
+      APPEND
+      _abs_import_paths
+      -i
+      ${_abs_import_path}
+    )
+  endforeach()
+
+  if(_arg_STL_FILES)
+    set(_input_files_list)
+
+    foreach(_stl_file ${_arg_STL_FILES})
+      get_filename_component(_abs_stl_file ${_stl_file} ABSOLUTE)
+      list(APPEND _input_files_list ${_abs_stl_file})
+    endforeach()
+
+    add_custom_target(
+      ${_arg_TARGET}
+      COMMAND sen::cli_gen typst stl ${_input_files_list} -i ${_abs_base_path} ${_abs_import_paths} --output
+              ${_arg_OUT} ${_opts}
+      DEPENDS sen::cli_gen ${_input_files_list}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      COMMENT "Generating typst reference for ${_input_files_list} in ${_arg_OUT}"
+      VERBATIM COMMAND_EXPAND_LISTS
+    )
+  endif()
+
+  if(_arg_HLA_FOM_DIRS)
+    set(_input_xmls)
+    set(_abs_fom_dirs)
+
+    foreach(_fom_dir ${_arg_HLA_FOM_DIRS})
+      get_filename_component(_abs_fom_dir ${_fom_dir} ABSOLUTE)
+      list(APPEND _abs_fom_dirs ${_abs_fom_dir})
+
+      file(
+        GLOB _xml_files
+        LIST_DIRECTORIES false
+        "${_fom_dir}/*.xml"
+      )
+      list(APPEND _input_xmls ${_xml_files})
+    endforeach()
+
+    set(_mapping_opt)
+    if(_arg_HLA_MAPPINGS_FILE)
+      get_filename_component(_abs_mapping_file ${_arg_HLA_MAPPINGS_FILE} ABSOLUTE)
+      list(APPEND _input_xmls ${_abs_mapping_file})
+      set(_mapping_opt "--mappings=${_abs_mapping_file}")
+    endif()
+
+    add_custom_target(
+      ${_arg_TARGET}
+      COMMAND sen::cli_gen typst fom ${_mapping_opt} --directories=${_abs_fom_dirs} --output ${_arg_OUT}
+              ${_opts}
+      DEPENDS sen::cli_gen ${_input_xmls}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      COMMENT "Generating typst reference for ${_arg_HLA_FOM_DIRS} in ${_arg_OUT}"
+      VERBATIM COMMAND_EXPAND_LISTS
+    )
+  endif()
+
+  if(_arg_PDF AND TARGET ${_arg_TARGET})
+    find_program(SEN_TYPST_EXECUTABLE typst)
+    if(SEN_TYPST_EXECUTABLE)
+      add_custom_command(
+        TARGET ${_arg_TARGET}
+        POST_BUILD
+        COMMAND ${SEN_TYPST_EXECUTABLE} compile ${_arg_OUT}/document.typ ${_arg_OUT}/reference.pdf
+        COMMENT "Compiling ${_arg_OUT}/reference.pdf"
+        VERBATIM
+      )
+    else()
+      message(STATUS "sen_generate_typst: typst not found, ${_arg_TARGET} writes .typ only")
+    endif()
+  endif()
+endfunction()
+
 # Invokes a Python script at build time to generate a YAML configuration file.
 # Creates a custom target that re-runs the script whenever its inputs change.
 # If mypy is found, also creates a <TARGET>_check target that type-checks the script.

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -56,6 +56,10 @@ ${sen_exec} generate html --help > ${snippets_dir}/sen_generate_html.sh\n\
 ${sen_exec} generate html stl --help > ${snippets_dir}/sen_generate_html_stl.sh\n\
 ${sen_exec} generate html fom --help > ${snippets_dir}/sen_generate_html_fom.sh\n\
 \n\
+${sen_exec} generate typst --help > ${snippets_dir}/sen_generate_typst.sh\n\
+${sen_exec} generate typst stl --help > ${snippets_dir}/sen_generate_typst_stl.sh\n\
+${sen_exec} generate typst fom --help > ${snippets_dir}/sen_generate_typst_fom.sh\n\
+\n\
 ${sen_exec} generate json package stl --help > ${snippets_dir}/sen_generate_json_package_stl.sh\n\
 ${sen_exec} generate json package fom --help > ${snippets_dir}/sen_generate_json_package_fom.sh\n\
 \n\
@@ -102,6 +106,67 @@ exit 0"
     HLA_FOM_DIRS ${fom_base_dir}/rpr ${fom_base_dir}/netn ${fom_base_dir}/link16
   )
 
+  # Two documents, because they show different things: a FOM is one deep class tree in two
+  # packages, and Sen's own API is fifteen packages three levels deep. PDF, so the pages can
+  # link to something a reader opens rather than to source they would have to compile.
+  set(typst_pages_dir ${PROJECT_SOURCE_DIR}/docs/typst)
+
+  sen_generate_typst(
+    TARGET
+    fom_document
+    OUT
+    ${snippets_dir}/fom-document
+    TITLE
+    "RPR, NETN and Link 16"
+    HLA_FOM_DIRS
+    ${fom_base_dir}/rpr
+    ${fom_base_dir}/netn
+    ${fom_base_dir}/link16
+    FRONT_MATTER
+    ${typst_pages_dir}/front-matter.typ
+    BEFORE_REFERENCE
+    ${typst_pages_dir}/about-this-example.typ
+    PDF
+  )
+
+  file(
+    GLOB
+    _sen_api_stl
+    CONFIGURE_DEPENDS
+    ${PROJECT_SOURCE_DIR}/libs/kernel/stl/sen/kernel/*.stl
+    ${PROJECT_SOURCE_DIR}/libs/db/stl/sen/db/*.stl
+    ${PROJECT_SOURCE_DIR}/components/*/stl/*.stl
+    ${PROJECT_SOURCE_DIR}/components/*/stl/sen/components/*/*.stl
+  )
+
+  # Each component roots its own imports, so one base path cannot resolve them all.
+  file(
+    GLOB _sen_api_imports
+    LIST_DIRECTORIES true
+    ${PROJECT_SOURCE_DIR}/components/* ${PROJECT_SOURCE_DIR}/components/*/stl
+  )
+
+  sen_generate_typst(
+    TARGET
+    api_document
+    OUT
+    ${snippets_dir}/api-document
+    TITLE
+    "The Sen API"
+    STL_FILES
+    ${_sen_api_stl}
+    BASE_PATH
+    ${PROJECT_SOURCE_DIR}/libs/kernel
+    IMPORT_PATHS
+    ${PROJECT_SOURCE_DIR}/libs/db
+    ${_sen_api_imports}
+    FRONT_MATTER
+    ${typst_pages_dir}/front-matter.typ
+    BEFORE_REFERENCE
+    ${typst_pages_dir}/about-this-example.typ
+    PDF
+  )
+
   sen_generate_uml(
     TARGET fom_uml
     OUT ${snippets_dir}/fom.plantuml
@@ -132,6 +197,9 @@ exit 0"
       ${snippets_dir}/sen_generate_html.sh
       ${snippets_dir}/sen_generate_html_stl.sh
       ${snippets_dir}/sen_generate_html_fom.sh
+      ${snippets_dir}/sen_generate_typst.sh
+      ${snippets_dir}/sen_generate_typst_stl.sh
+      ${snippets_dir}/sen_generate_typst_fom.sh
       ${snippets_dir}/sen_generate_json_package_stl.sh
       ${snippets_dir}/sen_generate_json_package_fom.sh
       ${snippets_dir}/sen_generate_json_component_stl.sh
@@ -195,6 +263,8 @@ exit 0"
     snippets_target
     fom_uml
     fom_reference
+    fom_document
+    api_document
     cli_sen
     cli_gen
     cli_run

--- a/docs/examples/generated_document.md
+++ b/docs/examples/generated_document.md
@@ -1,0 +1,69 @@
+# Typeset reference (PDF)
+
+A data model set as a document you would hand to somebody: an overview of the packages, the class
+hierarchy across all of them, a table for every type, and an index. Every type name is a link, so it
+reads on screen the way the [HTML reference](generated_reference.md) does, and it prints.
+
+Two, because they are shaped differently:
+
+[The RPR, NETN and Link 16 FOMs](../snippets/fom-document/reference.pdf){ target="_blank" } — the
+same model as the HTML reference. One deep class tree, several hundred pages.
+
+[The Sen API](../snippets/api-document/reference.pdf){ target="_blank" } — Sen's own model, which is
+fifteen packages nested three deep, so the overview shows the package tree rather than one flat list.
+
+Both were produced by running the model through the generator and compiling the result, with no
+editing in between. The cover and the page after the contents are Typst files of Sen's own, included
+at points the generated document leaves open — the documents explain that about themselves.
+
+This is how the `hla_fom` example asks for it:
+
+```cmake title="examples/packages/hla_fom/CMakeLists.txt"
+--8<-- "examples/packages/hla_fom/CMakeLists.txt:typst"
+```
+
+That writes three files. `document.typ` is the one you compile; it imports `style.typ` and includes
+`reference.typ`, which holds the model. `PDF` adds the compile step, which needs the
+[Typst](https://typst.app/) compiler on your path — a single binary with no runtime under it.
+
+From the command line the same thing is `sen generate typst fom --directories rpr netn link16
+-o document`, followed by `typst compile document/document.typ`.
+
+## Making it yours
+
+The generator writes the model. Everything around it is yours, named on the command line rather than
+guessed at:
+
+| | What it does |
+| --- | --- |
+| `--front-matter` | A Typst file included first, for a title page. |
+| `--before-reference` | A Typst file included after the front matter, for a scope or an approvals page. |
+| `--after-reference` | A Typst file included after the model, for appendices. |
+| `--style` | Replaces `style.typ`, and with it every decision about how the document looks. |
+
+The generator never reads any of those files. It writes an `#include`, copies the file in beside
+the document, and Typst resolves the name when the document is compiled — so a title page can be
+anything Typst can set, and changing it does not mean regenerating the model. They are copied
+because Typst resolves an include against the directory holding the document and refuses a path
+that climbs out of it.
+
+Sections can also be dropped: `--no-overview`, `--no-hierarchy`, `--no-summaries`, `--no-index`,
+`--no-used-by`, `--no-flag-legend` and `--no-built-ins`. `--include-package` and `--exclude-package`
+narrow the document to part of the model, and each takes one package and may be repeated.
+
+## Two things that are not styling
+
+**The fonts are named, not chosen.** Liberation Sans for the text and DejaVu Sans Mono for
+everything monospaced, so the same model produces the same document on every machine — which matters
+for something people cite by page number. Typst bundles DejaVu Sans Mono and no sans-serif at all, so
+Liberation Sans has to be installed: it is in Sen's build image, and `fonts-liberation` on a Linux
+desktop. Without it Typst warns and sets the document in a serif, which repaginates it and stops the
+tree connectors lining up, because those only align in a fixed pitch. `--style` replaces the choice
+entirely.
+
+**A link only ever points into the document.** Typst treats a link to something absent as an error
+rather than a dangling link, so narrowing the model with `--exclude-package` turns references into
+that package into plain text instead of breaking the build.
+
+The same command takes `stl` in place of `fom` for a model written in STL, or a model that mixes
+the two.

--- a/docs/typst/about-this-example.typ
+++ b/docs/typst/about-this-example.typ
@@ -1,0 +1,37 @@
+// Included between the contents and the generated reference. Like the title page, Sen
+// never reads this: it is a Typst file named on the command line, and everything it says
+// about itself is demonstrated by the fact that you are reading it.
+
+#pagebreak()
+
+= About this document
+
+#block(width: 15cm)[
+  This is an example published with Sen's documentation. It was produced by running the
+  model through `sen generate typst` and compiling the result, with no editing in between.
+
+  Everything from #emph[Model overview] onwards is generated. It follows the model and only
+  the model: if a type is added, renamed or given a new description, the next build says so,
+  and nothing anyone wrote by hand is lost in the process.
+
+  This page, and the cover before it, are not generated. They are Typst files of your own
+  that the document includes at points it leaves open for you:
+
+  #v(4pt)
+  #table(
+    columns: (4.6cm, 1fr),
+    stroke: none,
+    inset: (x: 0pt, y: 3pt),
+    align: (left, left),
+    [#raw("--front-matter")], [A cover, before the contents.],
+    [#raw("--before-reference")], [Anything between the contents and the model — a scope, a
+      set of conventions, an approvals table. This page.],
+    [#raw("--after-reference")], [Appendices, after the model.],
+    [#raw("--style")], [Every decision about how the document looks.],
+  )
+
+  #v(4pt)
+  The generator does not read any of those files. It writes an `#raw("#include")` and Typst
+  resolves it when the document is compiled, so a cover page can be anything Typst can set —
+  and changing it never means regenerating the model.
+]

--- a/docs/typst/front-matter.typ
+++ b/docs/typst/front-matter.typ
@@ -1,0 +1,37 @@
+// The title page for the documents the website publishes as examples. Sen never reads
+// this file: the generator writes `#include "front-matter.typ"` at the point the skeleton
+// marks, and Typst resolves it when the document is compiled.
+
+#v(1fr)
+
+#align(center)[
+  #context text(26pt, weight: 700)[#document.title]
+
+  #v(6pt)
+  #text(13pt, fill: luma(90))[Interface Control Document]
+
+  #v(2cm)
+  #block(width: 11cm)[
+    #set par(justify: false)
+    #set align(left)
+    #text(10pt, fill: luma(70))[
+      An example, generated from the data model by Sen. The reference that follows —
+      every package, every type, every table — is written by the tool and is rewritten
+      whenever the model changes.
+
+      This page is not. It is an ordinary Typst file included at a point the generated
+      document leaves open, which is how a project puts its own cover, approvals and
+      appendices around a reference it never has to edit.
+    ]
+  ]
+]
+
+#v(1fr)
+
+#align(center)[
+  #text(9pt, fill: luma(120))[
+    Placeholder for your own project or product assets
+  ]
+]
+
+#v(1cm)

--- a/docs/users_guide/code_generation.md
+++ b/docs/users_guide/code_generation.md
@@ -17,6 +17,7 @@ The names below are the ones you type after `sen generate`.
 | `uml` | A PlantUML document describing the model. | [UML generation](../examples/generated_uml.md) |
 | `mkdocs` | One markdown file covering every type, for a Material-flavoured MkDocs site. | [Command line tools](command_line.md#mkdocs-markdown) |
 | `html` | A browsable reference that opens from a file: a tree, a search, and a view per type showing what it carries and what uses it. | [HTML reference](../examples/generated_reference.md) |
+| `typst` | A tabular reference in the shape of an interface control document, ready to typeset as a PDF. | [Typeset reference (PDF)](../examples/generated_document.md) |
 
 ## Getting it as part of your build
 
@@ -57,6 +58,20 @@ To generate into a target you made yourself, `sen_generate_cpp` and `sen_generat
 output to a target that already exists. That target has to be a compilable C++ one: both call Sen's
 target setup, which requires C++17 of anything that links it, turns on warnings as errors and links
 `sen::core`. An interface library or a custom target is rejected.
+
+`sen_generate_typst` works the same way, and `PDF` adds the compile step:
+
+```cmake
+sen_generate_typst(
+  TARGET model_document
+  OUT ${CMAKE_CURRENT_BINARY_DIR}/document
+  STL_FILES stl/my_package/my_class.stl
+  PDF
+)
+```
+
+`PDF` needs the `typst` program on the path. Without it the target still writes the `.typ` files and
+says so, because a machine that cannot typeset should not fail your build.
 
 There is no CMake function for `mkdocs` or for `ts`, which does not mean you cannot generate them
 from a build: run `sen::cli_gen` from an `add_custom_command` instead, as Sen's own TypeScript
@@ -104,6 +119,20 @@ generated, so calls into an object are still made by name.
 **`mkdocs` writes one file, and expects Material.** Everything lands in a single markdown document,
 and it uses content tabs and icon shortcodes that need
 [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) rather than plain MkDocs.
+
+**`typst` writes a document, not a PDF.** The output is Typst source: `document.typ`, the
+`reference.typ` it includes, and the `style.typ` that decides how it looks. Turning that into a PDF
+needs the [Typst](https://typst.app/) compiler, one binary with nothing under it. Keeping the two
+apart is what lets you review the document as text, and lets a build machine without a typesetter
+still produce something.
+
+**What goes in the document is yours to say.** Nothing is inferred from the shape of the model:
+`--front-matter`, `--before-reference` and `--after-reference` name Typst files of your own that the
+document includes at those points, and `--style` replaces the look entirely. The generator never
+reads any of them — it writes an `#include` and copies the file in beside the document — so a title
+page can be anything Typst can set. Each section can also be dropped: `--no-overview`,
+`--no-hierarchy`, `--no-summaries`, `--no-index`, `--no-used-by`, `--no-flag-legend`,
+`--no-built-ins`.
 
 The generators are also a library, [`sen::gen`](gen_library.md), for a program that has to write any
 of this while it runs rather than while it builds.

--- a/docs/users_guide/command_line.md
+++ b/docs/users_guide/command_line.md
@@ -156,6 +156,31 @@ needs no server and no network, so the output opens straight from a file.
 --8<-- "snippets/sen_generate_html_fom.sh"
 ```
 
+### Typeset reference (PDF)
+
+Renders the data model as a Typst document, in the shape of an interface control document:
+an overview, a class hierarchy, a table per type and an index. It writes Typst source rather
+than a PDF, so producing one is a separate step with the [Typst](https://typst.app/) compiler.
+
+What the document contains, and what it looks like, is set by the options rather than inferred
+from the model.
+
+```title="sen generate typst"
+--8<-- "snippets/sen_generate_typst.sh"
+```
+
+#### Typst from STL
+
+```title="sen generate typst stl"
+--8<-- "snippets/sen_generate_typst_stl.sh"
+```
+
+#### Typst from HLA FOMs
+
+```title="sen generate typst fom"
+--8<-- "snippets/sen_generate_typst_fom.sh"
+```
+
 ### JSON schemas
 
 Generates json schemas from a Sen data model.

--- a/examples/packages/hla_fom/CMakeLists.txt
+++ b/examples/packages/hla_fom/CMakeLists.txt
@@ -27,6 +27,16 @@ sen_generate_uml(
 )
 # --8<-- [end:uml]
 
+# --8<-- [start:typst]
+sen_generate_typst(
+  TARGET hla_fom_document
+  OUT ${CMAKE_CURRENT_BINARY_DIR}/document
+  TITLE "RPR, NETN and Link 16"
+  HLA_FOM_DIRS rpr netn link16
+  PDF
+)
+# --8<-- [end:typst]
+
 # --8<-- [start:html]
 sen_generate_html(
   TARGET hla_fom_reference

--- a/libs/gen/CMakeLists.txt
+++ b/libs/gen/CMakeLists.txt
@@ -211,6 +211,25 @@ sen_internal_generate_template_headers(
   ${html_app_files}
 )
 
+file(
+  GLOB
+  typst_app_files
+  CONFIGURE_DEPENDS
+  "src/typst/app/*.typ"
+)
+
+sen_internal_generate_template_headers(
+  OUTDIR
+  ${CMAKE_CURRENT_BINARY_DIR}/gen/typst_app
+  GEN_FILE_LIST
+  typst_app_dumps
+  TEMPLATE_FILES
+  ${typst_app_files}
+)
+
+set(typst_public_headers include/sen/gen/typst.h)
+set(typst_sources src/typst/typst_generator.cpp)
+
 set(html_public_headers include/sen/gen/html.h)
 set(html_sources src/html/html_generator.cpp src/html/html_app.cpp src/html/html_app.h)
 
@@ -242,6 +261,9 @@ add_library(
   ${typescript_template_dumps}
   ${html_public_headers}
   ${html_sources}
+  ${typst_public_headers}
+  ${typst_sources}
+  ${typst_app_dumps}
   ${html_app_dumps}
 )
 add_library(sen::gen ALIAS gen)
@@ -295,6 +317,7 @@ source_group("typescript/sources" FILES ${typescript_sources})
 source_group("typescript/templates" FILES ${typescript_templates})
 source_group("typescript/templates/dumps" FILES ${typescript_template_dumps})
 source_group("html/public" FILES ${html_public_headers})
+source_group("typst/public" FILES ${typst_public_headers})
 source_group("html/sources" FILES ${html_sources})
 source_group("html/app" FILES ${html_app_files})
 source_group("html/app/dumps" FILES ${html_app_dumps})
@@ -309,6 +332,7 @@ install(
         ${mkdocs_public_headers}
         ${typescript_public_headers}
         ${html_public_headers}
+        ${typst_public_headers}
   DESTINATION libs/gen/include/sen/gen
 )
 

--- a/libs/gen/include/sen/gen/typst.h
+++ b/libs/gen/include/sen/gen/typst.h
@@ -29,9 +29,9 @@ struct TypstOptions
   std::string title {"Data model"};
 
   /// Packages to document. Empty means every package in the model.
-  std::vector<std::string> includePackages {};
+  std::vector<std::string> includePackages;
   /// Packages to leave out, applied after `includePackages`.
-  std::vector<std::string> excludePackages {};
+  std::vector<std::string> excludePackages;
 
   /// The overview: the package table and the class hierarchy across all packages.
   bool overview {true};
@@ -43,18 +43,20 @@ struct TypstOptions
   bool index {true};
   /// The "used by" line on each type.
   bool usedBy {true};
+  /// What the codes in the Flags column mean, before the first table that uses them.
   bool flagLegend {true};
+  /// The table of the built-in types the model names, at the back.
   bool builtIns {true};
 
   /// Typst files the document includes at named points. The generator never reads them:
   /// it emits `#include` and the paths resolve when the document is compiled.
-  std::filesystem::path frontMatter {};
-  std::filesystem::path beforeReference {};
-  std::filesystem::path afterReference {};
+  std::filesystem::path frontMatter;
+  std::filesystem::path beforeReference;
+  std::filesystem::path afterReference;
 
   /// Replaces the emitted `style.typ`. Every visual decision lives in that module,
   /// so a caller changing the look never edits generated output.
-  std::filesystem::path style {};
+  std::filesystem::path style;
 };
 
 /// Renders a Sen data model as a Typst document, in the shape of an interface control

--- a/libs/gen/include/sen/gen/typst.h
+++ b/libs/gen/include/sen/gen/typst.h
@@ -1,0 +1,87 @@
+// === typst.h =========================================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#ifndef SEN_LIBS_GEN_INCLUDE_SEN_GEN_TYPST_H
+#define SEN_LIBS_GEN_INCLUDE_SEN_GEN_TYPST_H
+
+#include "sen/core/base/compiler_macros.h"
+#include "sen/core/lang/stl_resolver.h"
+
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace sen::gen
+{
+
+/// What the document contains and how it is put together. Every field defaults to the
+/// whole model and the standard sections, so a default-constructed value produces a
+/// complete document and a caller who wants that need know none of this.
+struct TypstOptions
+{
+  /// Shown on the title page and in the running header.
+  std::string title {"Data model"};
+
+  /// Packages to document. Empty means every package in the model.
+  std::vector<std::string> includePackages {};
+  /// Packages to leave out, applied after `includePackages`.
+  std::vector<std::string> excludePackages {};
+
+  /// The overview: the package table and the class hierarchy across all packages.
+  bool overview {true};
+  /// The class hierarchy within the overview. Emitted only where classes inherit.
+  bool hierarchy {true};
+  /// The per-section table of every type with its description and page.
+  bool summaries {true};
+  /// The alphabetical index of every type, at the back.
+  bool index {true};
+  /// The "used by" line on each type.
+  bool usedBy {true};
+  bool flagLegend {true};
+  bool builtIns {true};
+
+  /// Typst files the document includes at named points. The generator never reads them:
+  /// it emits `#include` and the paths resolve when the document is compiled.
+  std::filesystem::path frontMatter {};
+  std::filesystem::path beforeReference {};
+  std::filesystem::path afterReference {};
+
+  /// Replaces the emitted `style.typ`. Every visual decision lives in that module,
+  /// so a caller changing the look never edits generated output.
+  std::filesystem::path style {};
+};
+
+/// Renders a Sen data model as a Typst document, in the shape of an interface control
+/// document. Writes Typst source; producing a PDF is a separate step, as with PlantUML.
+/// \ingroup gen
+class TypstGenerator
+{
+  SEN_NOCOPY_NOMOVE(TypstGenerator)
+
+public:
+  TypstGenerator();
+  ~TypstGenerator();
+
+  /// Map of relative output path -> file contents: the document skeleton, the style
+  /// module it imports, and the generated reference the skeleton includes.
+  using FileContents = std::map<std::filesystem::path, std::string>;
+
+  /// Renders the document. The three files are separate because they have different
+  /// owners: the skeleton and the style are a starting point a caller may replace, and
+  /// only the reference is regenerated when the model changes.
+  [[nodiscard]] FileContents generate(const sen::lang::TypeSetContext& typeSets, const TypstOptions& options);
+
+private:
+  class Impl;
+  std::unique_ptr<Impl> pimpl_;
+};
+
+}  // namespace sen::gen
+
+#endif  // SEN_LIBS_GEN_INCLUDE_SEN_GEN_TYPST_H

--- a/libs/gen/src/common/util.cpp
+++ b/libs/gen/src/common/util.cpp
@@ -8,8 +8,18 @@
 #include "util.h"
 
 // sen
+#include "sen/core/base/assert.h"
 #include "sen/core/lang/stl_resolver.h"
+#include "sen/core/meta/alias_type.h"
+#include "sen/core/meta/class_type.h"
 #include "sen/core/meta/custom_type.h"
+#include "sen/core/meta/enum_type.h"
+#include "sen/core/meta/optional_type.h"
+#include "sen/core/meta/quantity_type.h"
+#include "sen/core/meta/sequence_type.h"
+#include "sen/core/meta/struct_type.h"
+#include "sen/core/meta/type_visitor.h"
+#include "sen/core/meta/variant_type.h"
 
 // inja
 #include <inja/environment.hpp>
@@ -181,6 +191,86 @@ std::string capitalize(const std::string& str)
 }
 
 std::string capitalize(std::string_view str) { return capitalize(std::string(str)); }
+
+void throwUnsupportedType(const sen::Type& type)
+{
+  std::string err;
+  err.append("unsupported type '");
+  err.append(type.getName());
+  err.append("'");
+  sen::throwRuntimeError(err);
+}
+
+// The kind a type is presented as. Both documents that group a model have to agree, and
+// a visitor is the only way to reach the concrete type.
+namespace
+{
+
+class KindVisitor: protected sen::TypeVisitor
+{
+public:
+  [[nodiscard]] static std::string classify(const sen::CustomType& type)
+  {
+    KindVisitor visitor;
+    type.accept(visitor);
+    return visitor.kind_;
+  }
+
+protected:
+  void apply(const sen::Type& /*type*/) override { kind_ = "types"; }
+  void apply(const sen::StructType& /*type*/) override { kind_ = "structures"; }
+  void apply(const sen::EnumType& /*type*/) override { kind_ = "enumerations"; }
+  void apply(const sen::VariantType& /*type*/) override { kind_ = "variants"; }
+  void apply(const sen::SequenceType& /*type*/) override { kind_ = "sequences"; }
+  void apply(const sen::AliasType& /*type*/) override { kind_ = "aliases"; }
+  void apply(const sen::OptionalType& /*type*/) override { kind_ = "optionals"; }
+  void apply(const sen::QuantityType& /*type*/) override { kind_ = "quantities"; }
+  void apply(const sen::ClassType& /*type*/) override { kind_ = "classes"; }
+
+private:
+  std::string kind_;
+};
+
+}  // namespace
+
+std::string kindOf(const sen::CustomType& type) { return KindVisitor::classify(type); }
+
+std::string collapseWhitespace(std::string_view text)
+{
+  std::string result;
+  result.reserve(text.size());
+  bool gap = false;
+  for (const auto character: text)
+  {
+    const bool space = character == ' ' || character == '\t' || character == '\n' || character == '\r';
+    if (space)
+    {
+      gap = !result.empty();
+      continue;
+    }
+    if (gap)
+    {
+      result.push_back(' ');
+      gap = false;
+    }
+    result.push_back(character);
+  }
+  return result;
+}
+
+std::string computePackageName(const sen::lang::TypeSet& set)
+{
+  std::string result;
+  for (std::size_t i = 0U; i < set.package.size(); ++i)
+  {
+    result.append(set.package[i]);
+    if (i + 1U != set.package.size())
+    {
+      result.append(".");
+    }
+  }
+  return result;
+}
 
 std::string computeCppNamespace(const std::vector<std::string>& package)
 {

--- a/libs/gen/src/common/util.cpp
+++ b/libs/gen/src/common/util.cpp
@@ -18,6 +18,7 @@
 #include "sen/core/meta/quantity_type.h"
 #include "sen/core/meta/sequence_type.h"
 #include "sen/core/meta/struct_type.h"
+#include "sen/core/meta/type.h"
 #include "sen/core/meta/type_visitor.h"
 #include "sen/core/meta/variant_type.h"
 

--- a/libs/gen/src/common/util.h
+++ b/libs/gen/src/common/util.h
@@ -49,6 +49,24 @@ void configureEnv(inja::Environment& env);
 /// Transform a string_view to uppercase
 [[nodiscard]] std::string capitalize(std::string_view str);
 
+/// Refuses a type no template covers, in the one wording every generator used. Each had
+/// its own copy of these five lines, which is how six of them come to disagree.
+[[noreturn]] void throwUnsupportedType(const sen::Type& type);
+
+/// How a type is grouped in a document: "classes", "structures", "enumerations",
+/// "variants", "sequences", "quantities", "aliases", "optionals". Two documents
+/// describing one model have to agree about this, so there is one of it.
+[[nodiscard]] std::string kindOf(const sen::CustomType& type);
+
+/// Collapses a description to one run of prose. Model text wraps and indents its
+/// sentences in the source; a document renders it as a paragraph.
+[[nodiscard]] std::string collapseWhitespace(std::string_view text);
+
+/// Computes the dotted package name, as the language writes it: "sen.kernel", "rpr".
+/// Four generators each had their own copy of this; it is one function because a fix
+/// to one of four copies is a fix to one of four outputs.
+[[nodiscard]] std::string computePackageName(const sen::lang::TypeSet& set);
+
 /// Computes C++ namespace from a string package
 [[nodiscard]] std::string computeCppNamespace(const std::vector<std::string>& package);
 

--- a/libs/gen/src/cpp/cpp_generator.cpp
+++ b/libs/gen/src/cpp/cpp_generator.cpp
@@ -85,14 +85,7 @@ public:
   }
 
 protected:
-  void apply(const sen::Type& type) override
-  {
-    std::string err;
-    err.append("unsupported type '");
-    err.append(type.getName());
-    err.append("'");
-    sen::throwRuntimeError(err);
-  }
+  void apply(const sen::Type& type) override { sen::gen::detail::throwUnsupportedType(type); }
 
   void apply(const sen::StructType& type) override { compute(type, templates_.structType); }
 

--- a/libs/gen/src/html/html_generator.cpp
+++ b/libs/gen/src/html/html_generator.cpp
@@ -5,6 +5,7 @@
 //                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
 // =====================================================================================================================
 
+#include "../common/util.h"
 #include "sen/gen/html.h"
 
 // lib
@@ -71,70 +72,6 @@ constexpr std::array<KindName, 10> kindNames {{{"classes", "class", "classes"},
                                                {"quantities", "quantity", "quantities"},
                                                {"builtins", "built-in type", "built-in types"},
                                                {"types", "type", "types"}}};
-
-// The kind a type is presented as. Groups the tree and colours the filters.
-class KindVisitor: protected sen::TypeVisitor
-{
-public:
-  [[nodiscard]] static std::string kindOf(const sen::CustomType& type)
-  {
-    KindVisitor visitor;
-    type.accept(visitor);
-    return visitor.kind_;
-  }
-
-protected:
-  void apply(const sen::Type& /*type*/) override { kind_ = "types"; }
-  void apply(const sen::StructType& /*type*/) override { kind_ = "structures"; }
-  void apply(const sen::EnumType& /*type*/) override { kind_ = "enumerations"; }
-  void apply(const sen::VariantType& /*type*/) override { kind_ = "variants"; }
-  void apply(const sen::SequenceType& /*type*/) override { kind_ = "sequences"; }
-  void apply(const sen::AliasType& /*type*/) override { kind_ = "aliases"; }
-  void apply(const sen::OptionalType& /*type*/) override { kind_ = "optionals"; }
-  void apply(const sen::QuantityType& /*type*/) override { kind_ = "quantities"; }
-  void apply(const sen::ClassType& /*type*/) override { kind_ = "classes"; }
-
-private:
-  std::string kind_;
-};
-
-[[nodiscard]] std::string packageOf(const sen::lang::TypeSet& set)
-{
-  std::string result;
-  for (std::size_t i = 0U; i < set.package.size(); ++i)
-  {
-    result.append(set.package[i]);
-    if (i + 1U != set.package.size())
-    {
-      result.append(".");
-    }
-  }
-  return result;
-}
-
-// Description text as one run of prose; the source wraps and indents its sentences.
-[[nodiscard]] std::string prose(std::string_view text)
-{
-  std::string result;
-  result.reserve(text.size());
-  bool gap = false;
-  for (const auto character: text)
-  {
-    const bool space = character == ' ' || character == '\t' || character == '\n' || character == '\r';
-    if (space)
-    {
-      gap = !result.empty();
-      continue;
-    }
-    if (gap)
-    {
-      result.push_back(' ');
-      gap = false;
-    }
-    result.push_back(character);
-  }
-  return result;
-}
 
 // The title is the caller's and reaches the page as markup.
 [[nodiscard]] std::string escapeHtml(std::string_view text)
@@ -232,7 +169,7 @@ struct PrimitiveSink
   inja::json member;
   member["name"] = prop.getName();
   member["type"] = typeNameOf(*prop.getType(), sink);
-  member["desc"] = prose(prop.getDescription());
+  member["desc"] = sen::gen::detail::collapseWhitespace(prop.getDescription());
   member["flags"] = flagsOf(prop);
   return member;
 }
@@ -245,7 +182,7 @@ struct PrimitiveSink
     inja::json entry;
     entry["name"] = arg.name;
     entry["type"] = typeNameOf(*arg.type, sink);
-    entry["desc"] = prose(arg.description);
+    entry["desc"] = sen::gen::detail::collapseWhitespace(arg.description);
     out.emplace_back(std::move(entry));
   }
   return out;
@@ -255,7 +192,7 @@ struct PrimitiveSink
 {
   inja::json out;
   out["name"] = method.getName();
-  out["desc"] = prose(method.getDescription());
+  out["desc"] = sen::gen::detail::collapseWhitespace(method.getDescription());
   // A void return is the absence of a type, not a type.
   const auto& returned = *method.getReturnType();
   out["returns"] = returned.isVoidType() ? std::string {} : typeNameOf(returned, sink);
@@ -267,7 +204,7 @@ struct PrimitiveSink
 {
   inja::json out;
   out["name"] = event.getName();
-  out["desc"] = prose(event.getDescription());
+  out["desc"] = sen::gen::detail::collapseWhitespace(event.getDescription());
   out["args"] = argsOf(event.getArgs(), sink);
   return out;
 }
@@ -279,7 +216,7 @@ struct PrimitiveSink
   member["name"] = std::string(method.getName()) + "()";
   const auto& returned = *method.getReturnType();
   member["type"] = returned.isVoidType() ? std::string {} : typeNameOf(returned, sink);
-  member["desc"] = prose(method.getDescription());
+  member["desc"] = sen::gen::detail::collapseWhitespace(method.getDescription());
   member["flags"] = inja::json::array();
   return member;
 }
@@ -289,7 +226,7 @@ struct PrimitiveSink
   inja::json member;
   member["name"] = std::string(event.getName()) + "()";
   member["type"] = "";
-  member["desc"] = prose(event.getDescription());
+  member["desc"] = sen::gen::detail::collapseWhitespace(event.getDescription());
   member["flags"] = inja::json::array();
   return member;
 }
@@ -362,7 +299,7 @@ struct PrimitiveSink
   inja::json member;
   member["name"] = field.name;
   member["type"] = typeNameOf(*field.type, sink);
-  member["desc"] = prose(field.description);
+  member["desc"] = sen::gen::detail::collapseWhitespace(field.description);
   member["flags"] = inja::json::array();
   return member;
 }
@@ -466,14 +403,16 @@ void addFacts(const sen::CustomType& type, inja::json& entry, PrimitiveSink& sin
     // a fault in the page rather than an absence in the model.
     const auto& fields = type.asVariantType()->getFields();
     const bool described =
-      std::any_of(fields.begin(), fields.end(), [](const auto& field) { return !prose(field.description).empty(); });
+      std::any_of(fields.begin(),
+                  fields.end(),
+                  [](const auto& field) { return !sen::gen::detail::collapseWhitespace(field.description).empty(); });
 
     for (const auto& field: fields)
     {
       auto row = inja::json::array({typeNameOf(*field.type, sink)});
       if (described)
       {
-        row.push_back(prose(field.description));
+        row.push_back(sen::gen::detail::collapseWhitespace(field.description));
       }
       rows.push_back(std::move(row));
     }
@@ -491,8 +430,8 @@ void addFacts(const sen::CustomType& type, inja::json& entry, PrimitiveSink& sin
   inja::json entry;
   entry["name"] = name;
   entry["package"] = package;
-  entry["kind"] = KindVisitor::kindOf(type);
-  entry["desc"] = prose(type.getDescription());
+  entry["kind"] = sen::gen::detail::kindOf(type);
+  entry["desc"] = sen::gen::detail::collapseWhitespace(type.getDescription());
   entry["ancestry"] = inja::json::array();
   entry["groups"] = inja::json::array();
   entry["methods"] = inja::json::array();
@@ -563,7 +502,7 @@ void addPrimitives(inja::json& types, const PrimitiveSink& sink)
     // Built-in whatever their shape. Filing one by its real kind would promise facts that
     // are not gathered for it.
     entry["kind"] = "builtins";
-    entry["desc"] = prose(type->getDescription());
+    entry["desc"] = sen::gen::detail::collapseWhitespace(type->getDescription());
     entry["ancestry"] = inja::json::array();
     entry["groups"] = inja::json::array();
     entry["members"] = inja::json::array();
@@ -711,7 +650,7 @@ public:
 
     for (const auto& set: typeSets)
     {
-      const auto package = packageOf(set);
+      const auto package = sen::gen::detail::computePackageName(set);
       for (const auto& handle: set.types)
       {
         auto entry = entryFor(*handle, package, sink);

--- a/libs/gen/src/json/json_generator.cpp
+++ b/libs/gen/src/json/json_generator.cpp
@@ -77,14 +77,7 @@ public:
   }
 
 protected:
-  void apply(const sen::Type& type) override
-  {
-    std::string err;
-    err.append("unsupported type '");
-    err.append(type.getName());
-    err.append("'");
-    sen::throwRuntimeError(err);
-  }
+  void apply(const sen::Type& type) override { sen::gen::detail::throwUnsupportedType(type); }
 
   void apply(const sen::StructType& type) override { compute(type, templates_.structType); }
 
@@ -263,24 +256,6 @@ public:
   }
 
 private:
-  void collectDependentTypeSets(const sen::lang::TypeSet* set, std::set<const sen::lang::TypeSet*>& allSets)
-  {
-    // do nothing if already present
-    if (allSets.count(set) != 0)
-    {
-      return;
-    }
-
-    // add the current set
-    allSets.insert(set);
-
-    // add the imported sets
-    for (auto& imported: set->importedSets)
-    {
-      collectDependentTypeSets(imported, allSets);
-    }
-  }
-
   bool canMakeInstances(const sen::ClassType* classType)
   {
     if (auto methods = classType->getMethods(sen::ClassType::SearchMode::includeParents); !methods.empty())
@@ -298,16 +273,6 @@ private:
     }
 
     return true;
-  }
-
-  std::set<const sen::lang::TypeSet*> collectAllTypeSets(const sen::lang::TypeSetContext& typeSets)
-  {
-    std::set<const sen::lang::TypeSet*> result;
-    for (auto& set: typeSets)
-    {
-      collectDependentTypeSets(&set, result);
-    }
-    return result;
   }
 
   std::string getConfigType(const sen::lang::TypeSetContext& typeSets, bool componentMode)
@@ -371,7 +336,7 @@ private:
     inja::json fileData;
     fileData["schemaName"] = schemaName;
 
-    auto allTypeSets = collectAllTypeSets(typeSets);
+    auto allTypeSets = sen::gen::detail::collectAllTypeSets(typeSets);
     auto configType = getConfigType(typeSets, componentMode);
 
     std::vector<inja::json> definitions;

--- a/libs/gen/src/mkdocs/mkdocs_generator.cpp
+++ b/libs/gen/src/mkdocs/mkdocs_generator.cpp
@@ -76,6 +76,31 @@ void appendBlock(std::string& target, std::string_view rendered)
   target.append("\n\n");
 }
 
+// Model text lands in a markdown table cell, where a `|` ends the cell and a newline ends
+// the row, and in a link title, where a `"` ends the title. It is prose, never markup, so
+// the characters markdown reads are escaped rather than left to change what it says.
+[[nodiscard]] std::string markdownText(std::string_view text)
+{
+  static constexpr std::string_view inlineSpecial {"\\`*_[]<>|"};
+  const auto collapsed = sen::gen::detail::collapseWhitespace(text);
+
+  std::string result;
+  result.reserve(collapsed.size() + collapsed.size() / 8U);
+  for (const auto character: collapsed)
+  {
+    // A marker only opens a block at the start of the text; escaping it everywhere would
+    // put a backslash in front of every hyphen in the model.
+    const bool opensBlock = result.empty() && (character == '#' || character == '>' || character == '-' ||
+                                               character == '+' || character == '=');
+    if (opensBlock || inlineSpecial.find(character) != std::string_view::npos)
+    {
+      result.push_back('\\');
+    }
+    result.push_back(character);
+  }
+  return result;
+}
+
 [[nodiscard]] std::string toAnchorStr(std::string_view name, std::string_view link, std::string_view description = "")
 {
   std::string result = "[";
@@ -93,7 +118,14 @@ void appendBlock(std::string& target, std::string_view rendered)
   if (!description.empty())
   {
     result.append(" \"");
-    result.append(description);
+    for (const auto character: markdownText(description))
+    {
+      if (character == '"')
+      {
+        result.push_back('\\');
+      }
+      result.push_back(character);
+    }
     result.append("\"");
   }
 
@@ -143,14 +175,7 @@ public:
   }
 
 protected:
-  void apply(const sen::Type& type) override
-  {
-    std::string err;
-    err.append("unsupported type '");
-    err.append(type.getName());
-    err.append("'");
-    sen::throwRuntimeError(err);
-  }
+  void apply(const sen::Type& type) override { sen::gen::detail::throwUnsupportedType(type); }
 
   void apply(const sen::StructType& type) override
   {
@@ -241,21 +266,6 @@ void getClassPath(const sen::ClassType* current, std::vector<const sen::ClassTyp
     getClassPath(current->getParents().front().type(), path);
     path.push_back(current);
   }
-}
-
-[[nodiscard]] std::string computePackageName(const sen::lang::TypeSet& set)
-{
-  std::string result;
-  for (std::size_t i = 0U; i < set.package.size(); ++i)
-  {
-    result.append(set.package[i]);
-    if (i != set.package.size() - 1U)
-    {
-      result.append(".");
-    }
-  }
-
-  return result;
 }
 
 [[nodiscard]] uint32_t getLevel(const sen::ClassType* meta)
@@ -500,7 +510,7 @@ void append(const std::vector<T>& src, std::vector<T>& target)
   for (auto& storageElem: storage)
   {
     auto set = storageElem->getTypeSet();
-    auto packageName = computePackageName(set);
+    auto packageName = sen::gen::detail::computePackageName(set);
 
     detail::TemplateVisitorResult result;
 
@@ -588,6 +598,7 @@ public:
     detail::configureEnv(env_);
     env_.set_line_statement("***");
     env_.add_callback("toAnchor", 1, [](auto& args) { return toAnchor(*args.front()); });
+    env_.add_callback("md", 1, [](auto& args) { return markdownText(args.front()->template get<std::string>()); });
     templates_ = detail::makeMkDocsTemplates(env_);
     fileTemplate_ = env_.parse(sen::decompressSymbolToString(file_doc, file_docSize));
   }

--- a/libs/gen/src/mkdocs/templates/alias_doc.j2
+++ b/libs/gen/src/mkdocs/templates/alias_doc.j2
@@ -1,5 +1,5 @@
 ### {{ senQual }}
 
-{{ description }}
+{{ md(description) }}
 
 Aliased Type: {{ toAnchor(senQualAlias) }}

--- a/libs/gen/src/mkdocs/templates/class_doc.j2
+++ b/libs/gen/src/mkdocs/templates/class_doc.j2
@@ -5,7 +5,7 @@
 Parent: {{ toAnchor(nonInterfaceParent.senQual) }}
 
 *** endif
-{{ description }}
+{{ md(description) }}
 
 *** if hasOwnProperties
 **Properties**
@@ -13,7 +13,7 @@ Parent: {{ toAnchor(nonInterfaceParent.senQual) }}
 | Name      | Description |
 | :-------- | :---------- |
 *** for prop in props
-| **{{ prop.name }}** | {% if prop.writeAllowed %}:material-pencil:{ title="Writable" }{% else %}:material-pencil-lock:{ title="Read Only" }{% endif %}{% if prop.dynamic %}:material-clock-fast:{ title="Dynamic" }{% else %}:material-anvil:{ title="Static" }{% endif %}{% if prop.confirmed %}:material-truck-check:{ title="Confirmed" }{% else %}:material-email-fast-outline:{ title="Best Effort" }{% endif %} {{ toAnchor(prop.senQual) }} {{ prop.description }} |
+| **{{ prop.name }}** | {% if prop.writeAllowed %}:material-pencil:{ title="Writable" }{% else %}:material-pencil-lock:{ title="Read Only" }{% endif %}{% if prop.dynamic %}:material-clock-fast:{ title="Dynamic" }{% else %}:material-anvil:{ title="Static" }{% endif %}{% if prop.confirmed %}:material-truck-check:{ title="Confirmed" }{% else %}:material-email-fast-outline:{ title="Best Effort" }{% endif %} {{ toAnchor(prop.senQual) }} {{ md(prop.description) }} |
 *** endfor
 *** endif
 *** if hasOwnMethods
@@ -24,7 +24,7 @@ Parent: {{ toAnchor(nonInterfaceParent.senQual) }}
 
 :octicons-triangle-right-16: **{{ method.name }}** {% if method.confirmed %}:material-truck-check:{ title="Confirmed" }{% else %}:material-email-fast-outline:{ title="Best Effort" }{% endif %} {% if method.senQual != "void" %}{{ toAnchor(method.senQual) }}{% endif %}
 
-:   {{ method.description }}
+:   {{ md(method.description) }}
 
     Returns: {{ toAnchor(method.senQual) }}
 
@@ -32,7 +32,7 @@ Parent: {{ toAnchor(nonInterfaceParent.senQual) }}
     | Argument  | Type | Description |
     | :-------- | :--- | :---------- |
 *** for arg in method.args
-    | {{ arg.name }} | {{ toAnchor(arg.senQual) }} | {{ arg.description }} |
+    | {{ arg.name }} | {{ toAnchor(arg.senQual) }} | {{ md(arg.description) }} |
 *** endfor
 
 *** endif
@@ -44,13 +44,13 @@ Parent: {{ toAnchor(nonInterfaceParent.senQual) }}
 *** for event in events
 :octicons-triangle-right-16: **{{ event.name }}** {% if event.transportEnum == "::sen::TransportMode::confirmed" %}:material-truck-check:{ title="Confirmed" }{% else %}:material-email-fast-outline:{ title="Best Effort" }{% endif %}
 
-:   {{ event.description }}
+:   {{ md(event.description) }}
 
 *** if length(event.args) != 0
     | Argument  | Type | Description |
     | :-------- | :--- | :---------- |
 *** for arg in event.args
-    | {{ arg.name }} | {{ toAnchor(arg.senQual) }} | {{ arg.description }} |
+    | {{ arg.name }} | {{ toAnchor(arg.senQual) }} | {{ md(arg.description) }} |
 *** endfor
 *** endif
 

--- a/libs/gen/src/mkdocs/templates/enum_doc.j2
+++ b/libs/gen/src/mkdocs/templates/enum_doc.j2
@@ -1,11 +1,11 @@
 ### {{ senQual }}
 
-{{ description }}
+{{ md(description) }}
 
 Representation: {{ toAnchor(storageSenQual) }}
 
 | Enumerator  | Value |
 | :---------- | :---- |
 *** for enum in enums
-| {{ enum.name }} | {{ enum.key }} {{ enum.description }}|
+| {{ enum.name }} | {{ enum.key }} {{ md(enum.description) }}|
 *** endfor

--- a/libs/gen/src/mkdocs/templates/optional_doc.j2
+++ b/libs/gen/src/mkdocs/templates/optional_doc.j2
@@ -1,5 +1,5 @@
 ### {{ senQual }}
 
-{{ description }}
+{{ md(description) }}
 
 Optional Type: {{ toAnchor(senQualElementType) }}

--- a/libs/gen/src/mkdocs/templates/quantity_doc.j2
+++ b/libs/gen/src/mkdocs/templates/quantity_doc.j2
@@ -1,6 +1,6 @@
 ### {{ senQual }}
 
-{{ description }}
+{{ md(description) }}
 
 Representation: {{ elementType }}
 

--- a/libs/gen/src/mkdocs/templates/sequence_doc.j2
+++ b/libs/gen/src/mkdocs/templates/sequence_doc.j2
@@ -12,4 +12,4 @@
 *** endif
 *** endif
 
-{{ description }}
+{{ md(description) }}

--- a/libs/gen/src/mkdocs/templates/struct_doc.j2
+++ b/libs/gen/src/mkdocs/templates/struct_doc.j2
@@ -1,9 +1,9 @@
 ### {{ senQual }}
 
-{{ description }}
+{{ md(description) }}
 
 | Field     | Description |
 | :-------- | :---------- |
 *** for field in fields
-| **{{ field.name }}** | {{ toAnchor(field.senQual) }} {{ field.description }} |
+| **{{ field.name }}** | {{ toAnchor(field.senQual) }} {{ md(field.description) }} |
 *** endfor

--- a/libs/gen/src/mkdocs/templates/variant_doc.j2
+++ b/libs/gen/src/mkdocs/templates/variant_doc.j2
@@ -1,9 +1,9 @@
 ### {{ senQual }}
 
-{{ description }}
+{{ md(description) }}
 
 | Type |
 | :--- |
 *** for field in fields
-| {{ toAnchor(field.senQual) }} {{ field.description }} |
+| {{ toAnchor(field.senQual) }} {{ md(field.description) }} |
 *** endfor

--- a/libs/gen/src/plantuml/plantuml_generator.cpp
+++ b/libs/gen/src/plantuml/plantuml_generator.cpp
@@ -67,14 +67,7 @@ public:
   }
 
 protected:
-  void apply(const sen::Type& type) override
-  {
-    std::string err;
-    err.append("unsupported type '");
-    err.append(type.getName());
-    err.append("'");
-    sen::throwRuntimeError(err);
-  }
+  void apply(const sen::Type& type) override { sen::gen::detail::throwUnsupportedType(type); }
 
   void apply(const sen::StructType& type) override { compute(type, templates_.structType); }
 
@@ -142,21 +135,6 @@ private:
   const detail::PlantUmlTemplateSet& templates_;
 };
 
-std::string computePackageName(const sen::lang::TypeSet& set)
-{
-  std::string result;
-  for (std::size_t i = 0U; i < set.package.size(); ++i)
-  {
-    result.append(set.package[i]);
-    if (i != set.package.size() - 1U)
-    {
-      result.append(".");
-    }
-  }
-
-  return result;
-}
-
 }  // namespace
 
 class PlantUMLGenerator::Impl
@@ -188,7 +166,7 @@ public:
     for (auto& storageElem: storage)
     {
       auto set = storageElem->getTypeSet();
-      auto packageName = computePackageName(set);
+      auto packageName = sen::gen::detail::computePackageName(set);
 
       for (const auto& type: set.types)
       {

--- a/libs/gen/src/python/python_generator.cpp
+++ b/libs/gen/src/python/python_generator.cpp
@@ -67,14 +67,7 @@ public:
   }
 
 protected:
-  void apply(const sen::Type& type) override
-  {
-    std::string err;
-    err.append("unsupported type '");
-    err.append(type.getName());
-    err.append("'");
-    sen::throwRuntimeError(err);
-  }
+  void apply(const sen::Type& type) override { sen::gen::detail::throwUnsupportedType(type); }
 
   void apply(const sen::StructType& type) override { compute(type, templates_.structType); }
 
@@ -118,20 +111,6 @@ private:
   const detail::PythonTemplateSet& templates_;
 };
 
-std::string computePackageName(const sen::lang::TypeSet& set)
-{
-  std::string result;
-  for (std::size_t i = 0U; i < set.package.size(); ++i)
-  {
-    result.append(set.package[i]);
-    if (i != set.package.size() - 1U)
-    {
-      result.append(".");
-    }
-  }
-  return result;
-}
-
 }  // namespace
 
 class PythonGenerator::Impl
@@ -151,7 +130,7 @@ public:
   std::string generate(const sen::lang::TypeSet& typeSet)
   {
     auto storage = std::make_shared<detail::TypeStorage>(typeSet);
-    auto packageName = computePackageName(typeSet);
+    auto packageName = sen::gen::detail::computePackageName(typeSet);
 
     std::string visitorResult;
     std::vector<std::string> imports;

--- a/libs/gen/src/typescript/typescript_generator.cpp
+++ b/libs/gen/src/typescript/typescript_generator.cpp
@@ -63,14 +63,7 @@ public:
   }
 
 protected:
-  void apply(const sen::Type& type) override
-  {
-    std::string err;
-    err.append("unsupported type '");
-    err.append(type.getName());
-    err.append("'");
-    sen::throwRuntimeError(err);
-  }
+  void apply(const sen::Type& type) override { sen::gen::detail::throwUnsupportedType(type); }
 
   void apply(const sen::StructType& type) override { compute(type, templates_.structTemplate); }
   void apply(const sen::EnumType& type) override { compute(type, templates_.enumTemplate); }

--- a/libs/gen/src/typst/app/document.typ
+++ b/libs/gen/src/typst/app/document.typ
@@ -1,0 +1,46 @@
+// The document the generator emits. Everything that decides how it LOOKS is in
+// style.typ; everything that decides what NON-GENERATED content appears is a file
+// you supply. This skeleton is a starting point — replace it freely, and only
+// reference.typ is rewritten when the model changes.
+
+#let doc-title = {{TITLE}}
+#let doc-subtitle = "Interface Control Document"
+
+#set document(title: doc-title)
+
+#import {{STYLE}}: apply-text-rules, reference-layout
+
+#set page(
+  paper: "a4",
+  margin: (top: 2.2cm, bottom: 2cm, x: 2cm),
+  header: context {
+    if counter(page).get().first() > 1 [
+      #set text(8pt, fill: luma(100))
+      #doc-title #h(1fr) #doc-subtitle
+      #v(-6pt) #line(length: 100%, stroke: 0.4pt + luma(180))
+    ]
+  },
+  footer: context [
+    #set text(8pt, fill: luma(100))
+    #h(1fr) #counter(page).display("1 of 1", both: true)
+  ],
+)
+// Named, not a fallback chain: this is a reference people cite by page, and metrics
+// move the page count. Typst bundles no sans-serif, so Liberation Sans has to be
+// installed — it is in Sen's build image, and `fonts-liberation` on a Linux desktop.
+// Without it typst warns and sets the document in a serif instead.
+#set text(font: "Liberation Sans", size: 9pt)
+#set par(justify: true, leading: 0.62em)
+#show: apply-text-rules
+
+{{FRONT_MATTER}}
+
+#pagebreak()
+#outline(title: [Contents], depth: 2, indent: 1em)
+
+{{BEFORE_REFERENCE}}
+
+#show: reference-layout
+#include "reference.typ"
+
+{{AFTER_REFERENCE}}

--- a/libs/gen/src/typst/app/style.typ
+++ b/libs/gen/src/typst/app/style.typ
@@ -1,0 +1,237 @@
+// THE STYLE MODULE. One file decides how every table, heading and navigation
+// aid looks. The generated content imports it; a user can replace it wholesale
+// without touching a line of generated output.
+
+#let accent = rgb("#2f6fd0")
+
+// The html generator's kind palette, reused rather than invented: a reader who
+// uses both outputs sees one visual language, and the colour carries the kind
+// rather than decorating it.
+#let KIND-COLOUR = (
+  classes:      rgb("#4055c8"),
+  structures:   rgb("#1d7a70"),
+  enumerations: rgb("#8e3b9c"),
+  sequences:    rgb("#a05f00"),
+  variants:     rgb("#c2185b"),
+  quantities:   rgb("#4a7c1f"),
+  aliases:      rgb("#5a6b75"),
+  optionals:    rgb("#4553a8"),
+)
+#let kind-of(k) = KIND-COLOUR.at(k, default: luma(90))
+
+// Named rather than a fallback chain: metrics move the page count, and the tree
+// connectors only line up in a fixed pitch. DejaVu Sans Mono ships inside typst;
+// Liberation Sans is in the build image.
+#let MONO = "DejaVu Sans Mono"
+
+#let COL-NAME = 4.1cm
+#let COL-TYPE = 3.7cm
+#let COL-FLAGS = 1.9cm
+
+// An identifier is one long word and will not break on its own. Offering a
+// break at each camelCase boundary lets it wrap inside its column instead of
+// widening the table or running off the page.
+#let mono(s) = {
+  set text(font: MONO, size: 8pt)
+  s
+}
+// A wrapper type is one line of the language, so the page shows that line rather than
+// describing it in prose. Same shape and the same colours as the html explorer, so a
+// reader who uses both sees one visual language.
+#let kw(s) = text(fill: rgb("#8250df"), weight: 600, s)
+#let lit(s) = text(fill: rgb("#1d7a70"), s)
+#let declared(body) = block(
+  above: 4pt,
+  below: 8pt,
+  inset: (x: 7pt, y: 5pt),
+  fill: luma(249),
+  radius: 2pt,
+  width: 100%,
+  {
+    set text(font: MONO, size: 8.5pt)
+    body
+  },
+)
+
+#let rule-grey = luma(180)
+
+// The current section's colour, set by the generated content as each section
+// opens. A state rather than an argument, because the show rule that draws the
+// heading rule cannot be passed one.
+#let section-colour = state("section-colour", luma(150))
+#let section(name, kind) = {
+  section-colour.update(kind-of(kind))
+  heading(level: 3, name)
+}
+
+// A small coloured chip carrying the kind. Information, not ornament: it says
+// at a glance what a reader would otherwise have to infer from the tables.
+#let chip(kind, wording) = box(
+  inset: (x: 4pt, y: 1.5pt), outset: (y: 1pt), radius: 2pt,
+  fill: kind-of(kind).lighten(88%),
+  text(7pt, weight: 600, fill: kind-of(kind).darken(12%), upper(wording)),
+)
+
+// Justification is right for prose and wrong in a narrow cell, where it opens
+// rivers. Tables set ragged-right.
+#let sen-table(..args) = block(above: 8pt, below: 10pt, context {
+  set par(justify: false)
+  let c = section-colour.get()
+  table(
+    stroke: (x, y) => if y == 0 { (bottom: 0.8pt + c) } else { none },
+    inset: (x: 6pt, y: 4pt),
+    fill: (_, y) => if y == 0 { luma(243) } else if calc.odd(y) { luma(251) },
+    align: left + top,
+    ..args,
+  )
+})
+
+#let facts(body) = block(above: 3pt, below: 7pt, text(8pt, fill: luma(95), body))
+
+// Full measure, by preference: the narrower prose column was tried and the
+// wider one reads better here, where a description sits directly above the
+// table it introduces and the eye travels between them.
+#let prose(body) = block(above: 2pt, below: 7pt, body)
+#let legend(body) = block(above: 2pt, below: 8pt,
+  text(7.5pt, style: "italic", fill: luma(95), body))
+
+// The class hierarchy, in the spirit of the OMT object class structure table:
+// what inherits from what, at a glance, before any of the detail. Indentation
+// rather than the standard's nested columns, because four levels of nesting in
+// columns leaves the deepest names a few centimetres wide.
+#let hierarchy(..rows) = block(above: 6pt, below: 14pt, {
+  set par(justify: false)
+  set text(8.5pt)
+  table(
+    columns: (1fr, auto),
+    stroke: none,
+    inset: (x: 4pt, y: 2.4pt),
+    align: (left + top, right + top),
+    ..rows.pos().map(((branch, name, lbl)) => (
+      {
+        // The connectors must be monospace or the levels do not line up.
+        text(font: MONO, size: 8pt, fill: luma(155), branch)
+        name
+      },
+      context text(fill: luma(120), str(query(lbl).first().location().page())),
+    )).flatten(),
+  )
+})
+
+// What the model is made of, before any of it: one row per package, its size
+// broken down by kind, and where it starts.
+#let packages(ncols, head, ..rows) = block(above: 6pt, below: 14pt, {
+  set par(justify: false)
+  // Ten columns: at the body size the headers touch. They are short words and
+  // read fine a point smaller, which is cheaper than abbreviating them.
+  set text(7.5pt)
+  table(
+    // The name column takes what it needs; the counts are narrow and equal.
+    columns: (auto,) + (auto,) * (ncols - 1),
+    stroke: (x, y) => if y == 0 { (bottom: 0.8pt + luma(120)) } else { none },
+    inset: (x: 7pt, y: 3.5pt),
+    fill: (_, y) => if y == 0 { luma(243) } else if calc.odd(y) { luma(251) },
+    align: (col, _) => if col == 0 { left } else { right },
+    ..head, ..rows.pos().flatten(),
+  )
+})
+
+// ---- navigation ----------------------------------------------------------
+
+// The print equivalent of the html tree: every type in the section, one line
+// each, with the page it is on. Dot leaders because a reader scans across.
+#let summary(..rows) = block(above: 6pt, below: 14pt, {
+  set par(justify: false)
+  set text(8pt)
+  table(
+    columns: (auto, 1fr, auto),
+    stroke: none,
+    inset: (x: 4pt, y: 2.6pt),
+    align: (left + top, left + top, right + top),
+    ..rows.pos().map(((name, desc, lbl)) => (
+      name,
+      text(fill: luma(95), desc),
+      // A label's page is only knowable after layout, hence context.
+      context text(fill: luma(120), str(query(lbl).first().location().page())),
+    )).flatten(),
+  )
+})
+
+// A long enumeration is a narrow list. Running it down one side of the page
+// wastes three quarters of the width, so flow it into columns.
+#let enum-columns(n, ..rows) = block(above: 8pt, below: 10pt, {
+  set par(justify: false)
+  set text(8.5pt)
+  let pairs = rows.pos()
+  let inner(w) = table(
+    columns: w,
+    stroke: none,
+    inset: (x: 4pt, y: 2.2pt),
+    fill: (_, y) => if calc.odd(y) { luma(250) },
+    align: (left, right),
+    ..pairs.flatten(),
+  )
+  if n == 1 {
+    // One column means the names are long, not that the table should span the
+    // page: stretched, the value strands itself at the right margin two hundred
+    // millimetres from the name it belongs to. Hug the content instead.
+    inner((auto, auto))
+  } else {
+    // A right-aligned value at the edge of a balanced column sits against the
+    // next column's first character and reads as overlap. The gutter has to
+    // clear the widest value, not merely separate the boxes.
+    columns(n, gutter: 26pt, inner((1fr, auto)))
+  }
+})
+
+// The search equivalent: every type, alphabetical, with its page number.
+#let index-of(..entries) = {
+  set text(8pt)
+  set par(justify: false)
+  columns(3, gutter: 16pt, {
+    for (name, lbl) in entries.pos() {
+      block(above: 0pt, below: 1.6pt, {
+        name
+        h(1fr)
+        context text(fill: luma(120), str(query(lbl).first().location().page()))
+      })
+    }
+  })
+}
+
+// Applied by the document so a user replacing this file cannot silently lose
+// the page furniture.
+// TYPOGRAPHY applies to the whole document, user pages included: one look.
+#let apply-text-rules(doc) = {
+  // Real space above, not zero: a heading a caller writes can follow other content,
+  // and with zero space it overlaps the line before it.
+  show heading.where(level: 1): it => block(above: 24pt, below: 14pt,
+    text(19pt, weight: 700, it.body))
+  show heading.where(level: 2): it => block(above: 16pt, below: 10pt, {
+    text(16pt, weight: 600, it.body)
+    v(-6pt)
+    context line(length: 100%, stroke: 1.2pt + section-colour.get())
+  })
+  // A type heading alone did not separate entries strongly enough. A rule the
+  // full width of the page above it makes each type a visible band.
+  show heading.where(level: 4): it => block(above: 18pt, below: 6pt, width: 100%, {
+    context line(length: 100%, stroke: 0.7pt + section-colour.get().lighten(45%))
+    v(3pt)
+    text(11.5pt, weight: 600, font: MONO, fill: rgb("#12243c"), it.body)
+  })
+  show raw: set text(font: MONO, size: 8.5pt)
+  show link: set text(fill: accent)
+  doc
+}
+
+// PAGE BREAKING is scoped to the generated reference only. Applying it globally
+// gave a user's own "== Acronyms" a page break they never asked for: a style
+// rule that changes layout must not reach into pages the user wrote.
+#let reference-layout(doc) = {
+  // A package starts a page. A kind section does not: breaking on both left a
+  // package opener alone on a page with one line under it, and the coloured
+  // rule already separates the sections plainly enough.
+  show heading.where(level: 1): it => { pagebreak(weak: true); it }
+  show heading.where(level: 2): it => { pagebreak(weak: true); it }
+  doc
+}

--- a/libs/gen/src/typst/typst_generator.cpp
+++ b/libs/gen/src/typst/typst_generator.cpp
@@ -14,6 +14,7 @@
 
 // sen
 #include "sen/core/base/hash32.h"
+#include "sen/core/lang/stl_resolver.h"
 #include "sen/core/meta/alias_type.h"
 #include "sen/core/meta/class_type.h"
 #include "sen/core/meta/custom_type.h"
@@ -357,6 +358,23 @@ void forEachReferencedType(const sen::CustomType& type, const std::function<void
     return prefix + std::string {noun};
   }
   return prefix + (many.empty() ? std::string {noun} + "s" : std::string {many});
+}
+
+// Whether the document covers this package. The empty one holds the built-ins, which are
+// referenced rather than documented.
+[[nodiscard]] bool documented(const std::string& package, const TypstOptions& options)
+{
+  if (package.empty())
+  {
+    return false;
+  }
+  const auto& include = options.includePackages;
+  if (!include.empty() && std::find(include.begin(), include.end(), package) == include.end())
+  {
+    return false;
+  }
+  const auto& exclude = options.excludePackages;
+  return std::find(exclude.begin(), exclude.end(), package) == exclude.end();
 }
 
 [[nodiscard]] std::string qualifiedName(const sen::lang::TypeSet& set, const sen::CustomType& type)
@@ -979,18 +997,7 @@ TypstGenerator::Impl::Document TypstGenerator::Impl::read(const sen::lang::TypeS
   for (const auto* set: sen::gen::detail::collectAllTypeSets(typeSets))
   {
     const auto package = sen::gen::detail::computePackageName(*set);
-    if (package.empty())
-    {
-      continue;
-    }
-    if (!options.includePackages.empty() &&
-        std::find(options.includePackages.begin(), options.includePackages.end(), package) ==
-          options.includePackages.end())
-    {
-      continue;
-    }
-    if (std::find(options.excludePackages.begin(), options.excludePackages.end(), package) !=
-        options.excludePackages.end())
+    if (!documented(package, options))
     {
       continue;
     }

--- a/libs/gen/src/typst/typst_generator.cpp
+++ b/libs/gen/src/typst/typst_generator.cpp
@@ -19,23 +19,27 @@
 #include "sen/core/meta/custom_type.h"
 #include "sen/core/meta/enum_type.h"
 #include "sen/core/meta/optional_type.h"
+#include "sen/core/meta/property.h"
 #include "sen/core/meta/quantity_type.h"
 #include "sen/core/meta/sequence_type.h"
 #include "sen/core/meta/struct_type.h"
-#include "sen/core/meta/type_visitor.h"
+#include "sen/core/meta/type.h"
 #include "sen/core/meta/variant_type.h"
 
 // std
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cstddef>
 #include <cstring>
 #include <functional>
 #include <map>
+#include <memory>
 #include <set>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace sen::gen
@@ -359,7 +363,13 @@ void forEachReferencedType(const sen::CustomType& type, const std::function<void
 {
   const auto package = sen::gen::detail::computePackageName(set);
   const std::string name {type.getName()};
-  return package.empty() ? name : package + "." + name;
+  if (package.empty())
+  {
+    return name;
+  }
+  std::string qualified {package};
+  qualified.append(".").append(name);
+  return qualified;
 }
 
 }  // namespace
@@ -374,6 +384,16 @@ public:
   [[nodiscard]] FileContents generate(const sen::lang::TypeSetContext& typeSets, const TypstOptions& options);
 
 private:
+  /// What the document renders, read out of the model before any of it is written.
+  struct Document
+  {
+    std::map<std::string, Entry> entries;
+    std::map<std::string, std::string> builtIns;
+    PackageIndex byPackage;
+  };
+
+  [[nodiscard]] Document read(const sen::lang::TypeSetContext& typeSets, const TypstOptions& options);
+
   // What the document contains. A reference may only point at a type in here: Typst
   // treats a link to an absent label as an error rather than a dangling link, so the
   // model is not the document and the difference has to be tracked.
@@ -702,7 +722,7 @@ std::string TypstGenerator::Impl::inlineReference(const std::string& qualified, 
 std::string TypstGenerator::Impl::local(const std::string& qualified, const std::string& package)
 {
   const auto prefix = package + ".";
-  return qualified.rfind(prefix, 0U) == 0U ? qualified.substr(prefix.size()) : qualified;
+  return qualified.compare(0U, prefix.size(), prefix) == 0 ? qualified.substr(prefix.size()) : qualified;
 }
 
 void TypstGenerator::Impl::emitHierarchy(std::ostringstream& out, const std::map<std::string, Entry>& entries) const
@@ -928,8 +948,9 @@ namespace
 
 }  // namespace
 
-TypstGenerator::FileContents TypstGenerator::Impl::generate(const sen::lang::TypeSetContext& typeSets,
-                                                            const TypstOptions& options)
+// What the document renders, read out of the model before any of it is written.
+TypstGenerator::Impl::Document TypstGenerator::Impl::read(const sen::lang::TypeSetContext& typeSets,
+                                                          const TypstOptions& options)
 {
   // Every type in the model, in one flat map keyed by qualified name.
   std::map<std::string, Entry> entries;
@@ -1049,6 +1070,7 @@ TypstGenerator::FileContents TypstGenerator::Impl::generate(const sen::lang::Typ
   }
 
   std::vector<std::vector<std::string>> packageSegments;
+  packageSegments.reserve(byPackage.size());
   for (const auto& [package, kinds]: byPackage)
   {
     packageSegments.push_back(segmentsOf(package));
@@ -1058,6 +1080,14 @@ TypstGenerator::FileContents TypstGenerator::Impl::generate(const sen::lang::Typ
     sharedRoot_ = join(
       {packageSegments.front().begin(), packageSegments.front().begin() + static_cast<std::ptrdiff_t>(shared)}, ".");
   }
+
+  return {std::move(entries), std::move(builtIns), std::move(byPackage)};
+}
+
+TypstGenerator::FileContents TypstGenerator::Impl::generate(const sen::lang::TypeSetContext& typeSets,
+                                                            const TypstOptions& options)
+{
+  auto [entries, builtIns, byPackage] = read(typeSets, options);
 
   std::ostringstream out;
   out << "#import " << literal(styleImport(options))

--- a/libs/gen/src/typst/typst_generator.cpp
+++ b/libs/gen/src/typst/typst_generator.cpp
@@ -1,0 +1,1205 @@
+// === typst_generator.cpp =============================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#include "../common/util.h"
+#include "sen/gen/typst.h"
+
+// generated code
+#include "typst_app/document.h"
+#include "typst_app/style.h"
+
+// sen
+#include "sen/core/base/hash32.h"
+#include "sen/core/meta/alias_type.h"
+#include "sen/core/meta/class_type.h"
+#include "sen/core/meta/custom_type.h"
+#include "sen/core/meta/enum_type.h"
+#include "sen/core/meta/optional_type.h"
+#include "sen/core/meta/quantity_type.h"
+#include "sen/core/meta/sequence_type.h"
+#include "sen/core/meta/struct_type.h"
+#include "sen/core/meta/type_visitor.h"
+#include "sen/core/meta/variant_type.h"
+
+// std
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace sen::gen
+{
+
+namespace
+{
+
+// What a kind is called on the page. Both forms: a chip on one type says "class",
+// a section holding many says "Object classes".
+struct KindName
+{
+  std::string_view id;
+  std::string_view one;
+  std::string_view section;
+};
+
+// Section order is the order a reader wants them: the things with behaviour, then
+// the things that describe data, then the wrappers.
+constexpr std::array<KindName, 8> kindNames {{{"classes", "class", "Object classes"},
+                                              {"structures", "structure", "Fixed records"},
+                                              {"enumerations", "enumeration", "Enumerations"},
+                                              {"variants", "variant", "Variant records"},
+                                              {"sequences", "sequence", "Arrays"},
+                                              {"quantities", "quantity", "Quantities"},
+                                              {"aliases", "alias", "Aliases"},
+                                              {"optionals", "optional", "Optionals"}}};
+
+// Model text is data, not markup: a leading `=` is a heading, `//` a comment, `~` a
+// non-breaking space. A string literal is read verbatim, so only the two characters
+// that could end one need escaping.
+[[nodiscard]] std::string literal(std::string_view text)
+{
+  std::string result {"\""};
+  result.reserve(text.size() + text.size() / 8U + 2U);
+  for (const auto character: sen::gen::detail::collapseWhitespace(text))
+  {
+    if (character == '\\' || character == '"')
+    {
+      result.push_back('\\');
+    }
+    result.push_back(character);
+  }
+  result.push_back('"');
+  return result;
+}
+
+// An identifier is one long word and will not wrap. Offering a break at each camelCase
+// boundary and after each dot lets it fold inside its column instead of widening the
+// table or running off the page. U+200B is invisible and copies as nothing.
+[[nodiscard]] std::string breakable(std::string_view name)
+{
+  static constexpr std::string_view zeroWidthSpace {"​"};
+  std::string result;
+  result.reserve(name.size() + name.size() / 4U);
+  for (std::size_t i = 0U; i < name.size(); ++i)
+  {
+    const auto character = name[i];
+    const bool boundary = i > 0U && std::isupper(static_cast<unsigned char>(character)) != 0 &&
+                          std::islower(static_cast<unsigned char>(name[i - 1U])) != 0;
+    if (boundary)
+    {
+      result.append(zeroWidthSpace);
+    }
+    result.push_back(character);
+    if (character == '.')
+    {
+      result.append(zeroWidthSpace);
+    }
+  }
+  return result;
+}
+
+// Typst labels cannot hold a dot, and every qualified name has them.
+[[nodiscard]] std::string labelOf(std::string_view qualified)
+{
+  std::string result {"t-"};
+  result.reserve(qualified.size() + 2U);
+  for (const auto character: qualified)
+  {
+    result.push_back(character == '.' ? '-' : character);
+  }
+  return result;
+}
+
+// One entry the document will render, flattened out of the model so the emitting code
+// reads as layout rather than as traversal.
+struct Entry
+{
+  std::string qualified;
+  std::string package;
+  std::string kind;
+  std::string description;
+  std::vector<std::string> parents;  ///< direct parents, base first
+  std::vector<std::string> usedBy;   ///< qualified names of types that name this one
+  const sen::CustomType* type {nullptr};
+};
+
+// A member's type as the document names it. Optionals are unwrapped, because the page
+// says "optional" in the facts line rather than in every row.
+[[nodiscard]] std::string typeNameOf(const sen::Type& type)
+{
+  // The optional is a wrapper around the type that matters, and every optional is also a
+  // custom type, so it has to be unwrapped before that test rather than after it.
+  if (type.isOptionalType())
+  {
+    return typeNameOf(*type.asOptionalType()->getType());
+  }
+  if (type.isCustomType())
+  {
+    return std::string {type.asCustomType()->getQualifiedName()};
+  }
+  return std::string {type.getName()};
+}
+
+// Flags as codes with a legend, the way an interface control document writes them.
+// Spelling them out costs more column width than the descriptions can spare.
+[[nodiscard]] std::string flagCodes(const sen::Property& prop)
+{
+  const auto category = prop.getCategory();
+
+  // Only dynamicRW has a public setter. staticRW can be set from code and configuration,
+  // which is not the same thing.
+  const bool writable = category == sen::PropertyCategory::dynamicRW;
+  const bool dynamic = category == sen::PropertyCategory::dynamicRO || category == sen::PropertyCategory::dynamicRW;
+
+  std::string codes {writable ? "RW" : "RO"};
+  codes += dynamic ? " D" : " S";
+  codes += prop.getTransportMode() == sen::TransportMode::confirmed ? " C" : " BE";
+  return codes;
+}
+
+// A unit abbreviation is written for a machine: "m_per_s_sq". Typeset it the way the
+// quantity is actually written down, upright as SI asks and inline rather than as a
+// stacked fraction, which would be too tall for a line of declaration.
+[[nodiscard]] std::string unitMath(std::string_view abbreviation)
+{
+  const auto symbol = [](std::string_view token) -> std::string
+  {
+    // Micro and degree have no ASCII spelling, so the abbreviation approximates them.
+    if (token == "um" || token == "us")
+    {
+      return "\"\u00b5" + std::string {token.substr(1U)} + "\"";
+    }
+    if (token == "deg")
+    {
+      return "\"\u00b0\"";
+    }
+    if (token == "degC")
+    {
+      return "\"\u00b0C\"";
+    }
+    return "\"" + std::string {token} + "\"";
+  };
+
+  std::string body {abbreviation};
+  std::string exponent;
+  for (const auto& [suffix, power]: {std::pair {"_sq", "2"}, std::pair {"_cubed", "3"}})
+  {
+    if (body.size() > std::strlen(suffix) &&
+        body.compare(body.size() - std::strlen(suffix), std::strlen(suffix), suffix) == 0)
+    {
+      body.resize(body.size() - std::strlen(suffix));
+      exponent = std::string {"^"} + power;
+    }
+  }
+
+  const auto per = body.find("_per_");
+  if (per == std::string::npos)
+  {
+    return symbol(body) + exponent;
+  }
+  return symbol(body.substr(0U, per)) + "\\/" + symbol(body.substr(per + 5U)) + exponent;
+}
+
+[[nodiscard]] std::string limits(const sen::QuantityType& type)
+{
+  const auto low = type.getMinValue();
+  const auto high = type.getMaxValue();
+  std::ostringstream out;
+  if (low.has_value())
+  {
+    out << "min " << *low;
+  }
+  if (high.has_value())
+  {
+    out << (low.has_value() ? ", " : "") << "max " << *high;
+  }
+  return out.str();
+}
+
+// The codes flagCodes writes, and what each one tells a reader. Kept beside it so the
+// legend cannot come to disagree with the column it explains.
+constexpr std::array<std::pair<std::string_view, std::string_view>, 6> flagLegend {
+  {{"RO", "Read-only: the value is published by whoever owns it and cannot be set from outside."},
+   {"RW", "Read-write: the value can be set as well as read."},
+   {"D", "Dynamic: the value changes over the life of an instance."},
+   {"S", "Static: the value is fixed once an instance exists."},
+   {"C", "Confirmed: delivery is acknowledged, and the update is retried until it arrives."},
+   {"BE", "Best effort: the update is sent once and may be lost."}}};
+
+// Every type this one names: its members, its arguments and returns, whatever it wraps.
+// One walk, because the callers that need it would otherwise each carry their own and
+// the model would grow a kind that only some of them learned about.
+void forEachReferencedType(const sen::CustomType& type, const std::function<void(const sen::Type&)>& visit)
+{
+  if (const auto* asClass = type.isClassType() ? type.asClassType() : nullptr; asClass != nullptr)
+  {
+    constexpr auto ownOnly = sen::ClassType::SearchMode::doNotIncludeParents;
+    for (const auto& prop: asClass->getProperties(ownOnly))
+    {
+      visit(*prop->getType());
+    }
+    for (const auto& method: asClass->getMethods(ownOnly))
+    {
+      for (const auto& argument: method->getArgs())
+      {
+        visit(*argument.type);
+      }
+      visit(*method->getReturnType());
+    }
+    for (const auto& event: asClass->getEvents(ownOnly))
+    {
+      for (const auto& argument: event->getArgs())
+      {
+        visit(*argument.type);
+      }
+    }
+  }
+  else if (const auto* asStruct = type.isStructType() ? type.asStructType() : nullptr; asStruct != nullptr)
+  {
+    for (const auto& field: asStruct->getFields())
+    {
+      visit(*field.type);
+    }
+  }
+  else if (const auto* asVariant = type.isVariantType() ? type.asVariantType() : nullptr; asVariant != nullptr)
+  {
+    for (const auto& alternative: asVariant->getFields())
+    {
+      visit(*alternative.type);
+    }
+  }
+  else if (const auto* asSequence = type.isSequenceType() ? type.asSequenceType() : nullptr; asSequence != nullptr)
+  {
+    visit(*asSequence->getElementType());
+  }
+  else if (const auto* asAlias = type.isAliasType() ? type.asAliasType() : nullptr; asAlias != nullptr)
+  {
+    visit(*asAlias->getAliasedType());
+  }
+  else if (const auto* asQuantity = type.isQuantityType() ? type.asQuantityType() : nullptr; asQuantity != nullptr)
+  {
+    visit(*asQuantity->getElementType());
+  }
+}
+
+// An optional is a wrapper around the type that matters; nothing wants the wrapper.
+[[nodiscard]] const sen::Type& unwrapped(const sen::Type& type)
+{
+  return type.isOptionalType() ? *type.asOptionalType()->getType() : type;
+}
+
+[[nodiscard]] std::string join(const std::vector<std::string>& parts, const std::string& with)
+{
+  std::string out;
+  for (const auto& part: parts)
+  {
+    out += out.empty() ? part : with + part;
+  }
+  return out;
+}
+
+[[nodiscard]] std::vector<std::string> segmentsOf(const std::string& package)
+{
+  std::vector<std::string> segments;
+  for (std::size_t at = 0U; at <= package.size();)
+  {
+    const auto dot = std::min(package.find('.', at), package.size());
+    segments.push_back(package.substr(at, dot - at));
+    at = dot + 1U;
+  }
+  return segments;
+}
+
+// A leading segment every package shares carries no information: "sen" here, nothing in a
+// FOM. Dropping it gives Sen a tree and leaves flat packages flat. Never drop so much that
+// a package is left with no name of its own.
+[[nodiscard]] std::size_t sharedPrefix(const std::vector<std::vector<std::string>>& packages)
+{
+  if (packages.size() < 2U)
+  {
+    return 0U;
+  }
+  std::size_t shared = 0U;
+  const auto shortest =
+    std::min_element(packages.begin(), packages.end(), [](const auto& a, const auto& b) { return a.size() < b.size(); })
+      ->size();
+  while (
+    shared + 1U < shortest &&
+    std::all_of(packages.begin(), packages.end(), [&](const auto& p) { return p[shared] == packages.front()[shared]; }))
+  {
+    ++shared;
+  }
+  return shared;
+}
+
+/// "1 package", not "1 packages". A document that cannot count its own contents reads as
+/// generated, which is the impression a reference has to avoid.
+[[nodiscard]] std::string plural(std::size_t count, std::string_view noun, std::string_view many = {})
+{
+  const std::string prefix {std::to_string(count) + " "};
+  if (count == 1U)
+  {
+    return prefix + std::string {noun};
+  }
+  return prefix + (many.empty() ? std::string {noun} + "s" : std::string {many});
+}
+
+[[nodiscard]] std::string qualifiedName(const sen::lang::TypeSet& set, const sen::CustomType& type)
+{
+  const auto package = sen::gen::detail::computePackageName(set);
+  const std::string name {type.getName()};
+  return package.empty() ? name : package + "." + name;
+}
+
+}  // namespace
+
+class TypstGenerator::Impl
+{
+  /// package -> kind -> qualified names, ordered so the document is byte-identical
+  /// from one run to the next.
+  using PackageIndex = std::map<std::string, std::map<std::string, std::vector<std::string>>>;
+
+public:
+  [[nodiscard]] FileContents generate(const sen::lang::TypeSetContext& typeSets, const TypstOptions& options);
+
+private:
+  // What the document contains. A reference may only point at a type in here: Typst
+  // treats a link to an absent label as an error rather than a dangling link, so the
+  // model is not the document and the difference has to be tracked.
+  std::set<std::string> included_;
+
+  // The leading segments every package shares, as a dotted prefix. Carries no information,
+  // so it is dropped wherever a name is shown.
+  std::string sharedRoot_;
+
+  /// A link, if the document contains the target; plain text otherwise, since Typst treats
+  /// a link to an absent label as an error. `here` is the package doing the printing: a
+  /// name from it reads unqualified, one from elsewhere keeps its package.
+  [[nodiscard]] std::string reference(const std::string& qualified, const std::string& here = {}) const;
+
+  /// The same, for use inside a `#mono[..]` span: there a table-cell argument would be a
+  /// syntax error, so the link needs its leading hash and bare text needs no brackets.
+  [[nodiscard]] std::string inlineReference(const std::string& qualified, const std::string& here) const;
+
+  /// The name as it should read where it is printed: unqualified inside its own
+  /// package, since the section heading already said which package that is.
+  [[nodiscard]] static std::string local(const std::string& qualified, const std::string& package);
+
+  /// The tables for one type: what it carries, and what it can be asked to do.
+  void emitBody(std::ostringstream& out, const sen::CustomType& type, const std::string& package) const;
+
+  /// Orientation before detail: what the packages are, and how the class tree runs
+  /// across them. A per-package tree cannot show that one package's class descends
+  /// from another's, so there is one tree and it is here.
+  void emitOverview(std::ostringstream& out,
+                    const std::map<std::string, Entry>& entries,
+                    const PackageIndex& byPackage,
+                    bool withHierarchy) const;
+  void emitHierarchy(std::ostringstream& out, const std::map<std::string, Entry>& entries) const;
+  void emitMembers(std::ostringstream& out, const sen::ClassType& type, const std::string& here) const;
+  void emitFields(std::ostringstream& out, const sen::StructType& type, const std::string& here) const;
+  void emitEnumerators(std::ostringstream& out, const sen::EnumType& type) const;
+  void emitAlternatives(std::ostringstream& out, const sen::VariantType& type, const std::string& here) const;
+
+  /// What the codes in the Flags column mean.
+  static void emitFlagLegend(std::ostringstream& out);
+
+  /// Optionals, arrays, aliases and quantities: what is wrapped, and the bounds on it.
+  void emitWrapping(std::ostringstream& out, const sen::CustomType& type, const std::string& here) const;
+  void emitCallables(std::ostringstream& out, const sen::ClassType& type, const std::string& here) const;
+  void emitEvents(std::ostringstream& out, const sen::ClassType& type, const std::string& here) const;
+};
+
+void TypstGenerator::Impl::emitMembers(std::ostringstream& out,
+                                       const sen::ClassType& type,
+                                       const std::string& here) const
+{
+  const auto properties = type.getProperties(sen::ClassType::SearchMode::doNotIncludeParents);
+  if (properties.empty())
+  {
+    return;
+  }
+  out << "#sen-table(\n  columns: (COL-NAME, COL-TYPE, COL-FLAGS, 1fr),\n"
+         "  table.header([*Name*], [*Type*], [*Flags*], [*Description*]),\n";
+  for (const auto& prop: properties)
+  {
+    out << "  [#mono(" << literal(breakable(std::string {prop->getName()})) << ")], "
+        << reference(typeNameOf(*prop->getType()), here) << ", [" << flagCodes(*prop) << "], "
+        << literal(prop->getDescription()) << ",\n";
+  }
+  out << ")\n";
+}
+
+void TypstGenerator::Impl::emitFields(std::ostringstream& out,
+                                      const sen::StructType& type,
+                                      const std::string& here) const
+{
+  if (const auto parent = type.getParent(); parent.has_value())
+  {
+    out << "#facts[Extends " << inlineReference(std::string {(*parent)->getQualifiedName()}, here)
+        << ", and carries its fields as well.]\n";
+  }
+
+  const auto fields = type.getFields();
+  if (fields.empty())
+  {
+    return;
+  }
+  out << "#sen-table(\n  columns: (COL-NAME, COL-TYPE, 1fr),\n"
+         "  table.header([*Name*], [*Type*], [*Description*]),\n";
+  for (const auto& field: fields)
+  {
+    out << "  [#mono(" << literal(breakable(field.name)) << ")], " << reference(typeNameOf(*field.type), here) << ", "
+        << literal(field.description) << ",\n";
+  }
+  out << ")\n";
+}
+
+void TypstGenerator::Impl::emitEnumerators(std::ostringstream& out, const sen::EnumType& type) const
+{
+  out << "#facts[Held as #mono(" << literal(type.getStorageType().getName()) << ").]\n";
+
+  const auto enumerators = type.getEnums();
+  if (enumerators.empty())
+  {
+    return;
+  }
+  // The column count follows the length most names have, not the longest: one outlier
+  // would drop a long enumeration into a single column. Names carry break
+  // opportunities, so the rare long one wraps.
+  std::vector<std::size_t> lengths;
+  lengths.reserve(enumerators.size());
+  for (const auto& enumerator: enumerators)
+  {
+    lengths.push_back(enumerator.name.size());
+  }
+  const auto ninth = lengths.begin() + static_cast<std::ptrdiff_t>(lengths.size() * 9U / 10U);
+  std::nth_element(lengths.begin(), ninth, lengths.end());
+  const auto typical = *ninth;
+  const auto columns = typical <= 24U ? 3U : typical <= 38U ? 2U : 1U;
+
+  out << "#enum-columns(" << columns << ",\n";
+  for (const auto& enumerator: enumerators)
+  {
+    out << "  (" << literal(breakable(enumerator.name)) << ", [" << enumerator.key << "]),\n";
+  }
+  out << ")\n";
+}
+
+void TypstGenerator::Impl::emitAlternatives(std::ostringstream& out,
+                                            const sen::VariantType& type,
+                                            const std::string& here) const
+{
+  const auto alternatives = type.getFields();
+  if (alternatives.empty())
+  {
+    return;
+  }
+  out << "#sen-table(\n  columns: (COL-NAME, 1fr),\n  table.header([*Type*], [*Description*]),\n";
+  for (const auto& alternative: alternatives)
+  {
+    out << "  " << reference(typeNameOf(*alternative.type), here) << ", " << literal(alternative.description) << ",\n";
+  }
+  out << ")\n";
+}
+
+void TypstGenerator::Impl::emitCallables(std::ostringstream& out,
+                                         const sen::ClassType& type,
+                                         const std::string& here) const
+{
+  constexpr auto ownOnly = sen::ClassType::SearchMode::doNotIncludeParents;
+
+  const auto methods = type.getMethods(ownOnly);
+  if (!methods.empty())
+  {
+    // The signature column takes width in proportion to what it holds. A fixed share
+    // starves the descriptions where signatures are short and overflows where they are
+    // long, and one model has both.
+    std::size_t longest = 0U;
+    for (const auto& method: methods)
+    {
+      std::size_t width = 2U;
+      for (const auto& argument: method->getArgs())
+      {
+        width += argument.name.size() + typeNameOf(*argument.type).size() + 4U;
+      }
+      longest = std::max(longest, width);
+    }
+    const auto share = std::clamp(static_cast<double>(longest) / 90.0, 0.55, 1.4);
+
+    out << "#sen-table(\n  columns: (COL-NAME, " << share
+        << "fr, 1fr),\n"
+           "  table.header([*Method*], [*Signature*], [*Description*]),\n";
+    for (const auto& method: methods)
+    {
+      std::string signature {"("};
+      bool first = true;
+      for (const auto& argument: method->getArgs())
+      {
+        if (!first)
+        {
+          signature += ", ";
+        }
+        first = false;
+        signature += "#" + literal(breakable(argument.name)) + ": " + inlineReference(typeNameOf(*argument.type), here);
+      }
+      signature += ")";
+      // A void return is the absence of a type, not a null handle.
+      if (const auto& returned = *method->getReturnType(); !returned.isVoidType())
+      {
+        signature += " " + std::string {"\\u{2192}"} + " " + inlineReference(typeNameOf(returned), here);
+      }
+      out << "  [#mono(" << literal(breakable(std::string {method->getName()})) << ")], [#mono[" << signature << "]], "
+          << literal(method->getDescription()) << ",\n";
+    }
+    out << ")\n";
+  }
+}
+
+void TypstGenerator::Impl::emitFlagLegend(std::ostringstream& out)
+{
+  out << "= Reading the tables\n\n#prose[Every property carries three flags, in this order.]\n\n"
+         "#sen-table(\n  columns: (COL-FLAGS, 1fr),\n  table.header([*Flag*], [*Meaning*]),\n";
+  for (const auto& [code, meaning]: flagLegend)
+  {
+    out << "  [#mono[" << code << "]], [" << meaning << "],\n";
+  }
+  out << ")\n\n";
+}
+
+// What a class announces, as against what it can be asked. A class can carry nothing but
+// events, and without this it reaches the page as a heading with no content under it.
+void TypstGenerator::Impl::emitEvents(std::ostringstream& out,
+                                      const sen::ClassType& type,
+                                      const std::string& here) const
+{
+  const auto events = type.getEvents(sen::ClassType::SearchMode::doNotIncludeParents);
+  if (events.empty())
+  {
+    return;
+  }
+
+  out << "#sen-table(\n  columns: (COL-NAME, 1fr, 1fr),\n"
+         "  table.header([*Event*], [*Payload*], [*Description*]),\n";
+  for (const auto& event: events)
+  {
+    std::string payload {"("};
+    bool first = true;
+    for (const auto& argument: event->getArgs())
+    {
+      payload += (first ? "" : ", ") + ("#" + literal(breakable(argument.name))) + ": " +
+                 inlineReference(typeNameOf(*argument.type), here);
+      first = false;
+    }
+    payload += ")";
+    out << "  [#mono(" << literal(breakable(std::string {event->getName()})) << ")], [#mono[" << payload << "]], "
+        << literal(event->getDescription()) << ",\n";
+  }
+  out << ")\n";
+}
+
+void TypstGenerator::Impl::emitBody(std::ostringstream& out,
+                                    const sen::CustomType& type,
+                                    const std::string& package) const
+{
+  if (const auto* asClass = type.isClassType() ? type.asClassType() : nullptr; asClass != nullptr)
+  {
+    emitMembers(out, *asClass, package);
+    emitCallables(out, *asClass, package);
+    emitEvents(out, *asClass, package);
+  }
+  else if (const auto* asStruct = type.isStructType() ? type.asStructType() : nullptr; asStruct != nullptr)
+  {
+    emitFields(out, *asStruct, package);
+  }
+  else if (const auto* asEnum = type.isEnumType() ? type.asEnumType() : nullptr; asEnum != nullptr)
+  {
+    emitEnumerators(out, *asEnum);
+  }
+  else if (const auto* asVariant = type.isVariantType() ? type.asVariantType() : nullptr; asVariant != nullptr)
+  {
+    emitAlternatives(out, *asVariant, package);
+  }
+  else
+  {
+    emitWrapping(out, type, package);
+  }
+}
+
+// A wrapper type has no rows, only the type it wraps and the bounds put on it. Without
+// this it reaches the page as a heading and nothing else, which says less than the name.
+void TypstGenerator::Impl::emitWrapping(std::ostringstream& out,
+                                        const sen::CustomType& type,
+                                        const std::string& here) const
+{
+  const auto named = [this, &here](const sen::Type& wrapped) { return inlineReference(typeNameOf(wrapped), here); };
+  const auto own = literal(breakable(local(std::string {type.getQualifiedName()}, here)));
+
+  // A wrapper type is one line of the language. Writing that line says what it is and
+  // what it wraps at once, and reads the same way as the html explorer shows it.
+  if (const auto* asOptional = type.isOptionalType() ? type.asOptionalType() : nullptr; asOptional != nullptr)
+  {
+    out << "#declared[#kw[optional]\\<" << named(*asOptional->getType()) << "\\> #" << own << "#\";\"]\n";
+  }
+  else if (const auto* asSequence = type.isSequenceType() ? type.asSequenceType() : nullptr; asSequence != nullptr)
+  {
+    // The language has two keywords: a fixed array always holds its bound, a sequence
+    // holds up to it. Saying "at most" for an array contradicts the model.
+    out << "#declared[#kw[" << (asSequence->hasFixedSize() ? "array" : "sequence") << "]\\<"
+        << named(*asSequence->getElementType());
+    if (const auto bound = asSequence->getMaxSize(); bound.has_value())
+    {
+      out << ", #lit[" << *bound << "]";
+    }
+    out << "\\> #" << own << "#\";\"]\n";
+  }
+  else if (const auto* asAlias = type.isAliasType() ? type.asAliasType() : nullptr; asAlias != nullptr)
+  {
+    out << "#declared[#kw[alias] #" << own << " " << named(*asAlias->getAliasedType()) << "#\";\"]\n";
+  }
+  else if (const auto* asQuantity = type.isQuantityType() ? type.asQuantityType() : nullptr; asQuantity != nullptr)
+  {
+    out << "#declared[#kw[quantity]\\<" << named(*asQuantity->getElementType());
+    if (const auto unit = asQuantity->getUnit(); unit.has_value())
+    {
+      if (const auto symbol = (*unit)->getAbbreviation(); !symbol.empty())
+      {
+        out << ", #lit($" << unitMath(symbol) << "$)";
+      }
+    }
+    out << "\\> #" << own << "#\";\"";
+    if (const auto note = limits(*asQuantity); !note.empty())
+    {
+      out << "#text(fill: luma(140), " << literal("  // " + note) << ")";
+    }
+    out << "]\n";
+  }
+}
+
+std::string TypstGenerator::Impl::reference(const std::string& qualified, const std::string& here) const
+{
+  const auto text = literal(breakable(local(qualified, here)));
+  return included_.count(qualified) != 0U ? "link(<" + labelOf(qualified) + ">)[#" + text + "]" : text;
+}
+
+std::string TypstGenerator::Impl::inlineReference(const std::string& qualified, const std::string& here) const
+{
+  const auto text = literal(breakable(local(qualified, here)));
+  return included_.count(qualified) != 0U ? "#link(<" + labelOf(qualified) + ">)[#" + text + "]" : "#" + text;
+}
+
+std::string TypstGenerator::Impl::local(const std::string& qualified, const std::string& package)
+{
+  const auto prefix = package + ".";
+  return qualified.rfind(prefix, 0U) == 0U ? qualified.substr(prefix.size()) : qualified;
+}
+
+void TypstGenerator::Impl::emitHierarchy(std::ostringstream& out, const std::map<std::string, Entry>& entries) const
+{
+  std::map<std::string, std::vector<std::string>> children;
+  std::vector<std::string> roots;
+  for (const auto& [name, entry]: entries)
+  {
+    if (entry.kind != "classes")
+    {
+      continue;
+    }
+    const auto parent = entry.parents.empty() ? std::string {} : entry.parents.front();
+    if (!parent.empty() && entries.count(parent) != 0U)
+    {
+      children[parent].push_back(name);
+    }
+    else
+    {
+      roots.push_back(name);
+    }
+  }
+  if (roots.empty())
+  {
+    return;  // nothing inherits: a list of unconnected names is not a hierarchy
+  }
+
+  out << "*Class hierarchy across all packages*\n\n#hierarchy(\n";
+
+  // Depth-first, carrying the prefix that draws the connectors. Branch characters
+  // alone show that a name is indented; the continuation bars show what it hangs
+  // from, which is the part a reader actually needs.
+  const std::function<void(const std::string&, const std::string&, bool, bool)> walk =
+    [&](const std::string& name, const std::string& prefix, const bool last, const bool top)
+  {
+    const auto branch = top ? std::string {} : prefix + (last ? "└── " : "├── ");
+    const auto below = top ? std::string {} : prefix + (last ? "    " : "│   ");
+    out << "  (\"" << branch << "\", " << reference(name, sharedRoot_) << ", <" << labelOf(name) << ">),\n";
+    const auto found = children.find(name);
+    if (found != children.end())
+    {
+      for (std::size_t i = 0U; i < found->second.size(); ++i)
+      {
+        walk(found->second[i], below, i + 1U == found->second.size(), false);
+      }
+    }
+  };
+  for (const auto& root: roots)
+  {
+    walk(root, "", true, true);
+  }
+  out << ")\n\n";
+}
+
+void TypstGenerator::Impl::emitOverview(std::ostringstream& out,
+                                        const std::map<std::string, Entry>& entries,
+                                        const PackageIndex& byPackage,
+                                        bool withHierarchy) const
+{
+  out << "= Model overview\n\n";
+
+  // Derive what is true of this model rather than assert the shape of another: a FOM
+  // has one root and a hand-written API may have a dozen.
+  std::size_t classes = 0U;
+  std::size_t roots = 0U;
+  std::size_t inheritFromOutside = 0U;
+  for (const auto& [name, entry]: entries)
+  {
+    if (entry.kind != "classes")
+    {
+      continue;
+    }
+    ++classes;
+    if (entry.parents.empty())
+    {
+      ++roots;
+    }
+    // A class whose parent the document leaves out is not a root: counting it as one
+    // would claim the model has hierarchies it does not have.
+    else if (std::none_of(entry.parents.begin(),
+                          entry.parents.end(),
+                          [&entries](const auto& parent) { return entries.count(parent) != 0U; }))
+    {
+      ++inheritFromOutside;
+    }
+  }
+
+  out << "#prose("
+      << literal(
+           [&]
+           {
+             std::string said {plural(entries.size(), "type") + " in " + plural(byPackage.size(), "package") + "."};
+             if (roots == 1U && inheritFromOutside == 0U)
+             {
+               said += " Every class descends from a single root.";
+             }
+             else if (roots > 1U)
+             {
+               said += " " + plural(classes, "class", "classes") + " in " +
+                       plural(roots, "independent hierarchy", "independent hierarchies") + ".";
+             }
+             if (inheritFromOutside > 0U)
+             {
+               said += " " + plural(inheritFromOutside, "class", "classes") + " inherit from outside the document.";
+             }
+             return said;
+           }())
+      << ")\n\n";
+
+  // Only kinds this model uses get a column: two empty columns on every row is width
+  // the package names need, and dotted names then collide with the counts beside them.
+  std::vector<const KindName*> used;
+  for (const auto& kindName: kindNames)
+  {
+    const auto id = std::string {kindName.id};
+    const bool anywhere =
+      std::any_of(byPackage.begin(), byPackage.end(), [&id](const auto& pair) { return pair.second.count(id) != 0U; });
+    if (anywhere)
+    {
+      used.push_back(&kindName);
+    }
+  }
+
+  out << "*Packages*\n\n#packages(" << used.size() + 2U << ",\n  ([*Package*], [*Types*]";
+  for (const auto* kindName: used)
+  {
+    auto label = std::string {kindName->section};
+    out << ", [*" << label << "*]";
+  }
+  out << "),\n";
+  // The rows follow the package tree. A node the model never declares still gets a row,
+  // greyed and without counts, because the packages under it need something to hang from.
+  const auto shared = sharedRoot_.empty() ? 0U : segmentsOf(sharedRoot_).size();
+
+  std::set<std::vector<std::string>> rows;
+  std::vector<std::vector<std::string>> split;
+  for (const auto& [package, kinds]: byPackage)
+  {
+    split.push_back(segmentsOf(package));
+  }
+  for (const auto& segments: split)
+  {
+    for (auto depth = shared + 1U; depth <= segments.size(); ++depth)
+    {
+      rows.emplace(segments.begin(), segments.begin() + static_cast<std::ptrdiff_t>(depth));
+    }
+  }
+
+  for (const auto& path: rows)
+  {
+    const auto package = join(path, ".");
+    const auto found = byPackage.find(package);
+    const auto indent = (path.size() - shared - 1U) * 10U;
+    out << "  ([#h(" << indent << "pt)";
+    if (found == byPackage.end())
+    {
+      out << "#text(fill: luma(120))[#" << literal(path.back()) << "]], [—]";
+      for (std::size_t i = 0U; i < used.size(); ++i)
+      {
+        out << ", [—]";
+      }
+      out << "),\n";
+      continue;
+    }
+
+    std::size_t total = 0U;
+    for (const auto& [kind, names]: found->second)
+    {
+      total += names.size();
+    }
+    out << "#" << literal(path.back()) << "], [" << total << "]";
+    for (const auto* kindName: used)
+    {
+      const auto kind = found->second.find(std::string {kindName->id});
+      out << ", [" << (kind == found->second.end() ? std::string {"—"} : std::to_string(kind->second.size())) << "]";
+    }
+    out << "),\n";
+  }
+  out << ")\n\n";
+
+  if (withHierarchy)
+  {
+    emitHierarchy(out, entries);
+  }
+}
+
+namespace
+{
+
+// Which style module the document imports. A caller replacing it is naming a file we do
+// not write, so both the skeleton and the reference have to point at theirs, not at ours.
+[[nodiscard]] std::string styleImport(const TypstOptions& options)
+{
+  return options.style.empty() ? "style.typ" : options.style.generic_string();
+}
+
+// A caller supplies a title page by writing a Typst file, which this library never
+// reads. An unset point becomes a comment naming what could go there.
+[[nodiscard]] std::string fillSkeleton(std::string skeleton, const TypstOptions& options)
+{
+  const auto substitute = [&skeleton](std::string_view placeholder, const std::string& replacement)
+  {
+    const auto at = skeleton.find(placeholder);
+    if (at != std::string::npos)
+    {
+      skeleton.replace(at, placeholder.size(), replacement);
+    }
+  };
+
+  const auto includeOrHint = [](const std::filesystem::path& path, std::string_view what)
+  {
+    return path.empty() ? "// " + std::string {what} + ": supply a .typ file and include it here"
+                        : "#include " + literal(path.generic_string());
+  };
+
+  substitute("{{TITLE}}", literal(options.title));
+  substitute("{{STYLE}}", literal(styleImport(options)));
+  substitute("{{FRONT_MATTER}}", includeOrHint(options.frontMatter, "your title page"));
+  substitute("{{BEFORE_REFERENCE}}", includeOrHint(options.beforeReference, "your scope and conventions"));
+  substitute("{{AFTER_REFERENCE}}", includeOrHint(options.afterReference, "your appendices"));
+  return skeleton;
+}
+
+}  // namespace
+
+TypstGenerator::FileContents TypstGenerator::Impl::generate(const sen::lang::TypeSetContext& typeSets,
+                                                            const TypstOptions& options)
+{
+  // Every type in the model, in one flat map keyed by qualified name.
+  std::map<std::string, Entry> entries;
+  std::map<std::string, std::string> builtIns;
+
+  // Qualified name -> the types that name it. Built while the model is walked, because a
+  // type does not know what refers to it until everything has been read.
+  std::map<std::string, std::set<std::string>> uses;
+
+  // Types the model names that no type set declares: the kernel's own, sen.Duration and
+  // sen.TimeStamp among them. They are not part of the model and still have to lead
+  // somewhere, so they join the built-ins rather than reaching the page as bare text.
+  std::map<std::string, const sen::CustomType*> referencedButUndeclared;
+  included_.clear();
+  sharedRoot_.clear();
+
+  std::map<std::string, const sen::CustomType*> declared;
+  for (const auto* set: sen::gen::detail::collectAllTypeSets(typeSets))
+  {
+    for (const auto& handle: set->types)
+    {
+      declared.emplace(qualifiedName(*set, *handle), &*handle);
+    }
+  }
+
+  for (const auto* set: sen::gen::detail::collectAllTypeSets(typeSets))
+  {
+    const auto package = sen::gen::detail::computePackageName(*set);
+    if (package.empty())
+    {
+      continue;
+    }
+    if (!options.includePackages.empty() &&
+        std::find(options.includePackages.begin(), options.includePackages.end(), package) ==
+          options.includePackages.end())
+    {
+      continue;
+    }
+    if (std::find(options.excludePackages.begin(), options.excludePackages.end(), package) !=
+        options.excludePackages.end())
+    {
+      continue;
+    }
+
+    for (const auto& handle: set->types)
+    {
+      const auto& type = *handle;
+      Entry entry;
+      entry.qualified = qualifiedName(*set, type);
+      entry.package = package;
+      entry.kind = sen::gen::detail::kindOf(type);
+      entry.description = type.getDescription();
+      entry.type = &type;
+      if (const auto* asClass = type.isClassType() ? type.asClassType() : nullptr; asClass != nullptr)
+      {
+        // Direct parents, in declaration order: a base first, then anything implemented.
+        for (const auto& parent: asClass->getParents())
+        {
+          entry.parents.emplace_back(parent->getQualifiedName());
+        }
+      }
+      forEachReferencedType(type,
+                            [&](const sen::Type& referenced)
+                            {
+                              const auto& bare = unwrapped(referenced);
+                              if (const auto* custom = bare.isCustomType() ? bare.asCustomType() : nullptr;
+                                  custom != nullptr)
+                              {
+                                const std::string name {custom->getQualifiedName()};
+                                uses[name].insert(entry.qualified);
+                                if (declared.count(name) == 0U)
+                                {
+                                  referencedButUndeclared.emplace(name, custom);
+                                }
+                              }
+                              // void is what a method returns when it returns nothing, not
+                              // a type anything holds.
+                              else if (!bare.isVoidType())
+                              {
+                                builtIns.emplace(bare.getName(), bare.getDescription());
+                              }
+                            });
+      entries.emplace(entry.qualified, std::move(entry));
+    }
+  }
+
+  for (auto& [name, entry]: entries)
+  {
+    if (const auto found = uses.find(name); found != uses.end())
+    {
+      entry.usedBy.assign(found->second.begin(), found->second.end());
+    }
+  }
+
+  for (const auto& [name, entry]: entries)
+  {
+    included_.insert(name);
+  }
+  if (options.builtIns)
+  {
+    for (const auto& [name, type]: referencedButUndeclared)
+    {
+      builtIns.emplace(name, type->getDescription());
+    }
+    for (const auto& [name, description]: builtIns)
+    {
+      included_.insert(name);
+    }
+  }
+
+  // Packages, and the types within each grouped by kind. Both maps are ordered, so
+  // the document is byte-identical from one run to the next.
+  std::map<std::string, std::map<std::string, std::vector<std::string>>> byPackage;
+  for (const auto& [name, entry]: entries)
+  {
+    byPackage[entry.package][entry.kind].push_back(name);
+  }
+
+  std::vector<std::vector<std::string>> packageSegments;
+  for (const auto& [package, kinds]: byPackage)
+  {
+    packageSegments.push_back(segmentsOf(package));
+  }
+  if (const auto shared = sharedPrefix(packageSegments); shared > 0U)
+  {
+    sharedRoot_ = join(
+      {packageSegments.front().begin(), packageSegments.front().begin() + static_cast<std::ptrdiff_t>(shared)}, ".");
+  }
+
+  std::ostringstream out;
+  out << "#import " << literal(styleImport(options))
+      << ": sen-table, facts, declared, kw, lit, summary, chip, section, prose, "
+         "index-of, hierarchy, packages, enum-columns, mono, COL-NAME, COL-TYPE, COL-FLAGS\n\n";
+
+  if (options.overview)
+  {
+    emitOverview(out, entries, byPackage, options.hierarchy);
+  }
+
+  // The legend explains the Flags column, which only classes have. A model of nothing but
+  // records would otherwise open with a page explaining something it never shows.
+  const bool anyClasses = std::any_of(
+    byPackage.begin(), byPackage.end(), [](const auto& pair) { return pair.second.count("classes") != 0U; });
+  if (options.flagLegend && anyClasses)
+  {
+    emitFlagLegend(out);
+  }
+
+  // The heading follows the tree: a group opens a section, the packages under it are
+  // sub-headings carrying only what the group has not already said.
+  const auto sharedSegments = sharedRoot_.empty() ? 0U : segmentsOf(sharedRoot_).size();
+  std::string openGroup;
+
+  for (const auto& [package, kinds]: byPackage)
+  {
+    const auto segments = segmentsOf(package);
+    const auto group =
+      join({segments.begin(), segments.begin() + static_cast<std::ptrdiff_t>(sharedSegments + 1U)}, ".");
+    if (group != openGroup)
+    {
+      out << "= #"
+          << literal(join({segments.begin() + static_cast<std::ptrdiff_t>(sharedSegments),
+                           segments.begin() + static_cast<std::ptrdiff_t>(sharedSegments + 1U)},
+                          "."))
+          << "\n\n";
+      openGroup = group;
+    }
+    if (package != group)
+    {
+      out << "== #"
+          << literal(join({segments.begin() + static_cast<std::ptrdiff_t>(sharedSegments + 1U), segments.end()}, "."))
+          << "\n\n";
+    }
+
+    std::size_t total = 0U;
+    for (const auto& [kind, names]: kinds)
+    {
+      total += names.size();
+    }
+    out << "#prose[" << total << " types.]\n\n";
+
+    for (const auto& kindName: kindNames)
+    {
+      const auto found = kinds.find(std::string {kindName.id});
+      if (found == kinds.end())
+      {
+        continue;
+      }
+
+      out << "#section(\"" << kindName.section << "\", \"" << kindName.id << "\")\n\n";
+
+      if (options.summaries)
+      {
+        out << "#summary(\n";
+        for (const auto& name: found->second)
+        {
+          out << "  (" << reference(name, package) << ", " << literal(entries.at(name).description) << ", <"
+              << labelOf(name) << ">),\n";
+        }
+        out << ")\n\n";
+      }
+
+      for (const auto& name: found->second)
+      {
+        const auto& entry = entries.at(name);
+        out << "==== #" << literal(local(name, package)) << " #chip(\"" << entry.kind << "\", \"" << kindName.one
+            << "\") <" << labelOf(name) << ">\n";
+        if (!entry.description.empty())
+        {
+          out << "#prose(" << literal(entry.description) << ")\n";
+        }
+        emitBody(out, *entry.type, package);
+        if (options.usedBy && !entry.usedBy.empty())
+        {
+          out << "#facts[Named by ";
+          for (std::size_t i = 0U; i < entry.usedBy.size(); ++i)
+          {
+            out << (i == 0U ? "" : ", ") << inlineReference(entry.usedBy[i], package);
+          }
+          out << ".]\n";
+        }
+        out << "\n";
+      }
+    }
+  }
+
+  if (options.builtIns && !builtIns.empty())
+  {
+    out << "= Built-in types\n\n#prose[The types the language provides. Every one is written the same way "
+           "on the wire wherever it appears.]\n\n#sen-table(\n  columns: (COL-NAME, 1fr),\n"
+           "  table.header([*Type*], [*Meaning*]),\n";
+    for (const auto& [name, description]: builtIns)
+    {
+      out << "  [#mono(" << literal(name) << ") <" << labelOf(name) << ">], " << literal(description) << ",\n";
+    }
+    out << ")\n\n";
+  }
+
+  if (options.index)
+  {
+    out << "= Index\n\n#index-of(\n";
+    for (const auto& [name, entry]: entries)
+    {
+      out << "  (" << reference(name, sharedRoot_) << ", <" << labelOf(name) << ">),\n";
+    }
+    out << ")\n";
+  }
+
+  FileContents files;
+  files["reference.typ"] = out.str();
+
+  // The style is emitted unless the caller brings their own: every visual decision
+  // lives in that one module, so replacing it is how the document is restyled without
+  // anybody editing generated output.
+  if (options.style.empty())
+  {
+    files["style.typ"] = sen::decompressSymbolToString(style, styleSize);
+  }
+
+  files["document.typ"] = fillSkeleton(sen::decompressSymbolToString(document, documentSize), options);
+  return files;
+}
+
+TypstGenerator::TypstGenerator(): pimpl_(std::make_unique<Impl>()) {}
+TypstGenerator::~TypstGenerator() = default;
+
+TypstGenerator::FileContents TypstGenerator::generate(const sen::lang::TypeSetContext& typeSets,
+                                                      const TypstOptions& options)
+{
+  return pimpl_->generate(typeSets, options);
+}
+
+}  // namespace sen::gen

--- a/libs/gen/src/typst/typst_generator.cpp
+++ b/libs/gen/src/typst/typst_generator.cpp
@@ -181,17 +181,20 @@ struct Entry
   const auto symbol = [](std::string_view token) -> std::string
   {
     // Micro and degree have no ASCII spelling, so the abbreviation approximates them.
+    // Spelt as UTF-8 bytes: MSVC encodes a \u escape into its own code page instead,
+    // which puts a byte the document cannot carry into the output.
     if (token == "um" || token == "us")
     {
-      return "\"\u00b5" + std::string {token.substr(1U)} + "\"";
+      return "\"\xc2\xb5" + std::string {token.substr(1U)} + "\"";
     }
     if (token == "deg")
     {
-      return "\"\u00b0\"";
+      return "\"\xc2\xb0\"";
     }
     if (token == "degC")
     {
-      return "\"\u00b0C\"";
+      return "\"\xc2\xb0"
+             "C\"";
     }
     return "\"" + std::string {token} + "\"";
   };

--- a/libs/gen/test/CMakeLists.txt
+++ b/libs/gen/test/CMakeLists.txt
@@ -8,6 +8,7 @@
 set(gen_tests
     json_generator_test.cpp
     html_generator_test.cpp
+    typst_generator_test.cpp
     generators_test.cpp
     every_kind_model.h
 )

--- a/libs/gen/test/typst_generator_test.cpp
+++ b/libs/gen/test/typst_generator_test.cpp
@@ -135,7 +135,9 @@ using sen::gen::test::everyKindStl;
 
 // A qualified name carries a break opportunity after each dot, so a long one can wrap in a
 // narrow column instead of overflowing it. Expectations on rendered names have to allow it.
-[[nodiscard]] std::string zeroWidthSpace() { return "\u200b"; }
+// As UTF-8 bytes rather than an escape: MSVC cannot represent this character in its code
+// page and substitutes another, so the needle stops matching what the generator wrote.
+[[nodiscard]] std::string zeroWidthSpace() { return "\xe2\x80\x8b"; }
 
 // For failure messages: a missing break opportunity is invisible in a log otherwise.
 [[nodiscard]] std::string visible(std::string text)
@@ -487,7 +489,10 @@ quantity<f32, degC> Temperature;
 
   const auto& reference = file("reference.typ");
   EXPECT_NE(reference.find(R"($"m"\/"s"^2$)"), std::string::npos) << "m_per_s_sq is metres per second squared";
-  EXPECT_NE(reference.find("$\"\u00b0C\"$"), std::string::npos) << "degC carries a degree sign";
+  EXPECT_NE(reference.find("$\"\xc2\xb0"
+                           "C\"$"),
+            std::string::npos)
+    << "degC carries a degree sign";
   EXPECT_EQ(reference.find("m_per_s_sq"), std::string::npos) << "and the machine spelling does not reach the page";
 }
 

--- a/libs/gen/test/typst_generator_test.cpp
+++ b/libs/gen/test/typst_generator_test.cpp
@@ -1,0 +1,463 @@
+// === typst_generator_test.cpp ========================================================================================
+//                                               Sen Infrastructure
+//                   Released under the Apache License v2.0 (SPDX-License-Identifier Apache-2.0).
+//                                    See the LICENSE.txt file for more information.
+//                   © Airbus SAS, Airbus Helicopters, and Airbus Defence and Space SAU/GmbH/SAS.
+// =====================================================================================================================
+
+#include "every_kind_model.h"
+#include "sen/gen/typst.h"
+
+// sen
+#include "sen/core/lang/stl_parser.h"
+#include "sen/core/lang/stl_resolver.h"
+#include "sen/core/lang/stl_scanner.h"
+#include "sen/core/lang/stl_statement.h"
+
+// 3rd party
+#include <gtest/gtest.h>
+
+// std
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+class ATypstGenerator: public ::testing::Test
+{
+protected:
+  void generate(const std::string& stl, sen::gen::TypstOptions options = {})
+  {
+    resolve(stl);
+    files_ = sen::gen::TypstGenerator {}.generate(context_, options);
+  }
+
+  // A source declares one package, and an import names a file, so a model spanning two
+  // packages needs the imported one on disk for the resolver to find.
+  void generate(const std::string& imported,
+                const std::string& importedAs,
+                const std::string& main,
+                sen::gen::TypstOptions options = {})
+  {
+    const auto directory = std::filesystem::temp_directory_path() / "sen-typst-test";
+    std::filesystem::create_directories(directory);
+    std::ofstream {directory / importedAs} << imported;
+
+    resolve(main, {.includePaths = {directory}});
+    files_ = sen::gen::TypstGenerator {}.generate(context_, options);
+  }
+
+  [[nodiscard]] const std::string& file(const std::string& path) const
+  {
+    const auto found = files_.find(path);
+    if (found != files_.end())
+    {
+      return found->second;
+    }
+    ADD_FAILURE() << "no file named " << path;
+    static const std::string none;
+    return none;
+  }
+
+  [[nodiscard]] const sen::gen::TypstGenerator::FileContents& files() const { return files_; }
+
+  [[nodiscard]] bool contains(const std::string& path, const std::string& needle) const
+  {
+    return file(path).find(needle) != std::string::npos;
+  }
+
+  // For the checks that need two models rather than one document.
+  void resolveInto(sen::lang::TypeSetContext& context, const std::string& stl)
+  {
+    sen::lang::StlScanner scanner {stl};
+    sen::lang::StlParser parser {scanner.scanTokens()};
+    statements_.push_back(parser.parse());
+
+    const sen::lang::ResolverContext resolverContext {};
+    sen::lang::StlResolver resolver {statements_.back(), resolverContext, context};
+    resolver.resolve({});
+  }
+
+private:
+  void resolve(const std::string& stl, sen::lang::ResolverContext resolverContext = {})
+  {
+    sen::lang::StlScanner scanner {stl};
+    sen::lang::StlParser parser {scanner.scanTokens()};
+    statements_.push_back(parser.parse());
+
+    sen::lang::StlResolver resolver {statements_.back(), resolverContext, context_};
+    resolver.resolve({});
+  }
+
+  // The resolved model points into these, so they outlive resolution.
+  std::vector<std::vector<sen::lang::StlStatement>> statements_;
+  sen::lang::TypeSetContext context_;
+  sen::gen::TypstGenerator::FileContents files_;
+};
+
+constexpr auto twoClasses = R"(package t;
+
+// A base with something of its own.
+class Base
+{
+  var one : i32;
+}
+
+// Inherits one and adds another.
+class Derived: extends Base
+{
+  var two : f32;
+  fn compute(a: i32) -> f32;
+}
+)";
+
+using sen::gen::test::everyKindStl;
+
+// A qualified name carries a break opportunity after each dot, so a long one can wrap in a
+// narrow column instead of overflowing it. Expectations on rendered names have to allow it.
+const std::string zeroWidthSpace {"\u200b"};
+
+TEST_F(ATypstGenerator, writesAReferenceAStyleAndASkeleton)
+{
+  generate(twoClasses);
+  for (const auto* path: {"reference.typ", "style.typ", "document.typ"})
+  {
+    EXPECT_FALSE(file(path).empty()) << path << " is empty";
+  }
+}
+
+// The skeleton imports the style and includes the reference. If either name drifts the
+// document compiles to nothing useful and nothing else would notice.
+TEST_F(ATypstGenerator, theSkeletonNamesTheFilesThatAreEmitted)
+{
+  generate(twoClasses);
+  EXPECT_TRUE(contains("document.typ", "\"style.typ\""));
+  EXPECT_TRUE(contains("document.typ", "\"reference.typ\""));
+  EXPECT_TRUE(contains("reference.typ", "#import \"style.typ\""));
+}
+
+// The style is the caller's to replace; emitting ours over theirs would overwrite it.
+TEST_F(ATypstGenerator, doesNotEmitAStyleWhenTheCallerBringsOne)
+{
+  sen::gen::TypstOptions options;
+  options.style = "house-style.typ";
+  generate(twoClasses, options);
+  EXPECT_EQ(files().count("style.typ"), 0U);
+}
+
+// An unset include point still tells a reader where their own content belongs.
+TEST_F(ATypstGenerator, leavesAHintWhereACallerSuppliesNoPage)
+{
+  generate(twoClasses);
+  EXPECT_TRUE(contains("document.typ", "your title page"));
+
+  sen::gen::TypstOptions options;
+  options.frontMatter = "front.typ";
+  generate(twoClasses, options);
+  EXPECT_TRUE(contains("document.typ", "#include \"front.typ\""));
+  EXPECT_FALSE(contains("document.typ", "your title page"));
+}
+
+TEST_F(ATypstGenerator, opensEveryTypeAsAHeadingCarryingItsKind)
+{
+  generate(twoClasses);
+  EXPECT_TRUE(contains("reference.typ", "==== #\"Base\" #chip(\"classes\", \"class\")"));
+  EXPECT_TRUE(contains("reference.typ", "==== #\"Derived\" #chip(\"classes\", \"class\")"));
+}
+
+// The section heading already names the package, so repeating it on every heading, every
+// summary row and every type cell is noise that grows with the depth of the package tree.
+TEST_F(ATypstGenerator, writesNamesUnqualifiedInsideTheirOwnPackage)
+{
+  generate(twoClasses);
+  EXPECT_TRUE(contains("reference.typ", "==== #\"Base\""));
+  EXPECT_FALSE(contains("reference.typ", "==== #\"t."));
+  EXPECT_TRUE(contains("reference.typ", "link(<t-t-Base>)[#\"Base\"]")) << "nor in the summary rows";
+
+  // The index spans the document rather than one section, so there the package belongs.
+  // Its needle carries the break opportunity a qualified name is written with.
+  EXPECT_TRUE(contains("reference.typ", "[#\"t." + zeroWidthSpace + "Base\"]"));
+}
+
+// The other half: shortening a name from elsewhere would hide that the link leaves the
+// section. Only the package doing the printing may be dropped.
+TEST_F(ATypstGenerator, keepsThePackageOnANameFromAnotherOne)
+{
+  generate(R"(package a;
+
+// Something to point at.
+struct Shared { value : i32 }
+)",
+           "a.stl",
+           R"(package b;
+
+import "a.stl"
+
+// Holds one of a's.
+class Holder
+{
+  var borrowed : a.Shared;
+}
+)");
+  EXPECT_TRUE(contains("reference.typ", "\"a." + zeroWidthSpace + "Shared\""))
+    << "b refers out to a, so the package must show";
+}
+
+// Typst treats a link to a label the document does not contain as an error rather than
+// a dangling link, so a reference may only be made to a type that is present.
+TEST_F(ATypstGenerator, doesNotLinkToATypeTheDocumentDoesNotContain)
+{
+  // Two packages, one excluded: the surviving one still names a type in the excluded one,
+  // which is the only shape where the guard can be wrong. Excluding the only package would
+  // leave nothing to link from, and the check would hold however the guard behaved.
+  generate(R"(package a;
+
+// Something to point at.
+struct Shared { value : i32 }
+)",
+           "a.stl",
+           R"(package b;
+
+import "a.stl"
+
+// Holds one of a's.
+class Holder
+{
+  var borrowed : a.Shared;
+}
+)",
+           {.excludePackages = {"a"}});
+
+  const auto& reference = file("reference.typ");
+  EXPECT_NE(reference.find("Holder"), std::string::npos) << "b is still documented";
+  EXPECT_EQ(reference.find("link(<t-a-Shared>)"), std::string::npos) << "but a is not, so nothing may link into it";
+  EXPECT_NE(reference.find("a." + zeroWidthSpace + "Shared"), std::string::npos)
+    << "the name still shows, as plain text";
+}
+
+TEST_F(ATypstGenerator, tabulatesWhatAClassCarriesAndWhatItCanBeAsked)
+{
+  generate(twoClasses);
+  EXPECT_TRUE(contains("reference.typ", "table.header([*Name*], [*Type*], [*Flags*], [*Description*])"));
+  EXPECT_TRUE(contains("reference.typ", "table.header([*Method*], [*Signature*], [*Description*])"));
+  EXPECT_TRUE(contains("reference.typ", "compute")) << "the method should appear";
+}
+
+// Model prose is data, not markup. Typst reads a leading `=` as a heading, `//` as a
+// comment, `~` as a non-breaking space and `--` as an en dash, so prose emitted as markup
+// either fails to compile or silently changes what the model said. A string literal is
+// read verbatim, and only the two characters that could end it need an escape.
+TEST_F(ATypstGenerator, writesModelProseAsDataRatherThanMarkup)
+{
+  generate(R"(package t;
+
+// = Deprecated: 3//4 of the frame, ~5 typical, 0 -- 100, and a quote " here.
+class Awkward
+{
+  var one : i32;
+}
+)");
+
+  const auto& reference = file("reference.typ");
+  EXPECT_NE(reference.find(R"(= Deprecated: 3//4 of the frame, ~5 typical, 0 -- 100)"), std::string::npos)
+    << "the model's own words have to survive intact";
+  EXPECT_NE(reference.find(R"(and a quote \" here.)"), std::string::npos)
+    << "and a quote, which would otherwise end the literal, has to be escaped";
+}
+
+TEST_F(ATypstGenerator, rendersEveryKindTheModelCanHold)
+{
+  generate(everyKindStl);
+
+  const auto& reference = file("reference.typ");
+  for (const auto* section: {"Object classes", "Fixed records", "Enumerations", "Variant records"})
+  {
+    EXPECT_NE(reference.find(section), std::string::npos) << section << " has no section";
+  }
+}
+
+// A wrapper type is defined by what it wraps. Emitting the heading alone puts a page
+// number against a name and tells the reader nothing they did not have from the index.
+TEST_F(ATypstGenerator, saysWhatAWrapperTypeWraps)
+{
+  generate(everyKindStl);
+
+  const auto& reference = file("reference.typ");
+  // Each is written as the line of the language that declares it, which says what it is
+  // and what it wraps at once.
+  for (const auto* declared: {"#kw[optional]", "#kw[sequence]", "#kw[array]", "#kw[alias]", "#kw[quantity]"})
+  {
+    EXPECT_NE(reference.find(declared), std::string::npos) << "nothing is declared as: " << declared;
+  }
+}
+
+// A section switch that is off must remove the section, or the option is decorative.
+TEST_F(ATypstGenerator, honoursTheSectionSwitches)
+{
+  sen::gen::TypstOptions off;
+  off.summaries = false;
+  off.index = false;
+  generate(twoClasses, off);
+
+  EXPECT_EQ(file("reference.typ").find("#summary("), std::string::npos);
+  EXPECT_EQ(file("reference.typ").find("= Index"), std::string::npos);
+
+  generate(twoClasses);
+  EXPECT_NE(file("reference.typ").find("#summary("), std::string::npos)
+    << "and they must be present by default, or the check above proves nothing";
+}
+
+// Typst has two modes: inside a content block a link needs its leading hash, and a bare
+// `link(<x>)` there is read as text plus a *label definition*. That yields a duplicate
+// label and typst refuses the document — but only when someone runs it, so the rule is
+// checked here where it costs nothing.
+TEST_F(ATypstGenerator, writesContentModeLinksInsideContentBlocks)
+{
+  generate(everyKindStl);
+
+  const auto& reference = file("reference.typ");
+  std::size_t blocks = 0U;
+  for (std::size_t at = reference.find("#facts["); at != std::string::npos; at = reference.find("#facts[", at + 1U))
+  {
+    ++blocks;
+    const auto end = reference.find("]\n", at);
+    const auto block = reference.substr(at, end - at);
+    for (std::size_t use = block.find("link("); use != std::string::npos; use = block.find("link(", use + 1U))
+    {
+      EXPECT_TRUE(use > 0U && block[use - 1U] == '#')
+        << "a bare link( inside a content block defines a label: " << block;
+    }
+  }
+  EXPECT_GT(blocks, 0U) << "no content blocks were emitted, so this check proves nothing";
+}
+
+// A class can carry nothing but events, and they were reaching the page as a heading
+// with no content under it at all.
+TEST_F(ATypstGenerator, tabulatesWhatAClassAnnounces)
+{
+  generate(everyKindStl);
+  EXPECT_TRUE(contains("reference.typ", "table.header([*Event*], [*Payload*], [*Description*])"));
+}
+
+// A struct's own getFields() is own-fields-only and, unlike a class, nothing else in the
+// document said the type had a parent, so the inherited fields were unreachable.
+TEST_F(ATypstGenerator, saysWhenARecordExtendsAnother)
+{
+  generate(everyKindStl);
+  EXPECT_TRUE(contains("reference.typ", "Extends ")) << "Circle extends Point in the model";
+}
+
+// "at most 3" contradicted the model's own "always three" one line above it.
+TEST_F(ATypstGenerator, distinguishesAFixedArrayFromABoundedOne)
+{
+  // The language has two keywords for this and they mean different things, so the
+  // document has to use the one the model used.
+  generate(everyKindStl);
+  EXPECT_TRUE(contains("reference.typ", "#kw[array]")) << "array<Metres, 3> holds exactly three";
+  EXPECT_TRUE(contains("reference.typ", "#kw[sequence]")) << "sequence<Point, 8> holds up to eight";
+  EXPECT_TRUE(contains("reference.typ", "#lit[8]")) << "and the bound is shown";
+}
+
+// How wide an enumeration is on the wire is the fact an interface document is read for.
+TEST_F(ATypstGenerator, saysHowAnEnumerationIsHeld)
+{
+  generate(everyKindStl);
+  EXPECT_TRUE(contains("reference.typ", "Held as #mono("));
+}
+
+// What names a type is how a reader works out what a change to it would break. The
+// option and the field both existed and neither was ever read.
+TEST_F(ATypstGenerator, saysWhatNamesEachType)
+{
+  generate(everyKindStl);
+  EXPECT_TRUE(contains("reference.typ", "Named by")) << "Point is named by Circle, Track and Figure";
+
+  sen::gen::TypstOptions off;
+  off.usedBy = false;
+  generate(everyKindStl, off);
+  EXPECT_FALSE(contains("reference.typ", "Named by")) << "and the switch has to remove it";
+}
+
+// The switch has to remove the section without taking the overview with it.
+TEST_F(ATypstGenerator, honoursTheHierarchySwitch)
+{
+  generate(twoClasses);
+  EXPECT_TRUE(contains("reference.typ", "#hierarchy("));
+
+  sen::gen::TypstOptions off;
+  off.hierarchy = false;
+  generate(twoClasses, off);
+  EXPECT_FALSE(contains("reference.typ", "#hierarchy("));
+  EXPECT_TRUE(contains("reference.typ", "= Model overview")) << "without taking the overview with it";
+}
+
+// The caller's style was suppressed and never named, so the document imported a file
+// that nothing wrote and could not compile at all.
+TEST_F(ATypstGenerator, importsTheStyleTheCallerNamed)
+{
+  sen::gen::TypstOptions options;
+  options.style = "house.typ";
+  generate(twoClasses, options);
+
+  EXPECT_TRUE(contains("document.typ", "#import \"house.typ\""));
+  EXPECT_TRUE(contains("reference.typ", "#import \"house.typ\""));
+  EXPECT_FALSE(contains("document.typ", "\"style.typ\""));
+}
+
+// The title is the one string a caller supplies that reaches the page, and it went in
+// unescaped: a quote in it ended the literal and the document stopped compiling.
+TEST_F(ATypstGenerator, escapesTheTitle)
+{
+  sen::gen::TypstOptions options;
+  options.title = R"(Acme "Radar" ICD)";
+  generate(twoClasses, options);
+  EXPECT_TRUE(contains("document.typ", R"(Acme \"Radar\" ICD)"));
+}
+
+// Nothing said the generator was single-use, and a second run emitted links to types
+// only the first model held.
+TEST_F(ATypstGenerator, canBeRunTwice)
+{
+  sen::gen::TypstGenerator generator;
+
+  sen::lang::TypeSetContext first;
+  resolveInto(first, twoClasses);
+  const auto once = generator.generate(first, {});
+
+  sen::lang::TypeSetContext second;
+  resolveInto(second, R"(package other;
+
+// Nothing to do with the first model.
+struct Lonely { value : i32 }
+)");
+  const auto twice = generator.generate(second, {});
+
+  EXPECT_EQ(twice.at("reference.typ").find("t-t-Base"), std::string::npos)
+    << "the second document must not link into the first model";
+  EXPECT_NE(once.at("reference.typ").find("t-t-Base"), std::string::npos) << "which the first one did contain";
+}
+
+// A unit abbreviation is written for a machine -- "m_per_s_sq" -- and the page is read by
+// a person. Typeset upright as SI asks, and inline rather than as a stacked fraction,
+// which would be too tall for a line of declaration.
+TEST_F(ATypstGenerator, typesetsAUnitAsMathematics)
+{
+  generate(R"(package t;
+
+// Metres travelled each second, each second.
+quantity<f32, m_per_s_sq> Acceleration;
+
+// How warm it is.
+quantity<f32, degC> Temperature;
+)");
+
+  const auto& reference = file("reference.typ");
+  EXPECT_NE(reference.find(R"($"m"\/"s"^2$)"), std::string::npos) << "m_per_s_sq is metres per second squared";
+  EXPECT_NE(reference.find("$\"\u00b0C\"$"), std::string::npos) << "degC carries a degree sign";
+  EXPECT_EQ(reference.find("m_per_s_sq"), std::string::npos) << "and the machine spelling does not reach the page";
+}
+
+}  // namespace

--- a/libs/gen/test/typst_generator_test.cpp
+++ b/libs/gen/test/typst_generator_test.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 // std
+#include <cstddef>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -46,7 +47,9 @@ protected:
     std::filesystem::create_directories(directory);
     std::ofstream {directory / importedAs} << imported;
 
-    resolve(main, {.includePaths = {directory}});
+    sen::lang::ResolverContext resolverContext;
+    resolverContext.includePaths = {directory};
+    resolve(main, resolverContext);
     files_ = sen::gen::TypstGenerator {}.generate(context_, options);
   }
 
@@ -116,9 +119,16 @@ class Derived: extends Base
 
 using sen::gen::test::everyKindStl;
 
+[[nodiscard]] sen::gen::TypstOptions excluding(const std::string& package)
+{
+  sen::gen::TypstOptions options;
+  options.excludePackages = {package};
+  return options;
+}
+
 // A qualified name carries a break opportunity after each dot, so a long one can wrap in a
 // narrow column instead of overflowing it. Expectations on rendered names have to allow it.
-const std::string zeroWidthSpace {"\u200b"};
+[[nodiscard]] std::string zeroWidthSpace() { return "\u200b"; }
 
 TEST_F(ATypstGenerator, writesAReferenceAStyleAndASkeleton)
 {
@@ -179,7 +189,7 @@ TEST_F(ATypstGenerator, writesNamesUnqualifiedInsideTheirOwnPackage)
 
   // The index spans the document rather than one section, so there the package belongs.
   // Its needle carries the break opportunity a qualified name is written with.
-  EXPECT_TRUE(contains("reference.typ", "[#\"t." + zeroWidthSpace + "Base\"]"));
+  EXPECT_TRUE(contains("reference.typ", "[#\"t." + zeroWidthSpace() + "Base\"]"));
 }
 
 // The other half: shortening a name from elsewhere would hide that the link leaves the
@@ -202,7 +212,7 @@ class Holder
   var borrowed : a.Shared;
 }
 )");
-  EXPECT_TRUE(contains("reference.typ", "\"a." + zeroWidthSpace + "Shared\""))
+  EXPECT_TRUE(contains("reference.typ", "\"a." + zeroWidthSpace() + "Shared\""))
     << "b refers out to a, so the package must show";
 }
 
@@ -229,12 +239,12 @@ class Holder
   var borrowed : a.Shared;
 }
 )",
-           {.excludePackages = {"a"}});
+           excluding("a"));
 
   const auto& reference = file("reference.typ");
   EXPECT_NE(reference.find("Holder"), std::string::npos) << "b is still documented";
   EXPECT_EQ(reference.find("link(<t-a-Shared>)"), std::string::npos) << "but a is not, so nothing may link into it";
-  EXPECT_NE(reference.find("a." + zeroWidthSpace + "Shared"), std::string::npos)
+  EXPECT_NE(reference.find("a." + zeroWidthSpace() + "Shared"), std::string::npos)
     << "the name still shows, as plain text";
 }
 

--- a/libs/gen/test/typst_generator_test.cpp
+++ b/libs/gen/test/typst_generator_test.cpp
@@ -43,9 +43,16 @@ protected:
                 const std::string& main,
                 sen::gen::TypstOptions options = {})
   {
-    const auto directory = std::filesystem::temp_directory_path() / "sen-typst-test";
+    // Tests run as concurrent processes, so the file has to be this test's own: sharing one
+    // path means one process truncating what another is reading.
+    const auto directory = std::filesystem::temp_directory_path() / "sen-typst-test" /
+                           ::testing::UnitTest::GetInstance()->current_test_info()->name();
     std::filesystem::create_directories(directory);
-    std::ofstream {directory / importedAs} << imported;
+    {
+      std::ofstream written {directory / importedAs};
+      written << imported;
+      ASSERT_TRUE(written.good()) << "could not write " << (directory / importedAs).string();
+    }
 
     sen::lang::ResolverContext resolverContext;
     resolverContext.includePaths = {directory};
@@ -225,7 +232,8 @@ class Holder
 }
 )");
   EXPECT_TRUE(contains("reference.typ", "\"a." + zeroWidthSpace() + "Shared\""))
-    << "b refers out to a, so the package must show";
+    << "b refers out to a, so the package must show\n"
+    << visible(file("reference.typ"));
 }
 
 // Typst treats a link to a label the document does not contain as an error rather than

--- a/libs/gen/test/typst_generator_test.cpp
+++ b/libs/gen/test/typst_generator_test.cpp
@@ -130,6 +130,18 @@ using sen::gen::test::everyKindStl;
 // narrow column instead of overflowing it. Expectations on rendered names have to allow it.
 [[nodiscard]] std::string zeroWidthSpace() { return "\u200b"; }
 
+// For failure messages: a missing break opportunity is invisible in a log otherwise.
+[[nodiscard]] std::string visible(std::string text)
+{
+  const std::string marker {"<ZWSP>"};
+  const auto space = zeroWidthSpace();
+  for (auto at = text.find(space); at != std::string::npos; at = text.find(space, at + marker.size()))
+  {
+    text.replace(at, space.size(), marker);
+  }
+  return text;
+}
+
 TEST_F(ATypstGenerator, writesAReferenceAStyleAndASkeleton)
 {
   generate(twoClasses);
@@ -245,7 +257,8 @@ class Holder
   EXPECT_NE(reference.find("Holder"), std::string::npos) << "b is still documented";
   EXPECT_EQ(reference.find("link(<t-a-Shared>)"), std::string::npos) << "but a is not, so nothing may link into it";
   EXPECT_NE(reference.find("a." + zeroWidthSpace() + "Shared"), std::string::npos)
-    << "the name still shows, as plain text";
+    << "the name still shows, as plain text\n"
+    << visible(reference);
 }
 
 TEST_F(ATypstGenerator, tabulatesWhatAClassCarriesAndWhatItCanBeAsked)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -268,6 +268,7 @@ nav:
       - Request/response servers: snippets/examples/config/9_hla_servers/readme.md
       - JSON-RPC: snippets/examples/config/14_jsonrpc/readme.md
       - HTML reference: examples/generated_reference.md
+      - Typeset reference (PDF): examples/generated_document.md
       - UML generation: examples/generated_uml.md
   - License:
       - licenses/index.md

--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -31,6 +31,7 @@ ARG JUNITPARSER_VERSION=5.0.1
 ARG PYTEST_VERSION=9.1.1
 ARG PRECOMMIT_VERSION=4.5.1
 ARG PLANTUML_VERSION=1.2026.7
+ARG TYPST_VERSION=0.15.1
 # Both must equal the versions conanfile.py tool-requires, and nothing checks that
 # they do. The header says why the image carries them at all.
 ARG CMAKE_VERSION=3.31.10
@@ -92,6 +93,12 @@ RUN printf '%s\n' \
         python3-dev \
         python3-pip \
         sudo \
+        # Liberation Sans carries Helvetica's metrics, for the reference typst
+        # typesets. Without a sans installed the document falls back to a serif and
+        # repaginates, so the published PDF stops matching the one a developer sees.
+        fonts-liberation \
+        # tar -xJ, for the typst release below. Not in the base image.
+        xz-utils \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100 \
     && rm -rf /var/lib/apt/lists/*
@@ -105,6 +112,25 @@ RUN curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
     && printf '%s\n' '#!/bin/sh' 'exec java -jar /opt/plantuml.jar "$@"' > /usr/local/bin/plantuml \
     && chmod 0755 /usr/local/bin/plantuml \
     && plantuml -version
+
+# typst compiles the reference the documentation publishes as a PDF. The release is a
+# static musl binary with nothing under it, so there is no runtime to install beside it.
+# CMake finds it with find_program by name; without it the docs build still writes the
+# .typ sources and skips the compile, which is why the version is pinned here rather
+# than left to whatever a machine happens to have.
+ARG TARGETARCH
+RUN case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
+        amd64) typst_triple=x86_64-unknown-linux-musl ;; \
+        arm64) typst_triple=aarch64-unknown-linux-musl ;; \
+        *) echo "no typst release for ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
+        -o /tmp/typst.tar.xz \
+        "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${typst_triple}.tar.xz" \
+    && tar -xJf /tmp/typst.tar.xz -C /tmp \
+    && install -m 0755 "/tmp/typst-${typst_triple}/typst" /usr/local/bin/typst \
+    && rm -rf /tmp/typst.tar.xz "/tmp/typst-${typst_triple}" \
+    && typst --version
 
 # clang from apt.llvm.org: the matrix's clang leg and the clang-tidy lane
 # both use this major version. The repository is added directly instead of

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -295,12 +295,24 @@ stage. `base` installs cmake from pip rather than from the distribution
 because Conan writes `CMakeUserPresets.json` at version 4, which Ubuntu
 22.04's cmake 3.22 refuses to read.
 
+The image also carries the tools the documentation build finds by name: `plantuml`
+for the diagram the handbook embeds, and `typst` with Liberation Sans for the
+reference the handbook publishes as a PDF. The Python side of the documentation is
+not baked in -- `build_documentation` pip-installs `docs/requirements.txt` into the
+image at job time, which is where mkdocs and its plugins come from. The rule the two
+follow: a binary CMake locates with `find_program` belongs in the image, a Python
+package belongs in the requirements file.
+
 `ci-image.yaml` builds both stages and then checks what is inside them. For
 `base`: the expected tools are present, cmake and ninja report the versions
 `conanfile.py` tool-requires, clang can link a sanitizer binary, and the image
 does not run as root. For `dev`: cmake, ninja, gdb and dot are present and
 cmake is new enough to read the presets. A Dockerfile that still builds but
-lost a tool therefore fails in the pull request that broke it. `main.yaml` calls it when a change touches the build environment,
+lost a tool therefore fails in the pull request that broke it -- which only holds
+for tools the list names, so anything added to the Dockerfile has to be added
+there too. Liberation Sans is checked as a file rather than with `command -v`,
+since a missing font is not a missing command and there is no fontconfig to ask.
+`main.yaml` calls it when a change touches the build environment,
 and `ci-ok` needs it, so a broken image blocks the merge instead of showing up
 as a red mark beside it. Documentation under `tools/ci/` does not trigger it:
 the Dockerfile copies nothing out of the repository. Docker layer caching in the Actions cache keeps


### PR DESCRIPTION
## What and why

An eighth generator. It renders a data model as a tabular reference in the shape of an
interface control document: a package overview, a class hierarchy, a table per type and an
index, with every type name a link. It writes typst source; producing a PDF is a separate
step, as with plantuml.

What the document contains is set by explicit options rather than inferred from the model,
and a caller supplies their own title page, appendices and style by naming typst files the
document includes.

Model text is emitted as string literals rather than markup, so a description holding `=`
or `//` cannot break the document and `~` or `--` cannot change what it says. The mkdocs
generator had the same defect into markdown table cells and is fixed the same way.

Removes logic copied between the generators: a `KindVisitor` identical in two of them, an
unsupported-type error in six, and a copy of `collectAllTypeSets` in json whose pointer
ordering had diverged from the shared one, which made schema output depend on allocation
addresses.

The build image gains typst and Liberation Sans. The image check gains those and plantuml,
which it had never covered.

Two example documents are published with the handbook, generated by the build rather than
committed.

## Checklist

- [x] The title follows `type(scope): summary` and stays under 72 characters
- [x] This pull request is a single logical change
- [x] Tests cover the change where practical
- [ ] `conan.lock` was regenerated if `conanfile.py` changed — not touched
