### PR TITLE
fix(kernel): erase object updates on the thread that walks them

### DIFF
--- a/libs/kernel/src/bus/remote_interest_handler.h
+++ b/libs/kernel/src/bus/remote_interest_handler.h
@@ -92,6 +92,9 @@ struct RemoteInterestsHandler
   /// Removes object updates associated to a certain interest. There can be more than one interest mapped to a certain
   /// update. Returns true if the update was completely removed from the interest handler
   [[nodiscard]] bool removeObjectUpdateByInterest(ObjectUpdate* update, InterestId interestId);
+
+  /// Returns true while any interest still links to the update.
+  [[nodiscard]] bool hasAnyInterest(ObjectUpdate* update) const;
   void clear();
 
 private:
@@ -213,6 +216,13 @@ inline std::vector<ObjectUpdate*> RemoteInterestsHandler::removeInterest(Interes
   // Clear any orphans that may be left from previous removals (call to remove does not always clear them).
   interestsUpdatesBMMap.clearOrphans();
   return interestsUpdatesBMMap.remove(interestId).second;
+}
+
+inline bool RemoteInterestsHandler::hasAnyInterest(ObjectUpdate* update) const
+{
+  std::shared_lock lock(handlerMutex_);
+
+  return interestsUpdatesBMMap.contains(update);
 }
 
 inline void RemoteInterestsHandler::removeRejectedObject(RemoteParticipant* remote, ObjectUpdate* update)

--- a/libs/kernel/src/bus/remote_interest_manager.cpp
+++ b/libs/kernel/src/bus/remote_interest_manager.cpp
@@ -211,6 +211,11 @@ void RemoteInterestsManager::sendObjectUpdates()
 {
   SEN_TRACE_ZONE(owner_->getOwner()->getTracer());
 
+  // Before the return below, not after: dropping the last subscriber is what sets
+  // aRemoteParticipant_ to null, so an apply behind that guard would never run again and the
+  // recorded removals would accumulate for the life of the manager.
+  applyPendingUpdateRemovals();
+
   // only collect updates if there's at least one remote
   if (aRemoteParticipant_ == nullptr)
   {
@@ -383,21 +388,50 @@ void RemoteInterestsManager::objectsRemoved(std::shared_ptr<Interest> interest, 
 
 void RemoteInterestsManager::removeObjectUpdatesByInterest(ObjectId objectId, InterestId interestId)
 {
+  std::lock_guard lock(objectsMutex_);
+
   const auto updateItr = objectIdToUpdateItr_.find(objectId);
   if (updateItr == objectIdToUpdateItr_.end())
   {
     return;
   }
 
-  auto* updatePtr = &(*updateItr->second);
-
-  // only erase the object update if only one interest was linked to it
-  if (remoteInterestsHandler_.removeObjectUpdateByInterest(updatePtr, interestId))
+  // Unlinking here is what stops the update reaching a remote that has just unsubscribed. The
+  // erase is not done here: this runs on the thread that drops the interest, while another walks
+  // objectUpdates_, and erasing frees the node under that walk. It is recorded instead and the
+  // walking thread applies it.
+  if (remoteInterestsHandler_.removeObjectUpdateByInterest(&(*updateItr->second), interestId))
   {
+    updateRemovalsPending_.push_back(objectId);
+  }
+}
+
+void RemoteInterestsManager::applyPendingUpdateRemovals()
+{
+  std::lock_guard lock(objectsMutex_);
+
+  for (const auto objectId: updateRemovalsPending_)
+  {
+    const auto updateItr = objectIdToUpdateItr_.find(objectId);
+    if (updateItr == objectIdToUpdateItr_.end())
+    {
+      continue;
+    }
+
+    // A re-subscribe between the record and here relinks this same update rather than making a
+    // new one, so the recorded id is a hint. The handler is asked again, exactly as the recording
+    // side asked it, and only an update nothing links to is erased.
+    if (remoteInterestsHandler_.hasAnyInterest(&(*updateItr->second)))
+    {
+      continue;
+    }
+
     objectUpdates_.erase(updateItr->second);
     updatesObjectIdsBiMap_.remove(objectId);
     objectIdToUpdateItr_.erase(updateItr);
   }
+
+  updateRemovalsPending_.clear();
 }
 
 }  // namespace sen::kernel::impl

--- a/libs/kernel/src/bus/remote_interest_manager.h
+++ b/libs/kernel/src/bus/remote_interest_manager.h
@@ -121,6 +121,7 @@ protected:  // implements ObjectFilter
 private:
   /// Only removes updates linked to a certain interest (the updates could be linked to other interests as well)
   void removeObjectUpdatesByInterest(ObjectId objectId, InterestId interestId);
+  void applyPendingUpdateRemovals();
   void sendEvents(const std::list<::sen::impl::SerializableEvent>& events);
   void sendObjectUpdates();
   void updateRemoteReference();
@@ -136,6 +137,9 @@ private:
   std::mutex objectsMutex_;
   std::list<ObjectUpdate> objectUpdates_;
   std::unordered_map<ObjectId, decltype(objectUpdates_)::iterator> objectIdToUpdateItr_;
+  // Removals recorded by whoever drops the last interest, applied by the thread that walks
+  // objectUpdates_. Guarded by objectsMutex_ like the containers it names.
+  std::vector<ObjectId> updateRemovalsPending_;
   std::unordered_map<ObjectId, InterestId> objectIdToInterestIdMap_;
   std::shared_ptr<BestEffortPool> bestEffortPool_;
   Guarded<RemoteParticipant*> aRemoteParticipant_ {nullptr};


### PR DESCRIPTION
`removeObjectUpdatesByInterest` erased from `objectUpdates_` on the thread that drops
an interest, while `sendObjectUpdates` walked the same list on the runner thread. ASan
caught it twice on `main`, once at the iterator increment and once inside
`ObjectUpdate::reset`:

```
T4  RemoteInterestsManager::sendObjectUpdates()          remote_interest_manager.cpp:223
T3  RemoteInterestsManager::removeObjectUpdatesByInterest()                        :397
```

## What this changes

The remover still unlinks in the handler, which is what stops an update reaching a
remote that has unsubscribed, and then records the object id. `sendObjectUpdates`
applies the recorded removals before it walks, so the list has a single writer. The
applier asks the handler again rather than trusting the record, because a re-subscribe
relinks the same update rather than creating a new one.

The apply sits before the no-remote early return: dropping the last subscriber is what
sets `aRemoteParticipant_` to null, so an apply behind that guard would never run again
and the recorded removals would accumulate.

`removeObjectUpdatesByInterest` also read `objectIdToUpdateItr_` with no lock while
`objectsAdded` writes it under `objectsMutex_`. It now takes that mutex, keeping the
existing `objectsMutex_` then `handlerMutex_` order. No new mutex and no new lock order.

## What is verified, and what is not

Verified: the five affected integration tests pass under ASan, and no caller holds
`objectsMutex_` on either new path, so the added lock cannot self-deadlock.

**Not verified against the race itself.** It does not reproduce locally: 30 rounds of
the affected tests on unmodified `main` were as clean as 30 rounds with this change, so
the local result says nothing either way. The CI sanitizer lane is where it has been
observed.

The concurrency redesign replaces this file with a single-writer publisher that applies
removals as pending work on the runner thread. This is the same shape, agreed with that
work, so it should not need undoing beforehand.
