### PR TITLE
ci: grant the nightly the permission its docs job asks for

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -246,6 +246,9 @@ jobs:
     permissions:
       contents: read
       actions: write
+      # docs_check.yaml pulls the image it builds in. A called workflow cannot request
+      # more than this grants, and the whole nightly fails at startup when it does.
+      packages: read
 
   # Every packaged configuration, which a pull request does not run: it builds
   # only the configuration that ships.


### PR DESCRIPTION
docs_check.yaml began requesting packages: read when the lanes started pulling the image. main.yaml was given it in #305; nightly.yaml was not. A called workflow that requests more than its caller grants fails the entire run at startup, so the nightly has not run since — run 34431939035, startup_failure at 03:04Z, no jobs, no sanitizer lanes, no packaging, no coverage. The audit written for the first occurrence walked main.yaml's jobs only and could not see the second caller; re-run across every workflow, this is now the only mismatch and there are zero after the fix.