### PR TITLE
test(examples): give webexplorer smoke tests their own timeout

### DIFF
--- a/examples/config/CMakeLists.txt
+++ b/examples/config/CMakeLists.txt
@@ -128,6 +128,12 @@ foreach(config_file ${configs})
   set(test_name ${config_dir_name}_${config}_smoke)
   add_sen_run_smoke_test(${test_name} CONFIG_FILE ${config_file})
 
+  # Standing up the webexplorer backend takes ~10s against ctest's 20s global; the same configs
+  # without it take 0.6s. One lane has exceeded 20s and the spread is not characterised.
+  if("webexplorer" IN_LIST _required_components)
+    set_tests_properties(${test_name} PROPERTIES TIMEOUT 120)
+  endif()
+
   append_test_env_modification(
     ${test_name} "PYTHONPATH=path_list_append:${PROJECT_SOURCE_DIR}/examples/config/10_python/scripts"
   )


### PR DESCRIPTION
`14_jsonrpc_4_explorer_demo_smoke` timed out on a `clang-x86-20 [Debug]` lane while passing
everywhere else. The test is not slow by accident: it is a fixture sitting at half of ctest's
global ceiling, so it crosses the line the first time a runner is slow.

Measured from the green lanes of that same run:

| smoke test | duration |
|---|---|
| `14_jsonrpc_4_explorer_demo_smoke` (jsonrpc + webexplorer) | 10.79 s |
| `14_jsonrpc_3_explorer_smoke` (jsonrpc + webexplorer) | 10.57 s |
| `14_jsonrpc_2_animals_smoke` (jsonrpc alone) | 0.58 s |
| `14_jsonrpc_1_fibonacci_smoke` (jsonrpc alone) | 0.58 s |
| next heaviest smoke test in the suite | 1.78 s |

Standing up the webexplorer backend is the cost, and exactly two configs in the repository load it.
Against the `--timeout 20` that CI applies globally, those two run at 54% of the ceiling while every
other smoke test runs at 3%.

`cmake/util/test.cmake` already prescribes the remedy — the 20 s "was measured when each had [the
machine] to itself", and tests needing longer should be given "a TIMEOUT of their own, as the jsonrpc
and mcp_gateway suites do". The jsonrpc TypeScript suite does exactly that at 240 s, for the reason
its comment gives: so ctest does not kill the process before a diagnostic can fire, "which would turn
a real startup failure into a bare Timeout". That is precisely the failure mode seen here.

This applies that existing convention, keyed on the component the loop already computes rather than
on a list of names.

Verified by configuring and reading the generated test properties: `TIMEOUT 120.0` lands on
`14_jsonrpc_3_explorer_smoke` and `14_jsonrpc_4_explorer_demo_smoke`, and on no other smoke test.

One thing deliberately left open, recorded in the comment: the backend stands up in ~10 s on a green
lane and exceeded 20 s on the failing one. This ceiling accommodates that spread without explaining
it, and a timeout makes the variance invisible from here on.
