### PR TITLE
build(cmake): make MSVC read and write sources as UTF-8

### DIFF
--- a/cmake/util/sen_internal_utils.cmake
+++ b/cmake/util/sen_internal_utils.cmake
@@ -393,6 +393,12 @@ endif()
 
 if(MSVC)
   add_compile_options(/bigobj)
+  # Without this MSVC reads a source file as the build machine's ANSI code page and encodes
+  # narrow literals back into it. Our sources are UTF-8 and carry no BOM, so their bytes survive
+  # only because CP1252 happens to map them one to one; a machine with a multi-byte code page
+  # would corrupt them with no diagnostic. /utf-8 sets both charsets, so the build no longer
+  # depends on the locale it runs in.
+  add_compile_options(/utf-8)
 endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)


### PR DESCRIPTION
MSVC reads a source file as the build machine's ANSI code page unless told otherwise, and
encodes narrow string literals back into that same code page. Our sources are UTF-8 and
carry no BOM, so a character like `µ`, stored as the bytes `C2 B5`, is read as two
separate characters and re-encoded on the way into the binary. The bytes come out
unchanged only because CP1252 is single-byte and maps them one to one.
