### PR TITLE
ci: name the CI image and lint the real squash subject

### DIFF
--- a/.github/actions/build_documentation/action.yaml
+++ b/.github/actions/build_documentation/action.yaml
@@ -12,7 +12,7 @@ runs:
 
     - name: Name the image
       shell: bash
-      run: echo "SEN_CI_IMAGE=sen-ci:docs" >> "$GITHUB_ENV"
+      run: echo "SEN_CI_IMAGE=$(.github/scripts/image_name.sh docs)" >> "$GITHUB_ENV"
 
     # Keyed to the image rather than the runner: a conan package id does not record
     # which Ubuntu produced a binary, so a cache filled on a runner installs cleanly

--- a/.github/scripts/image_name.sh
+++ b/.github/scripts/image_name.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Prints the full reference for one of this repository's CI image variants.
+#
+# The repository name lives here and nowhere else. It was written by hand in
+# four tags across three files, so publishing to a registry would have meant
+# finding every one -- and a missed reference still pulls, from the old place.
+set -euo pipefail
+
+# Empty while no registry hosts the image, so the reference stays a local tag.
+# Publishing is one edit here: set it to "ghcr.io/airbus/sen/" and every caller
+# follows. It must end in a slash when set.
+SEN_CI_REGISTRY="${SEN_CI_REGISTRY-}"
+SEN_CI_REPOSITORY="sen-ci"
+
+variant="${1:?usage: image_name.sh <variant>   e.g. dev, probe, docs, lane}"
+
+case "$SEN_CI_REGISTRY" in
+    "" | */) ;;
+    *) echo "SEN_CI_REGISTRY must end in a slash: $SEN_CI_REGISTRY" >&2; exit 2 ;;
+esac
+
+printf '%s%s:%s\n' "$SEN_CI_REGISTRY" "$SEN_CI_REPOSITORY" "$variant"

--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -32,6 +32,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
+      # Both variants named from one place, so publishing to a registry is one
+      # edit in image_name.sh rather than a search for every hardcoded tag.
+      - name: Name the images
+        shell: bash
+        run: |
+          echo "SEN_CI_IMAGE_PROBE=$(.github/scripts/image_name.sh probe)" >> "$GITHUB_ENV"
+          echo "SEN_CI_IMAGE_DEV=$(.github/scripts/image_name.sh dev)" >> "$GITHUB_ENV"
+
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
 
       # Proves the Dockerfile builds; no registry hosts the image, so the
@@ -50,7 +58,7 @@ jobs:
           target: base
           push: false
           load: true
-          tags: sen-ci:probe
+          tags: ${{ env.SEN_CI_IMAGE_PROBE }}
           cache-from: type=gha
 
       # Every layer of the cached build is served from the Actions cache, so it
@@ -66,9 +74,9 @@ jobs:
               # dev is built on base, so one cold build covers both stages and
               # the second command only tags the base it has already produced.
               docker buildx build --no-cache --pull --load \
-                  --target dev -t sen-ci:dev -f tools/ci/Dockerfile tools/ci &&
+                  --target dev -t "$SEN_CI_IMAGE_DEV" -f tools/ci/Dockerfile tools/ci &&
               docker buildx build --pull --load \
-                  --target base -t sen-ci:probe -f tools/ci/Dockerfile tools/ci
+                  --target base -t "$SEN_CI_IMAGE_PROBE" -f tools/ci/Dockerfile tools/ci
           }
           build || { echo "cold build failed, retrying once"; build; }
 
@@ -84,7 +92,7 @@ jobs:
           cmake_version=$(sed -n 's/^ARG CMAKE_VERSION=//p' tools/ci/Dockerfile)
           ninja_version=$(sed -n 's/^ARG NINJA_VERSION=//p' tools/ci/Dockerfile)
           test -n "$conan_version" && test -n "$cmake_version" && test -n "$ninja_version"
-          docker run --rm sen-ci:probe bash -lc '
+          docker run --rm "$SEN_CI_IMAGE_PROBE" bash -lc '
             set -e
             for tool in conan python3 pip3 ccache git make g++-12 gcc-12 \
                         clang++-20 clang-tidy-20 gcovr lcov genhtml \
@@ -128,14 +136,14 @@ jobs:
           target: dev
           push: false
           load: true
