### PR TITLE
ci: let the conan cache keys fall back to the previous image

### DIFF
--- a/.github/actions/build_documentation/action.yaml
+++ b/.github/actions/build_documentation/action.yaml
@@ -26,7 +26,12 @@ runs:
       uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25  # v5
       with:
         path: ~/.conan2/p
-        key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs
+        key: conanp-image-docs-${{ hashFiles('tools/ci/Dockerfile') }}
+        # Hash after the suffix, because a restore key is a prefix: with it in the middle
+        # nothing could match "this lane, any image", so one Dockerfile line sent the lane
+        # cold and it built every dependency from source. 2026-09-08.
+        restore-keys: |
+          conanp-image-docs-
 
     # This keeps its cache inside the workspace, which the container mounts at the same
     # path, so what compiles inside the container writes where the runner saves from.
@@ -96,11 +101,11 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-      run: bash .github/scripts/drop_cache_key.sh "conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs"
+      run: bash .github/scripts/drop_cache_key.sh "conanp-image-docs-${{ hashFiles('tools/ci/Dockerfile') }}"
 
     - name: Save conan packages
       if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
       uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25  # v5
       with:
         path: ~/.conan2/p
-        key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-docs
+        key: conanp-image-docs-${{ hashFiles('tools/ci/Dockerfile') }}

--- a/.github/scripts/test_conan_cache_keys.py
+++ b/.github/scripts/test_conan_cache_keys.py
@@ -95,8 +95,12 @@ def test_the_key_families_are_the_ones_this_repository_uses():
     expected = {
         "conanp-{RUNNER}-{COMPILER}-{COMPILER_VERSION}-{STD}",
         "conanp-{RUNNER}-{COMPILER}-{COMPILER_VERSION}-",  # prepare_build's restore ladder
-        "conanp-image-{IMAGE}-docs",
-        "conanp-image-{IMAGE}-clang-20-17",
+        # Hash last, so a prefix can reach the family; the bare prefixes are the
+        # restore ladders that reach the previous image's entry.
+        "conanp-image-docs-{IMAGE}",
+        "conanp-image-docs-",
+        "conanp-image-clang-20-17-{IMAGE}",
+        "conanp-image-clang-20-17-",
     }
     found = set(keys())
     assert found == expected, (
@@ -112,6 +116,6 @@ def test_each_family_is_spelled_in_more_than_one_place():
     family found in a single file is one nobody is comparing.
     """
     found = keys()
-    for family in ("conanp-{RUNNER}-{COMPILER}-{COMPILER_VERSION}-{STD}", "conanp-image-{IMAGE}-docs"):
+    for family in ("conanp-{RUNNER}-{COMPILER}-{COMPILER_VERSION}-{STD}", "conanp-image-docs-{IMAGE}"):
         assert family in found, f"{family} is no longer found by the key scan"
         assert len(found[family]) >= 2, f"{family} is spelled once, in {found[family]}, so nothing is compared"

--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -53,7 +53,12 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.conan2/p
-          key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17
+          key: conanp-image-clang-20-17-${{ hashFiles('tools/ci/Dockerfile') }}
+          # Hash after the suffix, because a restore key is a prefix: with it in the middle
+          # nothing could match "this lane, any image", so one Dockerfile line sent the lane
+          # cold and it built every dependency from source. 2026-09-08.
+          restore-keys: |
+            conanp-image-clang-20-17-
 
       # No ccache: sanitized object files must not land in the entries the
       # ordinary builds depend on. Same rule as the nightly's sanitizer lanes.
@@ -154,11 +159,11 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: bash .github/scripts/drop_cache_key.sh "conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17"
+        run: bash .github/scripts/drop_cache_key.sh "conanp-image-clang-20-17-${{ hashFiles('tools/ci/Dockerfile') }}"
 
       - name: Save conan packages
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.conan2/p
-          key: conanp-image-${{ hashFiles('tools/ci/Dockerfile') }}-clang-20-17
+          key: conanp-image-clang-20-17-${{ hashFiles('tools/ci/Dockerfile') }}


### PR DESCRIPTION
A restore key is matched as a prefix, and the Dockerfile hash sat in the middle of the docs and sanitizer cache keys, so no prefix could reach the family and neither had a fallback. One line added to the Dockerfile in #285 changed the key, the docs lane found nothing, and it rebuilt all 36 dependencies from source — which only works while every upstream source host is up. One was not.

Moving the hash to the end lets each lane fall back to the previous image's cache and rebuild only what differs.

Costs one cold run, since nothing exists under the new prefix yet. Affordable now #293 has landed.