### PR TITLE
fix(core): swap float bytes so the stream is not integer-only

### DIFF
--- a/libs/core/include/sen/core/io/detail/endianness.h
+++ b/libs/core/include/sen/core/io/detail/endianness.h
@@ -9,6 +9,7 @@
 #define SEN_CORE_IO_DETAIL_ENDIANNESS_H
 
 // sen
+#include "sen/core/base/bits.h"
 #include "sen/core/base/compiler_macros.h"
 #include "sen/core/base/numbers.h"
 
@@ -110,9 +111,17 @@ namespace impl
 #endif
 }
 
-[[nodiscard]] SEN_ALWAYS_INLINE float32_t swapBytes(float32_t value) noexcept { return value; }
+// Through the same-width integer, because IEEE 754 fixes the bit pattern and not the order those
+// bytes sit in. Returning the value unchanged made the stream little-endian for integers only.
+[[nodiscard]] SEN_ALWAYS_INLINE float32_t swapBytes(float32_t value) noexcept
+{
+  return std_util::bit_cast<float32_t>(swapBytes(std_util::bit_cast<uint32_t>(value)));
+}
 
-[[nodiscard]] SEN_ALWAYS_INLINE float64_t swapBytes(float64_t value) noexcept { return value; }
+[[nodiscard]] SEN_ALWAYS_INLINE float64_t swapBytes(float64_t value) noexcept
+{
+  return std_util::bit_cast<float64_t>(swapBytes(std_util::bit_cast<uint64_t>(value)));
+}
 
 /// Swaps the bytes of val if this host is big endian
 template <typename T>

--- a/libs/core/include/sen/core/io/input_stream.h
+++ b/libs/core/include/sen/core/io/input_stream.h
@@ -71,8 +71,8 @@ public:
   void readUInt32(uint32_t& val) { readBasic(val); }
   void readInt64(int64_t& val) { readBasic(val); }
   void readUInt64(uint64_t& val) { readBasic(val); }
-  void readFloat32(float32_t& val);
-  void readFloat64(float64_t& val);
+  void readFloat32(float32_t& val) { readBasic(val); }
+  void readFloat64(float64_t& val) { readBasic(val); }
   void readString(std::string& val);
   void readTimeStamp(TimeStamp& val);
 
@@ -95,20 +95,6 @@ inline void InputStreamTemplate<BufferEndian>::readBool(bool& val)
   impl::BoolTransportType tmp;
   readBasic(tmp);
   val = (tmp != 0U);
-}
-
-template <typename BufferEndian>
-inline void InputStreamTemplate<BufferEndian>::readFloat32(float32_t& val)
-{
-  constexpr std::size_t size = sizeof(val);
-  std::memcpy(&val, advance(size), size);
-}
-
-template <typename BufferEndian>
-inline void InputStreamTemplate<BufferEndian>::readFloat64(float64_t& val)
-{
-  constexpr std::size_t size = sizeof(val);
-  std::memcpy(&val, advance(size), size);
 }
 
 template <typename BufferEndian>

--- a/libs/core/test/io/endianness_test.cpp
+++ b/libs/core/test/io/endianness_test.cpp
@@ -7,6 +7,7 @@
 
 // sen
 #include "sen/core/base/assert.h"
+#include "sen/core/base/bits.h"
 #include "sen/core/base/numbers.h"
 #include "sen/core/io/detail/endianness.h"
 
@@ -16,6 +17,7 @@
 // std
 #include <cstdint>
 #include <iterator>
