### PR TITLE
build(cmake): give MSVC a compiler cache

### DIFF
--- a/.github/workflows/standard_test.yaml
+++ b/.github/workflows/standard_test.yaml
@@ -73,12 +73,15 @@ jobs:
           path: ~/.conan2/p
           key: conanp-${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}
 
-      # Sen's targets reach ccache through CMAKE_<LANG>_COMPILER_LAUNCHER (sen_utils.cmake), so
-      # the shims must not also be on PATH while it builds: the launcher would invoke a shim and
-      # store every object twice. 631 compile edges drew 1223 ccache calls, run 34117054695.
+      # Sen's targets reach the cache through CMAKE_<LANG>_COMPILER_LAUNCHER (sen_utils.cmake),
+      # so the shims must not also be on PATH while it builds: the launcher would invoke a shim
+      # and store every object twice. 631 compile edges drew 1223 ccache calls, run 34117054695.
+      # Windows takes sccache because no ccache builds for MSVC. Without one that leg recompiled
+      # 860 edges every run: 35.2 minutes of a 36.9 minute job, against 5.4 on gcc [34357828664].
+      # The key already carries the runner, so the two variants never share an entry.
       - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
-        if: runner.os == 'Linux'
         with:
+          variant: ${{ runner.os == 'Windows' && 'sccache' || 'ccache' }}
           key: ${{ matrix.runner }}-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-${{ matrix.std }}-${{ matrix.build_type }}
           max-size: 1G
           verbose: 1

--- a/cmake/util/sen_utils.cmake
+++ b/cmake/util/sen_utils.cmake
@@ -19,26 +19,46 @@ include(util/sen_codegen_utils)
 # utils used to create Sen packages
 include(util/sen_package_utils)
 
-# try to use ccache, if available (totally optional)
-find_program(CCACHE_PROGRAM ccache)
-if(CCACHE_PROGRAM)
-  message(NOTICE "-- Using ccache to speedup builds")
-  set(ccacheEnv
-      CCACHE_BASEDIR=${CMAKE_BINARY_DIR}
-      # No time_macros: nothing bakes __DATE__ or __TIME__ in any more, and the setting told
-      # ccache to serve an object whose embedded timestamp was from whenever it was first built.
-      CCACHE_SLOPPINESS=clang_index_store,include_file_ctime,include_file_mtime,locale,pch_defines
-  )
+# try to use a compiler cache, if available (totally optional). ccache where it exists,
+# sccache otherwise: there is no ccache for MSVC, so the Windows leg recompiled every
+# translation unit on every run. The environment below is ccache's own and means nothing
+# to sccache, so it is set only on that path.
+find_program(SEN_COMPILER_CACHE NAMES ccache sccache)
+if(SEN_COMPILER_CACHE)
+  get_filename_component(_sen_cache_name "${SEN_COMPILER_CACHE}" NAME_WE)
+  message(NOTICE "-- Using ${_sen_cache_name} to speedup builds")
+
+  set(_sen_cache_env)
+  if(_sen_cache_name STREQUAL "ccache")
+    set(_sen_cache_env
+        CCACHE_BASEDIR=${CMAKE_BINARY_DIR}
+        # No time_macros: nothing bakes __DATE__ or __TIME__ in any more, and the setting told
+        # ccache to serve an object whose embedded timestamp was from whenever it was first built.
+        CCACHE_SLOPPINESS=clang_index_store,include_file_ctime,include_file_mtime,locale,pch_defines
+    )
+  endif()
 
   foreach(lang IN ITEMS C CXX CUDA)
     set(CMAKE_${lang}_COMPILER_LAUNCHER
         ${CMAKE_COMMAND}
         -E
         env
-        ${ccacheEnv}
-        ${CCACHE_PROGRAM}
+        ${_sen_cache_env}
+        ${SEN_COMPILER_CACHE}
     )
   endforeach()
+
+  # A compiler cache stores nothing against MSVC's separate program database, so a lane that
+  # gained one would report hits of zero and no reason. Say so at configure time rather than
+  # leaving it to be measured: the flags are not in the build log, which prints only objects.
+  if(MSVC)
+    message(NOTICE "-- MSVC release flags seen by the cache: ${CMAKE_CXX_FLAGS_RELEASE}")
+    if(CMAKE_CXX_FLAGS_RELEASE MATCHES "/Zi" OR CMAKE_MSVC_DEBUG_INFORMATION_FORMAT MATCHES "ProgramDatabase")
+      message(WARNING "MSVC is producing a program database; ${_sen_cache_name} will not cache. "
+                      "Set CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded with CMP0141 NEW."
+      )
+    endif()
+  endif()
 endif()
 
 if(NOT SEN_DISABLE_CLANG_TIDY)


### PR DESCRIPTION
The Windows leg has no compiler cache, so it recompiles 860 edges every run. Measured on one commit across both platforms [run 34357828664]:

```
                        gcc-x86-12 Release   msvc-x86-194 Release
compiler cache          ccache action        none
compile base libraries  5.4 min              35.2 min
job total               ~10 min              36.9 min
```

Conan restores in twelve seconds on Windows, so dependencies are not it. What rebuilds from zero is Sen's own translation units.

There is no ccache for MSVC. sccache covers `cl.exe` under Ninja, which is the generator `.conan/profiles/sen_msvc` already sets. The launcher in `sen_utils.cmake` now takes whichever cache is on PATH, and `CCACHE_BASEDIR` and `CCACHE_SLOPPINESS` stay on the ccache path only — they mean nothing to sccache. Linux behaviour is unchanged.

**A compiler cache stores nothing against a separate program database.** The Windows lane runs Release only [`generate_matrix_jobs.py`, one MSVC selector], and CMake applies its debug-information default to Debug and RelWithDebInfo, so this should not arise. That is reasoning from CMake's defaults rather than a measurement, and it cannot be read from the build log: Ninja prints the object it is building, never the command line, so grepping a Windows log for a compile flag returns zero for flags that are certainly applied. **Configure now prints the release flags and warns if a program database appears**, so the answer is in the log instead of being inferred.

The quota was the prerequisite, since sccache writes to the same 10 GB. Publishing the image moved the layer cache to the registry and 41 orphaned buildkit entries were deleted: 9.98 GB to 7.84.

## Reading the first run

The Windows cache starts empty, so this run pays the full compile and the save. `save` is gated on `refs/heads/main`, so a pull request never populates it — the first real measurement comes after a main run. What is worth reading here is the configure line on the Windows leg: `Using sccache to speedup builds`, and the release flags beside it.
