### PR TITLE
ci: publish the image and pull it instead of rebuilding

### DIFF
--- a/.github/actions/build_documentation/action.yaml
+++ b/.github/actions/build_documentation/action.yaml
@@ -12,7 +12,9 @@ runs:
 
     - name: Name the image
       shell: bash
-      run: echo "SEN_CI_IMAGE=$(.github/scripts/image_name.sh docs)" >> "$GITHUB_ENV"
+      env:
+        SEN_CI_REGISTRY: ghcr.io/airbus/
+      run: echo "SEN_CI_IMAGE=$(.github/scripts/image_name.sh base)" >> "$GITHUB_ENV"
 
     # Keyed to the image rather than the runner: a conan package id does not record
     # which Ubuntu produced a binary, so a cache filled on a runner installs cleanly
@@ -45,11 +47,27 @@ runs:
 
     # The documentation is built in the image this repository ships rather than on a
     # runner assembling its own toolchain, so what CI uses is what a developer can
-    # run. One retry after a wait, as in ci-image.yaml: the archives this pulls from
-    # do go quiet, and an immediate second attempt lands inside the same outage.
-    - name: Build the image the documentation is built in
+    # run. Pulled when the registry has this Dockerfile's image, built when it does
+    # not. The login is allowed to fail: without it the pull misses and the build
+    # below runs, which is what happens today anyway.
+    # One retry after a wait, as in ci-image.yaml: the archives this pulls from do
+    # go quiet, and an immediate second attempt lands inside the same outage.
+    - name: Log in to the registry
+      continue-on-error: true
+      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Get the image the documentation is built in
       shell: bash
       run: |
+        if docker pull --quiet "$SEN_CI_IMAGE"; then
+            echo "pulled $SEN_CI_IMAGE"
+            exit 0
+        fi
+        echo "not in the registry, building it"
         build() { docker build --target base --tag "$SEN_CI_IMAGE" tools/ci; }
         build || { echo "image build failed, retrying in 30s"; sleep 30; build; }
 

--- a/.github/scripts/image_name.sh
+++ b/.github/scripts/image_name.sh
@@ -6,17 +6,31 @@
 # finding every one -- and a missed reference still pulls, from the old place.
 set -euo pipefail
 
-# Empty while no registry hosts the image, so the reference stays a local tag.
-# Publishing is one edit here: set it to "ghcr.io/airbus/sen/" and every caller
-# follows. It must end in a slash when set.
+# Empty keeps the reference a local tag, which is what a developer building the
+# image gets. CI sets it to publish and to pull. It must end in a slash when set.
 SEN_CI_REGISTRY="${SEN_CI_REGISTRY-}"
 SEN_CI_REPOSITORY="sen-ci"
 
-variant="${1:?usage: image_name.sh <variant>   e.g. dev, probe, docs, lane}"
+variant="${1:?usage: image_name.sh <variant>   base, dev, or buildcache}"
 
 case "$SEN_CI_REGISTRY" in
     "" | */) ;;
     *) echo "SEN_CI_REGISTRY must end in a slash: $SEN_CI_REGISTRY" >&2; exit 2 ;;
 esac
 
-printf '%s%s:%s\n' "$SEN_CI_REGISTRY" "$SEN_CI_REPOSITORY" "$variant"
+# The layer cache is the one reference that must NOT carry the content: a build
+# imports it to avoid repeating work the last content already did, so tagging it
+# by content would mean never reusing it.
+if [ "$variant" = buildcache ]; then
+    printf '%s%s:buildcache\n' "$SEN_CI_REGISTRY" "$SEN_CI_REPOSITORY"
+    exit 0
+fi
+
+# Every image tag carries the Dockerfile's content, so an edit to it misses the
+# pull and the consumer rebuilds. Sharing one tag across contents would let a lane
+# run the previous environment and say nothing. git hash-object rather than
+# sha256sum: git is the one tool every platform here already has.
+root=$(git rev-parse --show-toplevel)
+content=$(git hash-object "$root/tools/ci/Dockerfile" | cut -c1-12)
+
+printf '%s%s:%s-%s\n' "$SEN_CI_REGISTRY" "$SEN_CI_REPOSITORY" "$variant" "$content"