+#include <limits>
 
 namespace
 {
@@ -119,39 +121,30 @@ TEST(Endianness, swap64)
 /// @requirements(SEN-893)
 TEST(Endianness, swapFloats)
 {
-  constexpr auto pi = 3.141592653589793238462643383279503f;
-
-  float32_t val1;
-  float32_t result1;
-
-  float64_t val2;
-  float64_t result2;
-
+  // This asserted that swapping a float returned it unchanged, which is what the two overloads
+  // did and is why the stream was little-endian for integers only. IEEE 754 fixes the bit
+  // pattern, not the order its bytes sit in, so a float swaps like the integer of its width.
   {
-    val1 = pi;
-    result1 = sen::impl::swapBytes(val1);
-    EXPECT_EQ(sizeof(result1), sizeof(val1));
-    EXPECT_EQ(result1, val1);
+    const auto swapped = sen::impl::swapBytes(3.14159F);
+    EXPECT_EQ(0xD00F4940U, sen::std_util::bit_cast<uint32_t>(swapped));
+    EXPECT_EQ(0x40490FD0U, sen::std_util::bit_cast<uint32_t>(3.14159F));
   }
 
   {
-    val1 = -pi;
-    result1 = sen::impl::swapBytes(val1);
-    EXPECT_EQ(sizeof(result1), sizeof(val1));
-    EXPECT_EQ(result1, val1);
+    const auto swapped = sen::impl::swapBytes(3.14159);
+    EXPECT_EQ(0x6E861BF0F9210940ULL, sen::std_util::bit_cast<uint64_t>(swapped));
+    EXPECT_EQ(0x400921F9F01B866EULL, sen::std_util::bit_cast<uint64_t>(3.14159));
   }
 
+  // Swapping twice is the identity, which also covers the negative and the denormal without
+  // hard-coding their patterns.
+  for (const auto value: {3.14159F, -3.14159F, 0.0F, std::numeric_limits<float32_t>::min()})
   {
-    val2 = pi;
-    result2 = sen::impl::swapBytes(val2);
-    EXPECT_EQ(sizeof(result2), sizeof(val2));
-    EXPECT_EQ(result2, val2);
+    EXPECT_EQ(value, sen::impl::swapBytes(sen::impl::swapBytes(value)));
   }
 
+  for (const auto value: {3.14159, -3.14159, 0.0, std::numeric_limits<float64_t>::min()})
   {
-    val2 = -pi;
-    result2 = sen::impl::swapBytes(val2);
-    EXPECT_EQ(sizeof(result2), sizeof(val2));
-    EXPECT_EQ(result2, val2);
+    EXPECT_EQ(value, sen::impl::swapBytes(sen::impl::swapBytes(value)));
   }
 }

--- a/libs/core/test/io/input_stream_test.cpp
+++ b/libs/core/test/io/input_stream_test.cpp
@@ -32,6 +32,7 @@
 
 using sen::InputStream;
 using sen::test::BufferedTestReader;
+using sen::test::TestReader;
 
 namespace
 {
@@ -426,4 +427,49 @@ TEST(InputStream, tryAdvance)
   EXPECT_TRUE(in.atEnd());
 
   EXPECT_ANY_THROW(std::ignore = in.tryAdvance(1U));
+}
+
+// The read side had its own float overloads that memcpy'd, so it never reached the swap at all.
+// Fixing swapBytes alone would have left a big-endian host unable to read back what it wrote.
+TEST(InputStream, FloatsAreReadInTheBufferByteOrder)
+{
+  // float32_t big endian
+  {
+    const std::vector<uint8_t> buffer {0x40U, 0x49U, 0x0FU, 0xD0U};
+    TestReader reader(buffer);
+    sen::InputStreamTemplate<sen::BigEndian> in(reader.getBuffer());
+    float32_t val = 0.0F;
+    in.readFloat32(val);
+    EXPECT_FLOAT_EQ(3.14159F, val);
+  }
+
+  // float32_t little endian
+  {
+    const std::vector<uint8_t> buffer {0xD0U, 0x0FU, 0x49U, 0x40U};
+    TestReader reader(buffer);
+    sen::InputStreamTemplate<sen::LittleEndian> in(reader.getBuffer());
+    float32_t val = 0.0F;
+    in.readFloat32(val);
+    EXPECT_FLOAT_EQ(3.14159F, val);
+  }
+
+  // float64_t big endian
+  {
+    const std::vector<uint8_t> buffer {0x40U, 0x09U, 0x21U, 0xF9U, 0xF0U, 0x1BU, 0x86U, 0x6EU};
+    TestReader reader(buffer);
+    sen::InputStreamTemplate<sen::BigEndian> in(reader.getBuffer());
+    float64_t val = 0.0;
+    in.readFloat64(val);
+    EXPECT_DOUBLE_EQ(3.14159, val);
+  }
+
+  // float64_t little endian
+  {
+    const std::vector<uint8_t> buffer {0x6EU, 0x86U, 0x1BU, 0xF0U, 0xF9U, 0x21U, 0x09U, 0x40U};
+    TestReader reader(buffer);
+    sen::InputStreamTemplate<sen::LittleEndian> in(reader.getBuffer());
+    float64_t val = 0.0;
+    in.readFloat64(val);
+    EXPECT_DOUBLE_EQ(3.14159, val);
+  }
 }

--- a/libs/core/test/io/output_stream_test.cpp
+++ b/libs/core/test/io/output_stream_test.cpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <limits>
 #include <string>
+#include <vector>
 
 using sen::OutputStream;
 using sen::test::TestWriter;
@@ -338,5 +339,43 @@ TEST(OutputStream, BigEndian)
 
     EXPECT_EQ(valueAsBytes, writer.getBuffer());
     EXPECT_EQ(sizeof(float32_t), writer.getBuffer().size() * sizeof(uint8_t));
+  }
+}
+
+// Against literal byte patterns rather than against swapBytes. The BigEndian float cases above
+// compute their expectation with the same function they exercise, so they agreed with the old
+// unswapped output and could not have caught it. These are IEEE 754 for 3.14159, written out.
+TEST(OutputStream, FloatsCrossInTheBufferByteOrder)
+{
+  // float32_t little endian
+  {
+    TestWriter writer;
+    sen::OutputStreamTemplate<sen::LittleEndian> out(writer);
+    out.writeFloat32(3.14159F);
+    EXPECT_EQ((std::vector<uint8_t> {0xD0U, 0x0FU, 0x49U, 0x40U}), writer.getBuffer());
+  }
+
+  // float32_t big endian
+  {
+    TestWriter writer;
+    sen::OutputStreamTemplate<sen::BigEndian> out(writer);
+    out.writeFloat32(3.14159F);
+    EXPECT_EQ((std::vector<uint8_t> {0x40U, 0x49U, 0x0FU, 0xD0U}), writer.getBuffer());
+  }
+
+  // float64_t little endian
+  {
+    TestWriter writer;
+    sen::OutputStreamTemplate<sen::LittleEndian> out(writer);
+    out.writeFloat64(3.14159);
+    EXPECT_EQ((std::vector<uint8_t> {0x6EU, 0x86U, 0x1BU, 0xF0U, 0xF9U, 0x21U, 0x09U, 0x40U}), writer.getBuffer());
+  }
+
+  // float64_t big endian
+  {
+    TestWriter writer;
+    sen::OutputStreamTemplate<sen::BigEndian> out(writer);
+    out.writeFloat64(3.14159);
+    EXPECT_EQ((std::vector<uint8_t> {0x40U, 0x09U, 0x21U, 0xF9U, 0xF0U, 0x1BU, 0x86U, 0x6EU}), writer.getBuffer());
   }
 }


### PR DESCRIPTION
`OutputStream` and `InputStream` are named for their buffer's byte order and honoured it for
integers only. `swapBytes(float32_t)` and `swapBytes(float64_t)` returned the value unchanged,
so on a big-endian host integers crossed little-endian as promised and floats crossed in host
order. Two big-endian peers agree with each other; a little-endian peer, or a recording read
on the other byte order, gets every float wrong. IEEE 754 fixes the bit pattern, not the order
its bytes sit in.