### PR TITLE
test(kernel): report where a hung integration test is stuck

### DIFF
--- a/libs/kernel/test/integration/runner.py
+++ b/libs/kernel/test/integration/runner.py
@@ -9,13 +9,25 @@
 import os
 import subprocess
 import sys
+import time
 
-# How long a supporting instance is given to stop before it is killed outright.
+# How long the supporting instances together are given to stop before they are killed
+# outright. A total rather than one each, so the wait does not grow with their number.
 SHUTDOWN_GRACE_SECONDS = 5
+
+# How long the tester itself may run. This exists so a hang is reported here rather than by
+# ctest: ctest kills the whole test at its own --timeout (20 s in cmake/util/test.cmake) and
+# nothing below ever prints, so a hung run says only "Timeout" and names no process. The
+# budget plus the grace above has to stay under that.
+TESTER_BUDGET_SECONDS = int(os.environ.get("SEN_RUNNER_BUDGET_SECONDS", "12"))
+
+# Exit status for a tester that had to be killed, distinct from anything it returns itself.
+TESTER_HUNG_STATUS = 124
 
 # An instance that ended before it was asked to makes the tester's own failure a
 # consequence rather than a cause. The verdict stays the tester's either way.
 INSTANCE = "runner.py: supporting instance"
+TESTER = "runner.py: tester"
 
 
 def run_sen_command(args):
@@ -32,6 +44,34 @@ def run_sen_command(args):
         return subprocess.Popen(["sen", "run", args], start_new_session=True, env=os.environ.copy())
     else:  # Unix-like
         return subprocess.Popen(["./sen", "run", args], start_new_session=True)
+
+
+def report_threads(pid, label):
+    """Says what every thread of a process is blocked in, from /proc.
+
+    wchan is the kernel function a thread is waiting in, which separates the two hangs worth
+    telling apart here: futex_wait is one of ours, a lock or a join, and ep_poll is a socket
+    event that never arrived. Linux only, and never allowed to fail a test by itself.
+    """
+    try:
+        tasks = sorted(os.listdir(f"/proc/{pid}/task"))
+    except OSError:
+        return  # not Linux, or it exited between the timeout and here
+
+    blocked = {}
+    for tid in tasks:
+        try:
+            with open(f"/proc/{pid}/task/{tid}/wchan", encoding="utf-8") as handle:
+                where = handle.read().strip() or "(running)"
+            with open(f"/proc/{pid}/task/{tid}/comm", encoding="utf-8") as handle:
+                name = handle.read().strip()
+        except OSError:
+            continue
+        blocked.setdefault((name, where), []).append(tid)
+
+    print(f"{label}: {len(tasks)} threads", flush=True)
+    for (name, where), tids in sorted(blocked.items(), key=lambda item: -len(item[1])):
+        print(f"{label}:   {len(tids):3d} in {where:24s} [{name}] tid {tids[0]}", flush=True)
 
 
 def end(instance, hard=False):
@@ -64,11 +104,13 @@ def stop(instances):
     for instance in instances:
         end(instance)
     ignored_the_request = set()
+    deadline = time.monotonic() + SHUTDOWN_GRACE_SECONDS
     for instance in instances:
         try:
-            instance.wait(timeout=SHUTDOWN_GRACE_SECONDS)
+            instance.wait(timeout=max(0.0, deadline - time.monotonic()))
         except subprocess.TimeoutExpired:
             ignored_the_request.add(instance.pid)
+            report_threads(instance.pid, f"{INSTANCE} {instance.pid}")
             end(instance, hard=True)
             instance.wait()
 
@@ -96,7 +138,16 @@ def main():
         # Run the main instance for the smoke test, as a child rather than through exec.
         # Exec replaces this process, so when the main instance dies on its own there is
         # nothing left to stop the other two. The status is still the main instance's.
-        return subprocess.run([os.path.join(os.curdir, "sen"), "run", arg3], check=False).returncode
+        tester = subprocess.Popen([os.path.join(os.curdir, "sen"), "run", arg3])  # noqa: S603
+        return tester.wait(timeout=TESTER_BUDGET_SECONDS)
+    except subprocess.TimeoutExpired:
+        # Popen and wait() rather than run(timeout=): run kills the process on expiry, and a
+        # killed process has nothing left to say about where it was stuck.
+        print(f"{TESTER}: still running after {TESTER_BUDGET_SECONDS}s", flush=True)
+        report_threads(tester.pid, TESTER)
+        end(tester, hard=True)
+        tester.wait()
+        return TESTER_HUNG_STATUS
     finally:
         stop(supporting)
 


### PR DESCRIPTION
`kernel_compatibility_mode_relaxed` timed out on a sanitizer run. Its own output showed the
assertion passing and both supporting instances shutting down cleanly; ctest then killed it
at exactly 20.02 s. The report named no process and no reason, so nothing could be aimed at
it.

That is structural rather than bad luck. `runner.py` ran the tester with no timeout, so a
hang waited for ctest's own `--timeout` (20 s). The runner's diagnostics run in the
`finally` after the tester returns, so on a hang they never printed at all — which is why
the failing run carried no `runner.py:` lines.

## What this changes

The tester now has a budget below ctest's, and on expiry the runner says what every thread
of it is blocked in, read from `/proc/<pid>/task/*/wchan`. That separates the two hangs
worth telling apart: `futex_wait` is a lock or a join of ours, `ep_poll` is a socket event
that never arrived. `Popen` and `wait()` rather than `run(timeout=)`, because `run` kills
the process on expiry and a killed process has nothing left to say.

The shutdown grace becomes a total across the supporting instances rather than one each, so
the wait does not grow with their number and the budget plus the grace stays under ctest's
limit: 12 + 5 against 20.

## Controls

```
tester hangs, mixed threads    4 in futex_wait_queue, 1 in do_epoll_wait, 1 in do_select
                               reported by name, exit 124
nothing hangs                  exit 0, no report
two instances ignore SIGTERM   both named, 5.1 s total rather than 10 s
the real suite, 10 rounds      0 failures, 0 spurious reports
```

## The trade

This tightens the tester's effective limit from 20 s to 12 s. The slowest of these tests
observed on CI is 4.94 s and most are near 3.9 s, so roughly 2.4x headroom;
`SEN_RUNNER_BUDGET_SECONDS` raises it for anything that legitimately needs longer.

It does not fix the hang. It replaces a bare `Timeout` with a report that names the process
and where its threads are stuck, so the next occurrence points somewhere instead of being
attributed by guesswork. `wchan` narrows to a subsystem, not a line; a C++ frame would need
a debugger in the lane's image.