--- a/.github/scripts/test_image_name.py
+++ b/.github/scripts/test_image_name.py
@@ -1,0 +1,114 @@
+"""Checks image_name.sh, whose output decides which image a lane runs.
+
+The tag carries the Dockerfile's content. If that stopped happening, a lane would
+pull the previous environment and report nothing, so the content test below is the
+one that matters; the rest guard the shape callers depend on.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent / "image_name.sh"
+
+
+def _env():
+    """Strips git's own variables from the environment.
+
+    git exports GIT_DIR into hooks and tests inherit it, which would make the
+    fixture repository below resolve to the real one.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env["PATH"] = os.environ["PATH"]
+    return env
+
+
+def _run(cwd, *args, registry=None):
+    env = _env()
+    if registry is not None:
+        env["SEN_CI_REGISTRY"] = registry
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """Builds a repository shaped like this one.
+
+    The script reads tools/ci/Dockerfile, so the fixture has to have one.
+    """
+    env = _env()
+    subprocess.run(["git", "init", "-q", str(tmp_path)], env=env, check=True)
+    dockerfile = tmp_path / "tools" / "ci" / "Dockerfile"
+    dockerfile.parent.mkdir(parents=True)
+    dockerfile.write_text("FROM ubuntu:22.04\n")
+    return tmp_path
+
+
+def test_a_local_build_gets_a_bare_tag(repo):
+    """A developer without a registry gets a local tag."""
+    out = _run(repo, "base").stdout.strip()
+    assert out.startswith("sen-ci:base-"), out
+
+
+def test_the_registry_prefixes_every_variant(repo):
+    """Setting the registry moves every caller at once."""
+    out = _run(repo, "dev", registry="ghcr.io/airbus/").stdout.strip()
+    assert out.startswith("ghcr.io/airbus/sen-ci:dev-"), out
+
+
+def test_a_registry_without_a_trailing_slash_is_refused(repo):
+    """It would silently produce a wrong reference."""
+    result = _run(repo, "dev", registry="ghcr.io/airbus")
+    assert result.returncode == 2
+    assert "must end in a slash" in result.stderr
+
+
+def test_a_missing_variant_is_refused(repo):
+    """There is no sensible default variant."""
+    assert _run(repo).returncode != 0
+
+
+def test_editing_the_dockerfile_moves_the_tag(repo):
+    """The load-bearing one.
+
+    Without this a consumer pulls the previous environment and reports nothing.
+    """
+    before = _run(repo, "base").stdout.strip()
+
+    (repo / "tools" / "ci" / "Dockerfile").write_text("FROM ubuntu:22.04\nRUN true\n")
+    after = _run(repo, "base").stdout.strip()
+    assert before != after, f"the tag did not move: {before}"
+
+    (repo / "tools" / "ci" / "Dockerfile").write_text("FROM ubuntu:22.04\n")
+    assert _run(repo, "base").stdout.strip() == before, "the tag did not come back"
+
+
+def test_variants_do_not_collide(repo):
+    """The base and dev stages are different images."""
+    assert _run(repo, "base").stdout.strip() != _run(repo, "dev").stdout.strip()
+
+
+def test_the_layer_cache_reference_is_stable_across_content(repo):
+    """It must not move with the Dockerfile.
+
+    A build imports it to skip work the last content already did.
+    """
+    before = _run(repo, "buildcache").stdout.strip()
+    assert before == "sen-ci:buildcache", before
+
+    (repo / "tools" / "ci" / "Dockerfile").write_text("FROM ubuntu:22.04\nRUN true\n")
+    assert _run(repo, "buildcache").stdout.strip() == before
+
+
+def test_the_layer_cache_is_not_confused_with_an_image(repo):
+    """One is content-tagged and the other is not."""
+    assert _run(repo, "buildcache").stdout.strip() != _run(repo, "base").stdout.strip()

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -26,6 +26,8 @@ permissions:
   contents: write
   # The documentation action drops the cache entry its save replaces.
   actions: write
+  # Pulling the image the documentation is built in, which is a private package.
+  packages: read
 
 jobs:
   deploy_docs:

--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -189,21 +189,6 @@ jobs:
       # must not become the one every lane pulls. Only from main -- a pull request
       # cannot write the package, and the tag carries the Dockerfile's content, so
       # a schedule run republishes the current one against the day's packages.
