### PR TITLE
ci: retry the archive fetches that the old flags never covered

### DIFF
--- a/.github/actions/build_documentation/action.yaml
+++ b/.github/actions/build_documentation/action.yaml
@@ -40,12 +40,13 @@ runs:
 
     # The documentation is built in the image this repository ships rather than on a
     # runner assembling its own toolchain, so what CI uses is what a developer can
-    # run. One retry, as in ci-image.yaml: the archives this pulls from do go quiet.
+    # run. One retry after a wait, as in ci-image.yaml: the archives this pulls from
+    # do go quiet, and an immediate second attempt lands inside the same outage.
     - name: Build the image the documentation is built in
       shell: bash
       run: |
         build() { docker build --target base --tag "$SEN_CI_IMAGE" tools/ci; }
-        build || { echo "image build failed, retrying once"; build; }
+        build || { echo "image build failed, retrying in 30s"; sleep 30; build; }
 
     - name: Build the documentation
       shell: bash

--- a/.github/actions/setup_build_context/action.yaml
+++ b/.github/actions/setup_build_context/action.yaml
@@ -52,7 +52,10 @@ runs:
       if: ${{ inputs.compiler-name == 'clang' }}
       shell: bash
       run: |
-        wget https://apt.llvm.org/llvm.sh
+        # wget already retries an unreachable host 20 times, but gives up on a refused
+        # connection instantly; --timeout bounds the wait, which otherwise runs to the
+        # OS connect timeout on each of those tries.
+        wget --retry-connrefused --timeout=30 https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         # llvm.sh refreshes the apt metadata and installs the whole toolchain, so it is
         # slow by nature: 15 minutes killed a run that was still making progress. This is

--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -56,8 +56,9 @@ jobs:
       # Every layer of the cached build is served from the Actions cache, so it
       # cannot see a dropped package or an unreachable apt.llvm.org. This one
       # imports no cache and exports none, which is the whole point of it.
-      # Both upstream failures in this repository's history were curl connect
-      # refusals that a plain re-run cleared, so one retry covers them.
+      # The upstream failures here have all been curl failing to resolve or to
+      # connect, and a later run cleared them, so one retry covers them -- but only
+      # with a wait: an immediate second attempt lands inside the same outage.
       - name: Build both stages cold
         if: github.event_name == 'schedule'
         shell: bash
@@ -70,7 +71,7 @@ jobs:
               docker buildx build --pull --load \
                   --target base -t sen-ci:probe -f tools/ci/Dockerfile tools/ci
           }
-          build || { echo "cold build failed, retrying once"; build; }
+          build || { echo "cold build failed, retrying in 30s"; sleep 30; build; }
 
       # Every tool below has been missing at some point, and a missing tool
       # shows up as a check that silently analysed nothing or a configure step

--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -61,15 +61,15 @@ jobs:
       # definition a developer can also run rather than a second one assembled on
       # the runner. Built here rather than pulled: publishing to the registry is
       # not available, and a runner builds for its own architecture anyway.
-      # One retry, for the same reason ci-image.yaml has one: the archives this
-      # pulls from do go quiet, and a plain re-run has cleared it before. The
-      # image also sets apt retries and timeouts, which the runner-side action
-      # this replaced did for itself.
+      # One retry after a wait, for the same reason ci-image.yaml has one: the
+      # archives this pulls from do go quiet, and an immediate second attempt
+      # lands inside the same outage. The image also sets apt retries and
+      # timeouts, which the runner-side action this replaced did for itself.
       - name: Build the image the lane runs in
         shell: bash
         run: |
           build() { docker build --target base --tag "$SEN_CI_IMAGE" tools/ci; }
-          build || { echo "image build failed, retrying once"; build; }
+          build || { echo "image build failed, retrying in 30s"; sleep 30; build; }
 
       - name: Install the conan profiles
         shell: bash

--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -53,9 +53,9 @@ ENV LANG=C.UTF-8 \
 # dependency chain (SDL needs libXext, the explorer needs libGL). make
 # serves the autotools-style Conan recipes; python3-dev serves pybind11;
 # bats runs the installer test suite.
-# Every apt and curl call in this file talks to a mirror that can stall or refuse a
-# connection; one such refusal from apt.llvm.org failed an image build. Retries turn
-# those into a pause instead of a red pipeline.
+# Every apt and curl call in this file talks to a mirror that can stall, refuse a
+# connection or go unreachable. Plain --retry covers only the stall, and
+# --retry-connrefused adds the refusal; the unreachable host needs --retry-all-errors.
 RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
         > /etc/apt/apt.conf.d/99-sen-retries
 
@@ -99,7 +99,7 @@ RUN printf '%s\n' \
 # plantuml renders the diagram the handbook embeds. Ubuntu's package is from 2020 and
 # pulls a full JDK, 218 packages against 40 for a headless JRE and the jar. CMake finds it
 # with find_program by name, so the wrapper is what has to be on PATH.
-RUN curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
+RUN curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
         -o /opt/plantuml.jar \
         "https://github.com/plantuml/plantuml/releases/download/v${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar" \
     && printf '%s\n' '#!/bin/sh' 'exec java -jar /opt/plantuml.jar "$@"' > /usr/local/bin/plantuml \
@@ -110,7 +110,7 @@ RUN curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
 # both use this major version. The repository is added directly instead of
 # running llvm.sh, which needs add-apt-repository.
 RUN install -m 0755 -d /etc/apt/keyrings \
-    && curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
+    && curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
         https://apt.llvm.org/llvm-snapshot.gpg.key -o /etc/apt/keyrings/llvm.asc \
     && echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" \
         > /etc/apt/sources.list.d/llvm.list \


### PR DESCRIPTION
Three retries that did not cover the fault that actually happens.

On 2026-09-09 apt.llvm.org went unreachable and docs-build died in 85 seconds. curl exited in 0.159s without retrying once, on both attempts, where `--retry 3 --retry-delay 2` could not take less than six [run 34351632773, job 102466143670].

curl's default retry set is timeouts and a few HTTP codes. `--retry-connrefused` adds ECONNREFUSED and nothing else, and an unreachable host is a different errno behind the same exit 7. `--retry-all-errors` covers both, and the image's curl 7.81 has it.

The `build || build` wrapper did fire — 295ms after the first failure, inside the same outage. It had absorbed two earlier faults, but both were failures to resolve, which clear on an instant retry because a resolver blip is over before the second docker build starts. It had never met a connect failure. Hence a wait. 30 seconds is a judgement, not a measurement; the outage length was never measured.

wget needs the opposite fix, so the two are deliberately not symmetrical. Measured in ubuntu:24.04, GNU Wget 1.21.4: a refused connection fails instantly with no retry, an unreachable host retries 20 times over 205 seconds. That lane was already covered against the fault that happened and bare against the other, so `--tries=3` would have cut working protection from 20 attempts to 3 to add one that was not missing. `--retry-connrefused --timeout=30` adds the refusal and bounds the wait.

This moves hashFiles('tools/ci/Dockerfile'), so the conan cache keys shift. #298's fallback is in place and both lanes have saved under the current prefix on refs/heads/main, so they restore the previous slice rather than going cold.