-          tags: sen-ci:dev
+          tags: ${{ env.SEN_CI_IMAGE_DEV }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
 
       - name: Check the editor tools are present
         shell: bash
         run: |
-          docker run --rm sen-ci:dev bash -lc '
+          docker run --rm "$SEN_CI_IMAGE_DEV" bash -lc '
             set -e
             for tool in cmake ninja gdb dot; do
                 command -v "$tool" > /dev/null || { echo "missing: $tool"; exit 1; }

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -86,16 +86,27 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: gitlint --commits "${BASE_SHA:-origin/main}..HEAD"
-      # The squash merge turns the title into the commit subject on main, with the
-      # pull request number appended. Linting the bare title passes a 71-character
-      # one and lands 79 on main, where it fails every later pull request.
-      - name: Lint the pull request title
+      # What a squash merge lands, with the pull request number appended, and the number
+      # is why a 71-character subject fails on main and then fails every later pull
+      # request. GitHub takes that subject from the ONE commit when a branch has one and
+      # from the title otherwise -- so linting only the title passed a 62-character one
+      # while the 71 it actually used went unchecked, and main's tip is 78 [#299].
+      - name: Lint what the squash will land
         if: github.event_name == 'pull_request'
         shell: bash
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: printf '%s (#%s)\n' "$PR_TITLE" "$PR_NUMBER" | gitlint
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          count=$(git rev-list --count "${BASE_SHA}..HEAD")
+          if [ "$count" -eq 1 ]; then
+            subject=$(git log -1 --format=%s HEAD)
+          else
+            subject=$PR_TITLE
+          fi
+          printf 'linting the squash subject for %s commit(s): %s\n' "$count" "$subject"
+          printf '%s (#%s)\n' "$subject" "$PR_NUMBER" | gitlint
 
   conan-lock-check:
     name: "Check conan.lock"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -77,31 +77,44 @@ jobs:
       - name: Run repository script tests
         shell: bash
         run: python -m pytest .github/scripts/ libs/kernel/test/integration/ -v
-      # From the pull request's own base, not from main: a stacked pull request
-      # sits on the branch below it, and origin/main would drag in every commit
-      # underneath and lint those again.
-      - name: Lint commit messages
+      # The base is the pull request's own, not main: a stacked pull request sits on the
+      # branch below it. And HEAD is the test-merge commit, whose first parent is main, so
+      # ending the range there reaches commits that already landed. Take the branch's side.
+      # A single-parent checkout -- the merge queue -- is already just what will land.
+      - name: Find what this run will land
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         shell: bash
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: gitlint --commits "${BASE_SHA:-origin/main}..HEAD"
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        run: |
+          if [ "$(git rev-list --parents -n 1 HEAD | wc -w)" -eq 3 ]; then
+            base=$(git merge-base HEAD^1 HEAD^2)
+            tip=$(git rev-parse HEAD^2)
+          else
+            base=${BASE_SHA:-origin/main}
+            tip=$(git rev-parse HEAD)
+          fi
+          printf 'LINT_BASE=%s\nLINT_TIP=%s\n' "$base" "$tip" | tee -a "$GITHUB_ENV"
+          git log --format='  %h %s' "$base..$tip"
+      - name: Lint commit messages
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        shell: bash
+        run: gitlint --commits "$LINT_BASE..$LINT_TIP"
       # What a squash merge lands, with the pull request number appended, and the number
       # is why a 71-character subject fails on main and then fails every later pull
       # request. GitHub takes that subject from the ONE commit when a branch has one and
       # from the title otherwise -- so linting only the title passed a 62-character one
-      # while the 71 it actually used went unchecked, and main's tip is 78 [#299].
+      # while the 71 it actually used went unchecked, and main carries a 78 [#299].
       - name: Lint what the squash will land
         if: github.event_name == 'pull_request'
         shell: bash
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          count=$(git rev-list --count "${BASE_SHA}..HEAD")
+          count=$(git rev-list --count "$LINT_BASE..$LINT_TIP")
           if [ "$count" -eq 1 ]; then
-            subject=$(git log -1 --format=%s HEAD)
+            subject=$(git log -1 --format=%s "$LINT_TIP")
           else
             subject=$PR_TITLE
           fi

--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -36,11 +36,14 @@ jobs:
     env:
       CC: clang-20
       CXX: clang++-20
-      SEN_CI_IMAGE: sen-ci:lane
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+
+      - name: Name the image
+        shell: bash
+        run: echo "SEN_CI_IMAGE=$(.github/scripts/image_name.sh lane)" >> "$GITHUB_ENV"
 
       # prepare_build is not reused here: it keys on the runner and compiler, and this lane
       # needs the image instead, for the reason below. A cache written from a pull request is


### PR DESCRIPTION
Two related fixes, both a value or a check sitting where it cannot do its job.

The image name was written by hand in six tags across three files, so pointing it at a registry meant finding every one — and a missed reference still pulls, from the old place. Adds .github/scripts/image_name.sh; setting SEN_CI_REGISTRY moves every caller at once. Nothing is published by this.

And the title lint checked a string GitHub may not use: a one-commit branch squashes under that commit's subject, not the pull request title. On #299 the title was 62 characters and passed while the 71-character commit subject went unchecked and landed on main at 78, which then fails every pull request opened before it. The step now lints whichever string the squash will use, and says which.