-      # TEMPORARY, remove before merge. Proves the workflow token can push through
-      # the workflow_call chain from main.yaml, which is the one thing local testing
-      # cannot reach. A throwaway reference on purpose: the real tag carries the
-      # Dockerfile's content, this branch does not change it, so publishing the real
-      # tag from here would overwrite exactly what every lane pulls.
-      - name: Publish a throwaway tag from this branch
-        if: github.ref != 'refs/heads/main'
-        shell: bash
-        env:
-          PROBE_REF: ghcr.io/airbus/sen-ci:probe-from-branch
-        run: |
-          docker tag "$SEN_CI_IMAGE_BASE" "$PROBE_REF"
-          docker push "$PROBE_REF"
-          echo "pushed $PROBE_REF"
-
       - name: Publish the images
         if: github.ref == 'refs/heads/main'
         shell: bash

--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -23,6 +23,12 @@ on:
 
 permissions:
   contents: read
+  # Pushing the built image. The organisation refuses public packages, not
+  # publishing, so the workflow token is enough and no personal token is needed.
+  packages: write
+
+env:
+  SEN_CI_REGISTRY: ghcr.io/airbus/
 
 jobs:
   build:
@@ -37,16 +43,29 @@ jobs:
       - name: Name the images
         shell: bash
         run: |
-          echo "SEN_CI_IMAGE_PROBE=$(.github/scripts/image_name.sh probe)" >> "$GITHUB_ENV"
-          echo "SEN_CI_IMAGE_DEV=$(.github/scripts/image_name.sh dev)" >> "$GITHUB_ENV"
+          {
+              echo "SEN_CI_IMAGE_BASE=$(.github/scripts/image_name.sh base)"
+              echo "SEN_CI_IMAGE_DEV=$(.github/scripts/image_name.sh dev)"
+              echo "SEN_CI_CACHE=$(.github/scripts/image_name.sh buildcache)"
+          } >> "$GITHUB_ENV"
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
 
-      # Proves the Dockerfile builds; no registry hosts the image, so the
-      # devcontainer and any self-hosted machine build it from this file.
+      # Before the build, not before the push: the layer cache is read from the
+      # registry as well, and the package is private so even reading needs this.
+      - name: Log in to the registry
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Proves the Dockerfile builds, and on main produces what the lanes pull.
       # Only the dev build below exports. dev is built on base, so its export
       # already carries these layers; a second export here would replace that
       # manifest with one the dev build cannot use.
+      # The layer cache lives in the registry rather than the Actions cache: it
+      # was 2.37 GB of a 10 GB quota that a compiler cache for MSVC needs.
       - name: Build image
         if: github.event_name != 'schedule'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
@@ -58,8 +77,8 @@ jobs:
           target: base
           push: false
           load: true
-          tags: ${{ env.SEN_CI_IMAGE_PROBE }}
-          cache-from: type=gha
+          tags: ${{ env.SEN_CI_IMAGE_BASE }}
+          cache-from: type=registry,ref=${{ env.SEN_CI_CACHE }}
 
       # Every layer of the cached build is served from the Actions cache, so it
       # cannot see a dropped package or an unreachable apt.llvm.org. This one
@@ -77,7 +96,7 @@ jobs:
               docker buildx build --no-cache --pull --load \
                   --target dev -t "$SEN_CI_IMAGE_DEV" -f tools/ci/Dockerfile tools/ci &&
               docker buildx build --pull --load \
-                  --target base -t "$SEN_CI_IMAGE_PROBE" -f tools/ci/Dockerfile tools/ci
+                  --target base -t "$SEN_CI_IMAGE_BASE" -f tools/ci/Dockerfile tools/ci
           }
           build || { echo "cold build failed, retrying in 30s"; sleep 30; build; }
 
@@ -93,7 +112,7 @@ jobs:
           cmake_version=$(sed -n 's/^ARG CMAKE_VERSION=//p' tools/ci/Dockerfile)
           ninja_version=$(sed -n 's/^ARG NINJA_VERSION=//p' tools/ci/Dockerfile)
           test -n "$conan_version" && test -n "$cmake_version" && test -n "$ninja_version"
-          docker run --rm "$SEN_CI_IMAGE_PROBE" bash -lc '
+          docker run --rm "$SEN_CI_IMAGE_BASE" bash -lc '
             set -e
             for tool in conan python3 pip3 ccache git make g++-12 gcc-12 \
                         clang++-20 clang-tidy-20 gcovr lcov genhtml \
