### PR TITLE
fix(cmake): ignore the asio null access at compile time

### DIFF
--- a/cmake/util/sanitizers.cmake
+++ b/cmake/util/sanitizers.cmake
@@ -26,10 +26,16 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
     get_filename_component(LSAN_SUPPRESSION_FILE cmake/util/lsan_ignorelist.txt ABSOLUTE)
     get_filename_component(ASAN_SUPPRESSION_FILE cmake/util/asan_ignorelist.txt ABSOLUTE)
-    get_filename_component(UBSAN_SUPPRESSION_FILE cmake/util/ubsan_ignorelist.txt ABSOLUTE)
+    get_filename_component(UBSAN_IGNORELIST_FILE cmake/util/ubsan_ignorelist.txt ABSOLUTE)
 
     add_compile_options(-fsanitize=address,undefined)
     add_link_options(-fsanitize=address,undefined)
+
+    # Compile time, not a runtime suppressions= entry: SEN_SANITIZER_FAIL_FAST below adds
+    # -fno-sanitize-recover=all, and under that flag UBSan aborts before it consults
+    # suppressions, so a runtime entry never fires on the lane that needs it. An ignorelist
+    # emits no check at all, which holds either way.
+    add_compile_options(-fsanitize-ignorelist=${UBSAN_IGNORELIST_FILE})
 
     if(SEN_SANITIZER_FAIL_FAST)
       add_compile_options(-fno-sanitize-recover=all)

--- a/cmake/util/test.cmake
+++ b/cmake/util/test.cmake
@@ -103,12 +103,11 @@ if(LSAN_SUPPRESSION_FILE)
   )
 endif()
 
-# Without print_stacktrace a finding is one line, often naming only a dependency.
-if(UBSAN_SUPPRESSION_FILE)
+# Without print_stacktrace a finding is one line, often naming only a dependency. No
+# suppressions= here: what UBSan ignores is decided at compile time, see sanitizers.cmake.
+if(UBSAN_IGNORELIST_FILE)
   target_compile_definitions(
-    sen_sanitizer_options
-    INTERFACE
-      SEN_UBSAN_DEFAULT_OPTIONS="suppressions=${UBSAN_SUPPRESSION_FILE}:print_stacktrace=1${SEN_SANITIZER_LOG_OPTION}"
+    sen_sanitizer_options INTERFACE SEN_UBSAN_DEFAULT_OPTIONS="print_stacktrace=1${SEN_SANITIZER_LOG_OPTION}"
   )
 endif()
 
@@ -311,7 +310,6 @@ function(add_sen_integration_test test_name)
 
   set(_lsan_suppressions ${LSAN_SUPPRESSION_FILE})
   set(_asan_suppressions ${ASAN_SUPPRESSION_FILE})
-  set(_ubsan_suppressions ${UBSAN_SUPPRESSION_FILE})
   set(_tsan_suppressions ${TSAN_SUPPRESSION_FILE})
   set(_sanitizer_log_option ${SEN_SANITIZER_LOG_OPTION})
 
@@ -326,7 +324,6 @@ function(add_sen_integration_test test_name)
     )
     set(_lsan_suppressions ${SEN_INTEGRATION_TEST_MOUNT}/cmake/util/lsan_ignorelist.txt)
     set(_asan_suppressions ${SEN_INTEGRATION_TEST_MOUNT}/cmake/util/asan_ignorelist.txt)
-    set(_ubsan_suppressions ${SEN_INTEGRATION_TEST_MOUNT}/cmake/util/ubsan_ignorelist.txt)
     set(_tsan_suppressions ${SEN_INTEGRATION_TEST_MOUNT}/cmake/util/tsan_ignorelist.txt)
 
     # And where a finding is written, for the same reason. Left on the host's path the
@@ -364,10 +361,8 @@ function(add_sen_integration_test test_name)
     )
   endif()
 