@@ -144,8 +163,10 @@ jobs:
           push: false
           load: true
           tags: ${{ env.SEN_CI_IMAGE_DEV }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: type=registry,ref=${{ env.SEN_CI_CACHE }}
+          # Only main writes it: a pull request has no write access to the package,
+          # and a fork's token has none at all.
+          cache-to: ${{ github.ref == 'refs/heads/main' && format('type=registry,ref={0},mode=min', env.SEN_CI_CACHE) || '' }}
 
       - name: Check the editor tools are present
         shell: bash
@@ -163,3 +184,30 @@ jobs:
             test "$(id -un)" = sen || { echo "image runs as $(id -un)"; exit 1; }
             echo "editor tools present"
           '
+
+      # After the checks, never as part of the build: an image that fails them
+      # must not become the one every lane pulls. Only from main -- a pull request
+      # cannot write the package, and the tag carries the Dockerfile's content, so
+      # a schedule run republishes the current one against the day's packages.
+      # TEMPORARY, remove before merge. Proves the workflow token can push through
+      # the workflow_call chain from main.yaml, which is the one thing local testing
+      # cannot reach. A throwaway reference on purpose: the real tag carries the
+      # Dockerfile's content, this branch does not change it, so publishing the real
+      # tag from here would overwrite exactly what every lane pulls.
+      - name: Publish a throwaway tag from this branch
+        if: github.ref != 'refs/heads/main'
+        shell: bash
+        env:
+          PROBE_REF: ghcr.io/airbus/sen-ci:probe-from-branch
+        run: |
+          docker tag "$SEN_CI_IMAGE_BASE" "$PROBE_REF"
+          docker push "$PROBE_REF"
+          echo "pushed $PROBE_REF"
+
+      - name: Publish the images
+        if: github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          docker push "$SEN_CI_IMAGE_BASE"
+          docker push "$SEN_CI_IMAGE_DEV"
+          echo "published $SEN_CI_IMAGE_BASE and $SEN_CI_IMAGE_DEV"

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -18,6 +18,8 @@ permissions:
   contents: read
   # build_documentation drops the cache entries its saves replace.
   actions: write
+  # Pulling the image the documentation is built in, which is a private package.
+  packages: read
 
 jobs:
   build_docs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -179,6 +179,11 @@ jobs:
     if: >-
       needs.detect-changes.outputs.image == 'true' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    # A called workflow cannot hold more than its caller grants, so the push it
+    # does on main has to be allowed from here.
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/ci-image.yaml
 
   # Packaging is the only check that builds Sen as a package and consumes it
@@ -214,6 +219,9 @@ jobs:
     uses: ./.github/workflows/pr_sanitizers.yaml
     permissions:
       contents: read
+      # Pulling the image rather than building it. The package is private, so
+      # even reading needs this.
+      packages: read
       # The lane drops the cache entry its save replaces.
       actions: write
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -170,6 +170,9 @@ jobs:
     permissions:
       contents: read
       actions: write
+      # Pulling the image the documentation is built in. A called workflow cannot
+      # request more than this grants, so leaving it out fails the run at startup.
+      packages: read
 
   # A change to the build environment has to prove the image still builds and
   # still holds the tools it promises. ci-ok needs this job, so a broken image

--- a/.github/workflows/pr_sanitizers.yaml
+++ b/.github/workflows/pr_sanitizers.yaml
@@ -25,6 +25,11 @@ permissions:
   contents: read
   # Deleting the cache entry a save replaces.
   actions: write
+  # Reading the image this lane runs in, which is a private package.
+  packages: read
+
+env:
+  SEN_CI_REGISTRY: ghcr.io/airbus/
 
 jobs:
   sanitizers:
@@ -43,7 +48,7 @@ jobs:
 
       - name: Name the image
         shell: bash
-        run: echo "SEN_CI_IMAGE=$(.github/scripts/image_name.sh lane)" >> "$GITHUB_ENV"
+        run: echo "SEN_CI_IMAGE=$(.github/scripts/image_name.sh base)" >> "$GITHUB_ENV"
 
       # prepare_build is not reused here: it keys on the runner and compiler, and this lane
       # needs the image instead, for the reason below. A cache written from a pull request is
@@ -67,15 +72,31 @@ jobs:
       # ordinary builds depend on. Same rule as the nightly's sanitizer lanes.
       # The lane runs in the image this repository builds, so what it uses is the
       # definition a developer can also run rather than a second one assembled on
-      # the runner. Built here rather than pulled: publishing to the registry is
-      # not available, and a runner builds for its own architecture anyway.
-      # One retry after a wait, for the same reason ci-image.yaml has one: the
-      # archives this pulls from do go quiet, and an immediate second attempt
-      # lands inside the same outage. The image also sets apt retries and
-      # timeouts, which the runner-side action this replaced did for itself.
-      - name: Build the image the lane runs in
+      # the runner. Pulled when the registry has this Dockerfile's image, built
+      # when it does not: the tag carries the content, so an edit to the Dockerfile
+      # misses and rebuilds rather than running the previous environment.
+      # The build stays because it is the fallback for a registry that is missing,
+      # unreachable or unauthorised. One retry after a wait, for the same reason
+      # ci-image.yaml has one: the archives it pulls from do go quiet, and an
+      # immediate second attempt lands inside the same outage. The image also sets
+      # apt retries and timeouts, which the runner-side action this replaced did
+      # for itself.
+      - name: Log in to the registry
+        continue-on-error: true
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get the image the lane runs in
         shell: bash
         run: |
+          if docker pull --quiet "$SEN_CI_IMAGE"; then
+              echo "pulled $SEN_CI_IMAGE"
+              exit 0
+          fi
+          echo "not in the registry, building it"
           build() { docker build --target base --tag "$SEN_CI_IMAGE" tools/ci; }
           build || { echo "image build failed, retrying in 30s"; sleep 30; build; }
 

--- a/tools/ci/architecture.md
+++ b/tools/ci/architecture.md
@@ -315,10 +315,14 @@ since a missing font is not a missing command and there is no fontconfig to ask.
 `main.yaml` calls it when a change touches the build environment,
 and `ci-ok` needs it, so a broken image blocks the merge instead of showing up
 as a red mark beside it. Documentation under `tools/ci/` does not trigger it:
-the Dockerfile copies nothing out of the repository. Docker layer caching in the Actions cache keeps
-rebuilds without changes fast. No registry hosts the image: the
-devcontainer and any self-hosted machine build it from this file, and the
-revision of the file identifies the environment. (The apt packages inside
+the Dockerfile copies nothing out of the repository. The layer cache lives in the
+registry rather than the Actions cache, which the compiler caches need the room in.
+A run on main publishes the image to `ghcr.io/airbus/sen-ci`, tagged with the
+Dockerfile's content, and the lanes pull that tag rather than building their own;
+an edit to the Dockerfile misses the tag and rebuilds. The package is private, so a
+fresh clone with no credentials builds from this file as it always has, and so does
+the devcontainer and any self-hosted machine. The revision of the file identifies
+the environment either way. (The apt packages inside
 the Dockerfile stay unpinned on purpose: the Ubuntu archive removes old
 package versions, so exact pins would break within weeks.)
 


### PR DESCRIPTION
Every lane builds its own image from unpinned apt packages. So what a lane runs changes with the calendar rather than with the diff, and every run contacts apt.llvm.org — which is how docs-build died in 85 seconds on 2026-09-09.

A run on main now publishes to `ghcr.io/airbus/sen-ci` and the lanes pull it. The build stays as the fallback for a registry that is missing, unreachable or unauthorised, so nothing new has to be trusted: the fallback is the path every run takes today.

**The tag carries the Dockerfile's content**, so an edit misses the pull and the consumer rebuilds. Sharing one tag across contents would let a lane run the previous environment and report nothing. `buildcache` is the deliberate exception — a layer cache tagged by content would never be reused.

**The layer cache moves to the registry**, returning 2.37 GB of a 10 GB quota that stands at 9.81. That headroom is the stated prerequisite for a compiler cache on MSVC, where 35.2 of 36.9 minutes is one uncached compile step.

**Publishing runs after the tool checks**, not as part of the build: an image that fails them must not become the one every lane pulls.

`probe`, `lane` and `docs` all built `--target base` — three names for one image, which is why the docs lane could never have hit the pull. They are one name now.

Publishing was never blocked. The administrator refused *public* packages; the workflow token can push to the private one, and has since 2026-08-29. What the refusal costs is a fresh clone pulling without credentials, which `tools/ci/architecture.md` claimed it could and no longer does.

## This branch carries a temporary step

`Publish a throwaway tag from this branch` pushes `sen-ci:probe-from-branch` on any ref that is not main. It exists to prove the workflow token can push through the `workflow_call` chain, which is the one thing local testing cannot reach. **It must be removed before merge**, and the throwaway tag deleted.

Tested locally against a real registry: the pull path, the build fallback when the tag is absent, and the registry layer cache read and written. The naming has eight tests; removing the content from the tag fails three of them.