-  if(UBSAN_SUPPRESSION_FILE)
-    append_test_env_modification(
-      ${test_name} "UBSAN_OPTIONS=set:suppressions=${_ubsan_suppressions}:print_stacktrace=1"
-    )
+  if(UBSAN_IGNORELIST_FILE)
+    append_test_env_modification(${test_name} "UBSAN_OPTIONS=set:print_stacktrace=1")
   endif()
 
   if(TSAN_SUPPRESSION_FILE)
@@ -495,10 +490,8 @@ function(add_sanitizer_options test_name)
     )
   endif()
 
-  if(UBSAN_SUPPRESSION_FILE)
-    append_test_env_modification(
-      ${test_name} "UBSAN_OPTIONS=set:suppressions=${UBSAN_SUPPRESSION_FILE}:print_stacktrace=1"
-    )
+  if(UBSAN_IGNORELIST_FILE)
+    append_test_env_modification(${test_name} "UBSAN_OPTIONS=set:print_stacktrace=1")
   endif()
 
   if(TSAN_SUPPRESSION_FILE)

--- a/cmake/util/ubsan_ignorelist.txt
+++ b/cmake/util/ubsan_ignorelist.txt
@@ -1,0 +1,17 @@
+# Passed to clang as -fsanitize-ignorelist, so nothing named here is instrumented and no
+# check is emitted. This is not a runtime suppressions file: the sanitizer lane builds with
+# -fno-sanitize-recover=all, and under that flag UBSan aborts the process before it reads
+# suppressions, so a runtime entry cannot stop a finding failing a test.
+#
+# An entry costs real coverage -- the code below is not checked at all -- so it is for third
+# party code we cannot fix, not for our own.
+
+[undefined]
+# asio reads a member of a descriptor_state after another thread has nulled it. The null
+# check is already there and does not close the race: start_op tests the pointer, blocks
+# acquiring the descriptor mutex, and deregister_descriptor nulls the pointer while holding
+# that same lock, so the waiter wakes to a null. Open upstream since 2019 as
+# chriskohlhoff/asio#686, and the newest code has the same shape, so no version to move to.
+# A run that reaches this path aborts the process holding it, after the test's own
+# assertions have passed. Remove this if a release ever carries a fix.
+src:*asio/detail/impl/epoll_reactor.ipp


### PR DESCRIPTION
A UBSan finding in `asio` aborts test processes on the sanitizer lane after the tests' own
assertions have passed, so the pipeline goes red for a defect in a dependency.

`epoll_reactor::start_op` already checks the pointer, and the check does not close the
race: while a thread waits for the descriptor mutex, `deregister_descriptor` nulls the
pointer while holding that same lock, and the waiter wakes to read a member of a null.
Open upstream since 2019 as chriskohlhoff/asio#686. The pin is asio 1.36.0 and the newest
upstream code has the same shape, so there is no version to move to.

`cmake/util/ubsan_ignorelist.txt` was passed as a runtime `suppressions=` option, which
could never have covered it: under `-fno-sanitize-recover=all` UBSan aborts before it
reads suppressions. Measured on a benign null member access:

```
runtime suppression, even null:*  + -fno-sanitize-recover=all   exit=1  still fires
compile-time ignorelist           + same flag                   exit=0  suppressed
neither (control)                                               exit=1  fires
```

It is now passed as `-fsanitize-ignorelist`, where no check is emitted at all, and the
variable is renamed `UBSAN_IGNORELIST_FILE` to match. The three `UBSAN_OPTIONS` sites keep
`print_stacktrace=1` and no longer name a suppressions file.

Cost: UBSan no longer instruments that asio file, so a different defect there would go
unseen. The entry carries a removal condition.

Verified against the real conan path shape, with a control that fires without the
ignorelist; the flag reaches 597 compile lines and a translation unit compiles clean under
it. This PR's own lane cannot demonstrate the fix — the finding appeared in two of
thirteen recent runs, so a green lane is what `main` gives most of the time too.
